### PR TITLE
MRC-188 remove models submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/models"]
-	path = src/models
-	url = https://github.com/vimc/montagu-webmodels.git

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/ActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/ActionContext.kt
@@ -1,8 +1,8 @@
 package org.vaccineimpact.orderlyweb
 
 import org.pac4j.core.profile.CommonProfile
-import org.vaccineimpact.api.models.permissions.PermissionSet
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import spark.Response
 
 interface ActionContext

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
@@ -5,7 +5,7 @@ import com.google.gson.GsonBuilder
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.core.profile.ProfileManager
 import org.pac4j.sparkjava.SparkWebContext
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
 import org.vaccineimpact.orderlyweb.security.montaguPermissions

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Endpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Endpoint.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.orderlyweb
 
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.security.MontaguAuthorizer
 import org.vaccineimpact.orderlyweb.security.PermissionRequirement

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Serializer.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Serializer.kt
@@ -5,8 +5,8 @@ import com.github.salomonbrys.kotson.registerTypeAdapter
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonPrimitive
-import org.vaccineimpact.api.models.Result
-import org.vaccineimpact.api.models.ResultStatus
+import org.vaccineimpact.orderlyweb.models.Result
+import org.vaccineimpact.orderlyweb.models.ResultStatus
 
 open class Serializer
 {
@@ -35,7 +35,7 @@ open class Serializer
 
     open fun toResult(data: Any?): String = toJson(Result(ResultStatus.SUCCESS, data, emptyList()))
 
-    open fun toJson(result: org.vaccineimpact.api.models.Result): String = gson.toJson(result)
+    open fun toJson(result: org.vaccineimpact.orderlyweb.models.Result): String = gson.toJson(result)
 
     fun convertFieldName(name: String): String
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/ArtefactController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/ArtefactController.kt
@@ -1,7 +1,7 @@
 package org.vaccineimpact.orderlyweb.controllers
 
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/Controller.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/Controller.kt
@@ -1,9 +1,9 @@
 package org.vaccineimpact.orderlyweb.controllers
 
 import khttp.responses.Response
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.encompass
-import org.vaccineimpact.api.models.permissions.PermissionSet
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.encompass
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 import org.vaccineimpact.orderlyweb.ActionContext
 
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/DataController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/DataController.kt
@@ -1,7 +1,7 @@
 package org.vaccineimpact.orderlyweb.controllers
 
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.FileSystem

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/ReportController.kt
@@ -1,13 +1,13 @@
 package org.vaccineimpact.orderlyweb.controllers
 
-import org.vaccineimpact.api.models.Changelog
-import org.vaccineimpact.api.models.Report
-import org.vaccineimpact.api.models.ReportVersion
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.encompass
-import org.vaccineimpact.api.models.permissions.PermissionSet
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
-import org.vaccineimpact.api.models.permissions.RoleAssignment
+import org.vaccineimpact.orderlyweb.models.Changelog
+import org.vaccineimpact.orderlyweb.models.Report
+import org.vaccineimpact.orderlyweb.models.ReportVersion
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.encompass
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.permissions.RoleAssignment
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/ResourceController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/ResourceController.kt
@@ -1,7 +1,7 @@
 package org.vaccineimpact.orderlyweb.controllers
 
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/VersionController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/VersionController.kt
@@ -1,9 +1,9 @@
 package org.vaccineimpact.orderlyweb.controllers
 
-import org.vaccineimpact.api.models.Changelog
-import org.vaccineimpact.api.models.ReportVersionDetails
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.Changelog
+import org.vaccineimpact.orderlyweb.models.ReportVersionDetails
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -2,7 +2,7 @@ package org.vaccineimpact.orderlyweb.db
 
 import org.jooq.impl.DSL.select
 import org.jooq.impl.DSL.trueCondition
-import org.vaccineimpact.api.models.*
+import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.db.Tables.*
 import org.vaccineimpact.orderlyweb.db.tables.records.ReportVersionRecord
 import org.vaccineimpact.orderlyweb.errors.UnknownObjectError

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.orderlyweb.db
 
-import org.vaccineimpact.api.models.*
+import org.vaccineimpact.orderlyweb.models.*
 
 import org.vaccineimpact.orderlyweb.errors.UnknownObjectError
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/InvalidOneTimeLinkToken.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/InvalidOneTimeLinkToken.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.orderlyweb.errors
 
-import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
 
 class InvalidOneTimeLinkToken(code: String, message: String) : MontaguError(400, listOf(
         ErrorInfo("invalid-token-$code", message)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/MissingParameterError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/MissingParameterError.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.orderlyweb.errors
 
-import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
 
 class MissingParameterError(parameterName: String)
     : MontaguError(400, listOf(ErrorInfo("bad-request", "Missing parameter '$parameterName'")))

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/MissingRequiredPermissionError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/MissingRequiredPermissionError.kt
@@ -1,8 +1,8 @@
 package org.vaccineimpact.orderlyweb.errors
 
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 
 class MissingRequiredPermissionError(missingPermissions: Set<ReifiedPermission>) : MontaguError(403, listOf(
-        org.vaccineimpact.api.models.ErrorInfo("forbidden", "You do not have sufficient permissions to access this resource. " +
+        org.vaccineimpact.orderlyweb.models.ErrorInfo("forbidden", "You do not have sufficient permissions to access this resource. " +
                 "Missing these permissions: ${missingPermissions.joinToString(", ")}")
 ))

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/MontaguError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/MontaguError.kt
@@ -2,14 +2,14 @@ package org.vaccineimpact.orderlyweb.errors
 
 abstract class MontaguError(
         open val httpStatus: Int,
-        val problems: Iterable<org.vaccineimpact.api.models.ErrorInfo>
+        val problems: Iterable<org.vaccineimpact.orderlyweb.models.ErrorInfo>
 ) : Exception(formatProblemsIntoMessage(problems))
 {
-    open fun asResult() = org.vaccineimpact.api.models.Result(org.vaccineimpact.api.models.ResultStatus.FAILURE, null, problems)
+    open fun asResult() = org.vaccineimpact.orderlyweb.models.Result(org.vaccineimpact.orderlyweb.models.ResultStatus.FAILURE, null, problems)
 
     companion object
     {
-        fun formatProblemsIntoMessage(problems: Iterable<org.vaccineimpact.api.models.ErrorInfo>): String
+        fun formatProblemsIntoMessage(problems: Iterable<org.vaccineimpact.orderlyweb.models.ErrorInfo>): String
         {
             val joined = problems.map { it.message }.joinToString("\n")
             return "the following problems occurred:\n$joined"

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/OrderlyFileNotFoundError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/OrderlyFileNotFoundError.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.orderlyweb.errors
 
-import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
 
 class OrderlyFileNotFoundError(filename: String) : MontaguError(404, listOf(
         ErrorInfo("file-not-found", "File with name '$filename' does not exist. ")

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/UnableToConnectToDatabaseError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/UnableToConnectToDatabaseError.kt
@@ -1,5 +1,5 @@
 package org.vaccineimpact.orderlyweb.errors
 
 class UnableToConnectToDatabaseError(url: String) : MontaguError(500, listOf(
-        org.vaccineimpact.api.models.ErrorInfo("database-connection-error", "Unable to establish connection to the database at $url")
+        org.vaccineimpact.orderlyweb.models.ErrorInfo("database-connection-error", "Unable to establish connection to the database at $url")
 ))

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/UnableToParseJsonError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/UnableToParseJsonError.kt
@@ -3,7 +3,7 @@ package org.vaccineimpact.orderlyweb.errors
 import com.google.gson.JsonSyntaxException
 
 class UnableToParseJsonError(e: JsonSyntaxException) : MontaguError(400, listOf(
-        org.vaccineimpact.api.models.ErrorInfo("bad-json", formatMessage(e))
+        org.vaccineimpact.orderlyweb.models.ErrorInfo("bad-json", formatMessage(e))
 ))
 {
     companion object

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/UnexpectedError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/UnexpectedError.kt
@@ -1,5 +1,5 @@
 package org.vaccineimpact.orderlyweb.errors
 
 class UnexpectedError : MontaguError(500, listOf(
-        org.vaccineimpact.api.models.ErrorInfo("unexpected-error", "An unexpected error occurred. Please see server logs for more details")
+        org.vaccineimpact.orderlyweb.models.ErrorInfo("unexpected-error", "An unexpected error occurred. Please see server logs for more details")
 ))

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/UnknownObjectError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/UnknownObjectError.kt
@@ -1,7 +1,7 @@
 package org.vaccineimpact.orderlyweb.errors
 
 class UnknownObjectError(id: Any, typeName: Any) : MontaguError(404, listOf(
-        org.vaccineimpact.api.models.ErrorInfo("unknown-${mangleTypeName(typeName)}", "Unknown ${mangleTypeName(typeName)} : '$id'")
+        org.vaccineimpact.orderlyweb.models.ErrorInfo("unknown-${mangleTypeName(typeName)}", "Unknown ${mangleTypeName(typeName)} : '$id'")
 ))
 {
     companion object

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Artefact.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Artefact.kt
@@ -1,0 +1,3 @@
+package org.vaccineimpact.orderlyweb.models
+
+data class Artefact(val format: ArtefactFormat, val description: String, val files: List<String>)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Changelog.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Changelog.kt
@@ -1,0 +1,8 @@
+package org.vaccineimpact.orderlyweb.models
+import java.beans.ConstructorProperties
+data class Changelog
+@ConstructorProperties("reportVersion", "label", "value", "fromFile")
+constructor(val reportVersion: String,
+            val label: String,
+            val value: String,
+            val fromFile: Boolean)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/OrderlyEnums.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/OrderlyEnums.kt
@@ -1,0 +1,27 @@
+package org.vaccineimpact.orderlyweb.models
+
+enum class FilePurpose
+{
+    SOURCE,
+    SCRIPT,
+    RESOURCE,
+    ORDERLY_YML,
+    GLOBAL;
+
+    override fun toString(): String {
+        return this.name.toLowerCase()
+    }
+}
+
+enum class ArtefactFormat
+{
+    STATICGRAPH,
+    INTERACTIVEGRAPH,
+    DATA,
+    REPORT,
+    INTERACTIVEHTML;
+
+    override fun toString(): String {
+        return this.name.toLowerCase()
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
@@ -1,0 +1,22 @@
+package org.vaccineimpact.orderlyweb.models
+
+import java.beans.ConstructorProperties
+import java.time.Instant
+
+data class Report
+@ConstructorProperties("name", "displayname", "latestVersion")
+constructor(val name: String,
+            val displayName: String?,
+            val latestVersion: String)
+
+data class ReportVersion
+@ConstructorProperties("name", "displayname", "id", "latestVersion", "published", "date", "author",
+        "requester")
+constructor(val name: String,
+            val displayName: String?,
+            val id: String,
+            val latestVersion: String,
+            val published: Boolean,
+            val date: Instant,
+            val author: String,
+            val requester: String)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
@@ -1,0 +1,16 @@
+package org.vaccineimpact.orderlyweb.models
+
+import java.time.Instant
+
+data class ReportVersionDetails(val name: String,
+                                val displayName: String?,
+                                val id: String,
+                                val published: Boolean,
+                                val date: Instant,
+                                val author: String,
+                                val requester: String,
+                                val description: String?,
+                                val artefacts: List<Artefact>,
+                                val resources: List<String>,
+                                val dataHashes: Map<String, String>)
+

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Result.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Result.kt
@@ -1,0 +1,18 @@
+package org.vaccineimpact.orderlyweb.models
+
+class Result(val status: ResultStatus, data: Any?, errors: Iterable<ErrorInfo>)
+{
+    val data = data ?: ""
+    val errors = errors.toList()
+}
+
+enum class ResultStatus
+{
+    SUCCESS, FAILURE
+}
+
+data class ErrorInfo(val code: String, val message: String)
+{
+    override fun toString(): String = message
+}
+

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Scope.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Scope.kt
@@ -1,0 +1,93 @@
+package org.vaccineimpact.orderlyweb.models
+
+import org.vaccineimpact.orderlyweb.models.permissions.AssociateRole
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedRole
+import org.vaccineimpact.orderlyweb.models.permissions.RoleAssignment
+
+sealed class Scope  (val value: String)
+{
+    class Global : Scope("*")
+    {
+        // Global scope is greater than or equal to all other scopes
+        override fun encompasses(other: Scope) = true
+
+        override val databaseScopePrefix = null
+        override val databaseScopeId = ""
+    }
+
+    class Specific(scopePrefix: String, scopeId: String) : Scope("$scopePrefix:$scopeId")
+    {
+        override fun encompasses(other: Scope): Boolean = when (other)
+        {
+        // Global scope is larger than any specific scope
+            is Global -> false
+
+        // Different specific scopes are not ordered relative to each other, so only return true if they are indentical
+            is Specific -> equals(other)
+        }
+
+        override val databaseScopePrefix = scopePrefix
+        override val databaseScopeId = scopeId
+    }
+
+    override fun toString() = value
+    override fun equals(other: Any?) = when (other)
+    {
+        is Scope -> other.toString() == toString()
+        else -> false
+    }
+
+    override fun hashCode() = toString().hashCode()
+
+    abstract fun encompasses(other: Scope): Boolean
+    abstract val databaseScopePrefix: String?
+    abstract val databaseScopeId: String
+
+    companion object
+    {
+        fun parse(rawScope: String): Scope
+        {
+            if (rawScope == "*")
+            {
+                return Global()
+            }
+            else
+            {
+                val parts = rawScope.split(':')
+                return Specific(parts[0], parts[1])
+            }
+        }
+
+        fun parse(role: RoleAssignment): Scope
+        {
+            if (role.scopePrefix.isNullOrEmpty())
+            {
+                return Scope.Global()
+            }
+            else
+            {
+
+                return Scope.Specific(role.scopePrefix!!, role.scopeId!!)
+            }
+        }
+
+        fun parse(role: AssociateRole): Scope
+        {
+            if (role.scopePrefix.isNullOrEmpty())
+            {
+                return Scope.Global()
+            }
+            else
+            {
+
+                return Scope.Specific(role.scopePrefix!!, role.scopeId!!)
+            }
+        }
+
+    }
+}
+
+fun Iterable<Scope>.encompass(other: Scope): Boolean
+{
+    return this.any { it.encompasses(other) }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/User.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/User.kt
@@ -1,0 +1,12 @@
+package org.vaccineimpact.orderlyweb.models
+
+import java.beans.ConstructorProperties
+import java.time.Instant
+
+data class User
+@ConstructorProperties("username", "name", "email", "lastLoggedIn")
+constructor(val username: String,
+            val name: String,
+            val email: String,
+            val lastLoggedIn: Instant?
+)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/PermissionSet.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/PermissionSet.kt
@@ -1,0 +1,20 @@
+package org.vaccineimpact.orderlyweb.models.permissions
+
+class PermissionSet(val permissions: Set<ReifiedPermission>): Set<ReifiedPermission> by permissions
+{
+    constructor(vararg rawPermissions: String)
+            : this(rawPermissions.map { ReifiedPermission.parse(it) }.toSet())
+    constructor(rawPermissions: Iterable<String>)
+            : this(rawPermissions.map { ReifiedPermission.parse(it) }.toSet())
+
+    val names by lazy { permissions.map { it.name }.distinct() }
+
+    infix operator fun plus(other: PermissionSet) = PermissionSet(this.permissions + other.permissions)
+    infix operator fun plus(other: ReifiedPermission) = PermissionSet(this.permissions + other)
+    infix operator fun plus(other: String) = this + ReifiedPermission.parse(other)
+
+    override fun toString(): String
+    {
+        return "[${permissions.joinToString()}]"
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/ReifiedPermission.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/ReifiedPermission.kt
@@ -1,0 +1,35 @@
+package org.vaccineimpact.orderlyweb.models.permissions
+
+import org.vaccineimpact.orderlyweb.models.Scope
+
+// A permission is just a name, like 'coverage.read'
+// To be usable, it must be reified with a scope, like:
+// */coverage.read (for the global scope)
+// modelling-group:IC-Garske/coverage.read (for a more specific scope)
+data class ReifiedPermission(
+        val name: String,
+        val scope: Scope
+)
+{
+    override fun toString() = "$scope/$name"
+
+    fun satisfiedBy(permission: ReifiedPermission)
+            = name == permission.name && permission.scope.encompasses(scope)
+
+    companion object
+    {
+        fun parse(raw: String): ReifiedPermission
+        {
+            try
+            {
+                val parts = raw.split('/')
+                val rawScope = parts[0]
+                val name = parts[1]
+                return ReifiedPermission(name, Scope.parse(rawScope))
+            } catch (e: Exception)
+            {
+                throw ReifiedPermissionParseException(raw)
+            }
+        }
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/ReifiedPermissionParseException.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/ReifiedPermissionParseException.kt
@@ -1,0 +1,6 @@
+package org.vaccineimpact.orderlyweb.models.permissions
+
+class ReifiedPermissionParseException(raw: String)
+    : Exception("Unable to parse '$raw' as a ReifiedPermission. " +
+        "It should have the form 'scope/name' where scope is either the global scope '*' " +
+        "or a specific scope identifier in the form 'prefix:id'")

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/Role.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/Role.kt
@@ -1,0 +1,24 @@
+package org.vaccineimpact.orderlyweb.models.permissions
+
+import org.vaccineimpact.orderlyweb.models.Scope
+import java.beans.ConstructorProperties
+
+data class ReifiedRole(
+        val name: String,
+        val scope: Scope
+)
+{
+    override fun toString() = "$scope/$name"
+}
+
+
+data class RoleAssignment @ConstructorProperties("name", "scopePrefix", "scopeId")
+constructor(val name: String, var scopePrefix: String?, var scopeId: String?)
+{
+    constructor(role: ReifiedRole) : this(role.name, role.scope.databaseScopePrefix, role.scope.databaseScopeId)
+}
+
+data class AssociateRole(val action: String,
+                         val name: String,
+                         val scopePrefix: String?,
+                         val scopeId: String?)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/CompressedJWTCookieClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/CompressedJWTCookieClient.kt
@@ -4,7 +4,7 @@ import org.pac4j.core.context.WebContext
 import org.pac4j.core.credentials.TokenCredentials
 import org.pac4j.http.client.direct.CookieClient
 import org.pac4j.http.credentials.extractor.CookieExtractor
-import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
 
 class CompressedJWTCookieClientWrapper(helper: TokenVerifier) : MontaguCredentialClientWrapper
 {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/CompressedJWTHeaderClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/CompressedJWTHeaderClient.kt
@@ -4,7 +4,7 @@ import org.pac4j.core.context.WebContext
 import org.pac4j.core.credentials.TokenCredentials
 import org.pac4j.core.credentials.extractor.HeaderExtractor
 import org.pac4j.http.client.direct.HeaderClient
-import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
 
 class CompressedJWTHeaderClientWrapper(helper: TokenVerifier) : MontaguCredentialClientWrapper
 {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/CompressedJWTParameterClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/CompressedJWTParameterClient.kt
@@ -4,7 +4,7 @@ import org.pac4j.core.context.WebContext
 import org.pac4j.core.credentials.TokenCredentials
 import org.pac4j.core.credentials.extractor.ParameterExtractor
 import org.pac4j.http.client.direct.ParameterClient
-import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
 
 class CompressedJWTParameterClientWrapper(helper: TokenVerifier,
                                           tokenStore: OnetimeTokenStore)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/MontaguAuthorizer.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/MontaguAuthorizer.kt
@@ -5,7 +5,7 @@ import org.pac4j.core.context.WebContext
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.sparkjava.SparkWebContext
 import org.slf4j.LoggerFactory
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.DirectActionContext
 
 open class MontaguAuthorizer(requiredPermissions: Set<PermissionRequirement>)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/MontaguCredentialClientWrapper.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/MontaguCredentialClientWrapper.kt
@@ -3,7 +3,7 @@ package org.vaccineimpact.orderlyweb.security
 import org.pac4j.core.client.DirectClient
 import org.pac4j.core.credentials.TokenCredentials
 import org.pac4j.core.profile.CommonProfile
-import org.vaccineimpact.api.models.ErrorInfo
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
 
 interface MontaguCredentialClientWrapper
 {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/PermissionRequirement.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/PermissionRequirement.kt
@@ -1,7 +1,7 @@
 package org.vaccineimpact.orderlyweb.security
 
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.errors.PermissionRequirementParseException
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/Profile.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/Profile.kt
@@ -1,8 +1,8 @@
 package org.vaccineimpact.orderlyweb.security
 
 import org.pac4j.core.profile.CommonProfile
-import org.vaccineimpact.api.models.permissions.PermissionSet
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 
 private const val USER_OBJECT = "userObject"
 private const val MISSING_PERMISSIONS = "missingPermissions"

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/TokenActionAdapter.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/TokenActionAdapter.kt
@@ -3,9 +3,9 @@ package org.vaccineimpact.orderlyweb.security
 import org.pac4j.core.context.HttpConstants
 import org.pac4j.sparkjava.DefaultHttpActionAdapter
 import org.pac4j.sparkjava.SparkWebContext
-import org.vaccineimpact.api.models.ErrorInfo
-import org.vaccineimpact.api.models.Result
-import org.vaccineimpact.api.models.ResultStatus
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
+import org.vaccineimpact.orderlyweb.models.Result
+import org.vaccineimpact.orderlyweb.models.ResultStatus
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.DirectActionContext
 import org.vaccineimpact.orderlyweb.Serializer

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/TokenVerifyingConfigFactory.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/TokenVerifyingConfigFactory.kt
@@ -3,7 +3,7 @@ package org.vaccineimpact.orderlyweb.security
 import org.pac4j.core.config.Config
 import org.pac4j.core.config.ConfigFactory
 import org.pac4j.core.profile.CommonProfile
-import org.vaccineimpact.api.models.permissions.PermissionSet
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 import org.vaccineimpact.orderlyweb.db.TokenStore
 
 class TokenVerifyingConfigFactory(

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/InsertHelpers.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/InsertHelpers.kt
@@ -1,8 +1,8 @@
 package org.vaccineimpact.orderlyweb.tests
 
-import org.vaccineimpact.api.models.ArtefactFormat
-import org.vaccineimpact.api.models.Changelog
-import org.vaccineimpact.api.models.FilePurpose
+import org.vaccineimpact.orderlyweb.models.ArtefactFormat
+import org.vaccineimpact.orderlyweb.models.Changelog
+import org.vaccineimpact.orderlyweb.models.FilePurpose
 import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.JooqContext

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ArtefactTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ArtefactTests.kt
@@ -91,7 +91,7 @@ class ArtefactTests : CleanDatabaseTests()
                 fileNames = listOf("graph.png", "summary.csv"))
 
         insertArtefact("version1", description = "animated gif",
-                format = org.vaccineimpact.api.models.ArtefactFormat.DATA,
+                format = org.vaccineimpact.orderlyweb.models.ArtefactFormat.DATA,
                 fileNames = listOf("img.gif"))
 
         val sut = createSut()
@@ -100,11 +100,11 @@ class ArtefactTests : CleanDatabaseTests()
 
         assertThat(result[0].description).isEqualTo("graph and summary")
         assertThat(result[0].files).hasSameElementsAs(listOf("graph.png", "summary.csv"))
-        assertThat(result[0].format).isEqualTo(org.vaccineimpact.api.models.ArtefactFormat.REPORT)
+        assertThat(result[0].format).isEqualTo(org.vaccineimpact.orderlyweb.models.ArtefactFormat.REPORT)
 
         assertThat(result[1].description).isEqualTo("animated gif")
         assertThat(result[1].files).hasSameElementsAs(listOf("img.gif"))
-        assertThat(result[1].format).isEqualTo(org.vaccineimpact.api.models.ArtefactFormat.DATA)
+        assertThat(result[1].format).isEqualTo(org.vaccineimpact.orderlyweb.models.ArtefactFormat.DATA)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/OrderlyChangelogTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/OrderlyChangelogTests.kt
@@ -2,7 +2,7 @@ package org.vaccineimpact.orderlyweb.tests.database_tests
 
 import org.assertj.core.api.Assertions
 import org.junit.Test
-import org.vaccineimpact.api.models.Changelog
+import org.vaccineimpact.orderlyweb.models.Changelog
 import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.errors.UnknownObjectError
 import org.vaccineimpact.orderlyweb.tests.ChangelogWithPublicVersion

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ResourceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ResourceTests.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
-import org.vaccineimpact.api.models.FilePurpose
+import org.vaccineimpact.orderlyweb.models.FilePurpose
 import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.errors.UnknownObjectError
 import org.vaccineimpact.orderlyweb.tests.insertFileInput

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
@@ -3,9 +3,9 @@ package org.vaccineimpact.orderlyweb.tests.database_tests
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.api.models.Artefact
-import org.vaccineimpact.api.models.ArtefactFormat
-import org.vaccineimpact.api.models.FilePurpose
+import org.vaccineimpact.orderlyweb.models.Artefact
+import org.vaccineimpact.orderlyweb.models.ArtefactFormat
+import org.vaccineimpact.orderlyweb.models.FilePurpose
 import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.errors.UnknownObjectError
 import org.vaccineimpact.orderlyweb.tests.insertArtefact

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/ResourceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/ResourceTests.kt
@@ -2,7 +2,7 @@ package org.vaccineimpact.orderlyweb.tests.integration_tests.tests
 
 import org.assertj.core.api.Assertions
 import org.junit.Test
-import org.vaccineimpact.api.models.FilePurpose
+import org.vaccineimpact.orderlyweb.models.FilePurpose
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.tests.insertFileInput

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/ReportControllerTests.kt
@@ -5,11 +5,11 @@ import khttp.responses.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
-import org.vaccineimpact.api.models.Changelog
-import org.vaccineimpact.api.models.Report
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.PermissionSet
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.Changelog
+import org.vaccineimpact.orderlyweb.models.Report
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.OrderlyServerAPI
 import org.vaccineimpact.orderlyweb.ZipClient

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/VersionControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/VersionControllerTests.kt
@@ -4,11 +4,11 @@ import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.api.models.Changelog
-import org.vaccineimpact.api.models.ReportVersionDetails
-import org.vaccineimpact.api.models.Scope
-import org.vaccineimpact.api.models.permissions.PermissionSet
-import org.vaccineimpact.api.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.Changelog
+import org.vaccineimpact.orderlyweb.models.ReportVersionDetails
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.FileSystem
 import org.vaccineimpact.orderlyweb.OrderlyServerAPI


### PR DESCRIPTION
There's no need to share model code with any other Montagu apps, so this removes the shared submodule and just brings any needed models into the main project.