### PR TITLE
add dist base image that includes templates

### DIFF
--- a/dist.Dockerfile
+++ b/dist.Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:8u121
+
+RUN mkdir /static/public -p
+
+COPY ./src/app/static/public /static/public
+COPY ./src/app/templates /templates

--- a/scripts/make-build-env.sh
+++ b/scripts/make-build-env.sh
@@ -1,1 +1,3 @@
 docker build --tag orderly-web-build-environment .
+
+docker build --tag orderly-web-dist-base --file dist.Dockerfile .

--- a/scripts/run-smoke-test.sh
+++ b/scripts/run-smoke-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -ex
+here=$(dirname $0)
+
+git_id=$(git rev-parse --short=7 HEAD)
+git_branch=$(git symbolic-ref --short HEAD)
+
+ ## Run all dependencies
+export MONTAGU_ORDERLY_PATH=$PWD/git
+export ORDERLY_SERVER_USER_ID=$UID
+$here/run-dependencies.sh
+
+ # Run the OrderlyWeb image
+docker run --rm \
+    -d \
+    -v $PWD/demo:/orderly \
+    -p 8081:8081 \
+    --name orderly-web \
+    docker.montagu.dide.ic.ac.uk:5000/orderly-web:$git_id
+
+function cleanup(){
+    docker stop orderly-web
+    docker-compose -f $here/docker-compose.yml --project-name montagu down
+}
+trap cleanup EXIT
+
+docker exec orderly-web mkdir -p /etc/orderly/web
+docker exec orderly-web touch /etc/orderly/web/go_signal
+
+ # Wait for go signal
+sleep 2
+
+ # Hit the index page and check it works
+response=$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8081/api/v1)
+
+if [[ $response -ne 200 ]]; then exit 1; fi;

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 }
 
 docker {
-    baseImage = "openjdk:8u121-jre"
+    baseImage = "orderly-web-dist-base"
 }
 
 distDocker {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/GoSignal.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/GoSignal.kt
@@ -12,7 +12,7 @@ fun waitForGoSignal()
 
     while (!path.exists())
     {
-        Thread.sleep(2000)
+        Thread.sleep(500)
     }
     println("Go signal detected. Running API")
 }


### PR DESCRIPTION
This fixes a bug with the docker build process which means the current master image is not working, because files external to the app (the static and template directories) were not included in the image. 

This also was a simple fix - creating a new base image with the static files included for the app to inherit from. To test things of this nature I have added a basic smoke test - a bash script that just runs the app image and checks the app has started by making a request to the API index. This can be run on TC.