### PR TITLE
mrc-226 add template object wrapper

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/Router.kt
@@ -4,7 +4,7 @@ import freemarker.template.Configuration
 import org.slf4j.LoggerFactory
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.controllers.Controller
-import org.vaccineimpact.orderlyweb.controllers.api.Template
+import org.vaccineimpact.orderlyweb.controllers.web.Template
 import org.vaccineimpact.orderlyweb.errors.RouteNotFound
 import org.vaccineimpact.orderlyweb.errors.UnsupportedValueException
 import org.vaccineimpact.orderlyweb.models.AuthenticationResponse
@@ -22,7 +22,6 @@ import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationConfig
 import org.pac4j.core.config.Config
 import org.pac4j.sparkjava.LogoutRoute
 import org.vaccineimpact.orderlyweb.security.WebSecurityConfigFactory
-import org.vaccineimpact.orderlyweb.security.clients.MontaguIndirectClient
 
 
 class Router(freeMarkerConfig: Configuration)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/SparkApp.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/SparkApp.kt
@@ -26,7 +26,7 @@ class OrderlyWeb
 {
     private val logger = LoggerFactory.getLogger(OrderlyWeb::class.java)
 
-    fun getPropertiesAsString(prop: Properties): String
+    private fun getPropertiesAsString(prop: Properties): String
     {
         val writer = StringWriter()
         prop.list(PrintWriter(writer))
@@ -37,6 +37,7 @@ class OrderlyWeb
     {
 
         val freeMarkerConfig = Configuration(Configuration.VERSION_2_3_26)
+        freeMarkerConfig.objectWrapper = TemplateObjectWrapper()
         freeMarkerConfig.setDirectoryForTemplateLoading(File("templates").absoluteFile)
         freeMarkerConfig.addAutoInclude("layouts/layout.ftl")
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/TemplateObjectWrapper.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/TemplateObjectWrapper.kt
@@ -1,0 +1,30 @@
+package org.vaccineimpact.orderlyweb.app_start
+
+import freemarker.template.Configuration
+import freemarker.template.DefaultObjectWrapper
+import freemarker.template.TemplateModel
+import org.vaccineimpact.orderlyweb.Serializer
+import org.vaccineimpact.orderlyweb.controllers.web.Serialise
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+
+class TemplateObjectWrapper : freemarker.ext.beans.BeansWrapper(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS)
+{
+    private val baseObjectWrapper = DefaultObjectWrapper(this.incompatibleImprovements)
+
+    override fun wrap(model: Any): TemplateModel
+    {
+        val properties = model::class.memberProperties
+        val result = mutableMapOf<String, Any?>()
+        properties.map {
+            val propertyValue = it.getter.call(model)
+            val annotation = it.findAnnotation<Serialise>()
+            if (annotation != null)
+            {
+                result[annotation.propertyName] = Serializer.instance.gson.toJson(propertyValue)
+            }
+            result[it.name] = propertyValue
+        }
+        return baseObjectWrapper.wrap(result)
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/HomeController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/HomeController.kt
@@ -2,7 +2,6 @@ package org.vaccineimpact.orderlyweb.controllers.web
 
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.Controller
-import org.vaccineimpact.orderlyweb.controllers.api.Template
 import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.db.OrderlyClient
 import org.vaccineimpact.orderlyweb.models.Report

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/TemplateAnnotation.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/TemplateAnnotation.kt
@@ -1,4 +1,7 @@
-package org.vaccineimpact.orderlyweb.controllers.api
+package org.vaccineimpact.orderlyweb.controllers.web
 
 @Target(AnnotationTarget.FUNCTION)
 annotation class Template(val templateName: String)
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class Serialise(val propertyName: String)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.orderlyweb.tests.unit_tests
+package org.vaccineimpact.orderlyweb.tests.integration_tests.tests
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/TemplateObjectWrapperTests.kt
@@ -1,0 +1,92 @@
+package org.vaccineimpact.orderlyweb.tests.unit_tests
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import freemarker.ext.beans.StringModel
+import freemarker.template.SimpleHash
+import freemarker.template.SimpleSequence
+import freemarker.template.TemplateBooleanModel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.pac4j.core.profile.CommonProfile
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.Serializer
+import org.vaccineimpact.orderlyweb.app_start.TemplateObjectWrapper
+import org.vaccineimpact.orderlyweb.controllers.web.HomeController.IndexViewModel
+import org.vaccineimpact.orderlyweb.controllers.web.Serialise
+import org.vaccineimpact.orderlyweb.models.Artefact
+import org.vaccineimpact.orderlyweb.models.ArtefactFormat
+import org.vaccineimpact.orderlyweb.models.Report
+import org.vaccineimpact.orderlyweb.models.ReportVersionDetails
+import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+import java.time.Instant
+
+class TemplateObjectWrapperTests : TeamcityTests()
+{
+    class TestClass(@Serialise("reportJson") val report: Report)
+
+    @Test
+    fun `can wrap complex properties`()
+    {
+        val now = Instant.now()
+        val report = ReportVersionDetails("r1",
+                "first report",
+                "v1",
+                true,
+                now,
+                "dr author",
+                "ms funder",
+                "a fake report",
+                listOf(Artefact(ArtefactFormat.DATA, "a graph", listOf("graph.png"))),
+                listOf(),
+                mapOf("hash" to "data.csv"))
+
+        val sut = TemplateObjectWrapper()
+        val result = sut.wrap(report) as SimpleHash
+
+        assertThat(result["name"].toString()).isEqualTo("r1")
+        assertThat(result["id"].toString()).isEqualTo("v1")
+        assertThat((result["published"] as TemplateBooleanModel).asBoolean).isEqualTo(true)
+        assertThat((result["date"]).toString()).isEqualTo(now.toString())
+
+        val wrappedArtefacts = result["artefacts"] as SimpleSequence
+        val wrappedArtefact = wrappedArtefacts[0] as StringModel
+        assertThat(wrappedArtefact["format"].toString()).isEqualTo("data")
+        assertThat(wrappedArtefact["description"].toString()).isEqualTo("a graph")
+
+        val files = wrappedArtefact["files"] as SimpleSequence
+        assertThat(files[0].toString()).isEqualTo("graph.png")
+
+        val data = result["dataHashes"] as SimpleHash
+        assertThat(data["hash"].toString()).isEqualTo("data.csv")
+    }
+
+    @Test
+    fun `adds extra field when marked with the serialise attribute`()
+    {
+        val report = Report("some report", "display name", "v1")
+        val model = TestClass(report)
+        val sut = TemplateObjectWrapper()
+        val result = sut.wrap(model) as SimpleHash
+
+        assertThat(result["reportJson"].toString())
+                .isEqualTo(Serializer.instance.gson.toJson(report))
+    }
+
+    @Test
+    fun `includes all declared and inherited properties of view model`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { it.userProfile } doReturn CommonProfile().apply { id = "user.name" }
+        }
+        val model = IndexViewModel(mockContext, listOf())
+
+        val sut = TemplateObjectWrapper()
+        val result = sut.wrap(model) as SimpleHash
+        assertThat(result["appName"].toString()).isEqualTo("Reporting portal")
+        assertThat(result["authProvider"].toString()).isEqualTo("montagu")
+        assertThat(result["appEmail"].toString()).isEqualTo("montagu-help@imperial.ac.uk")
+        assertThat(result["user"].toString()).isEqualTo("user.name")
+        assertThat((result["loggedIn"] as TemplateBooleanModel).asBoolean).isEqualTo(true)
+    }
+}


### PR DESCRIPTION
We want certain properties on view models serialised to json for the page js to read. 

I've added a custom `ObjectWrapper` - this is the class that freemarker uses to convert viewmodels into something the templates can use. The new class looks for properties marked with a serialise attribute and adds them to the model before passing it on to freemarker's built in `DefaultObjectWrapper`.