### PR TITLE
mrc-259 preliminary refactor

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/HomeController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/HomeController.kt
@@ -6,6 +6,7 @@ import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.db.OrderlyClient
 import org.vaccineimpact.orderlyweb.models.Report
 import org.vaccineimpact.orderlyweb.viewmodels.AppViewModel
+import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 
 class HomeController: OrderlyDataController
 {
@@ -13,8 +14,6 @@ class HomeController: OrderlyDataController
                 orderly: OrderlyClient): super(actionContext, orderly)
 
     constructor(actionContext: ActionContext): super(actionContext)
-
-    open class IndexViewModel(context: ActionContext, open val reports: List<Report>) : AppViewModel(context)
 
     @Template("index.ftl")
     fun index(): IndexViewModel

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -1,14 +1,13 @@
 package org.vaccineimpact.orderlyweb.controllers.web
 
 import org.vaccineimpact.orderlyweb.ActionContext
-import org.vaccineimpact.orderlyweb.controllers.Controller
-import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.db.OrderlyClient
-import org.vaccineimpact.orderlyweb.models.Artefact
-import org.vaccineimpact.orderlyweb.models.ReportVersionDetails
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
-import org.vaccineimpact.orderlyweb.viewmodels.AppViewModel
+import org.vaccineimpact.orderlyweb.viewmodels.ArtefactViewModel
+import org.vaccineimpact.orderlyweb.viewmodels.DownloadableFileViewModel
+import org.vaccineimpact.orderlyweb.viewmodels.InputDataViewModel
+import org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel
 import java.net.URLEncoder
 
 class ReportController: OrderlyDataController
@@ -18,24 +17,8 @@ class ReportController: OrderlyDataController
 
     constructor(actionContext: ActionContext): super(actionContext)
 
-    open class ReportViewModel(@Serialise("reportJson") open val report: ReportVersionDetails,
-                          open val focalArtefactUrl: String?,
-                          open val isAdmin: Boolean,
-                          open val artefacts: List<ArtefactViewModel>,
-                          open val dataLinks: List<InputDataViewModel>,
-                          open val resources: List<DownloadableFileViewModel>,
-                          open val zipFile: DownloadableFileViewModel,
-                          context: ActionContext) : AppViewModel(context)
-
-
-    class ArtefactViewModel(val artefact: Artefact, val files: List<DownloadableFileViewModel>, val inlineArtefactFigure: String?)
-
-    class InputDataViewModel(val key: String, val csv: DownloadableFileViewModel, val rds: DownloadableFileViewModel)
-
-    class DownloadableFileViewModel(val name: String, val url: String)
-
     @Template("report-page.ftl")
-    fun getByNameAndVersion(): ReportViewModel
+    fun getByNameAndVersion(): ReportVersionViewModel
     {
         val reportName = context.params(":name")
         val version = context.params(":version")
@@ -59,7 +42,8 @@ class ReportController: OrderlyDataController
         val artefacts = reportDetails.artefacts.map{ ArtefactViewModel(it,
                 it.files.map{filename -> DownloadableFileViewModel(filename,
                         buildArtefactFileUrl(reportName, version, filename, false)) },
-                getArtefactInlineFigure(reportName, version, it.files))}
+                getArtefactInlineFigure(reportName, version, it.files))
+        }
 
         val dataLinks = reportDetails.dataHashes.map{ InputDataViewModel(
                 it.key,
@@ -75,7 +59,7 @@ class ReportController: OrderlyDataController
 
         val isAdmin = context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))
 
-        return ReportViewModel(reportDetails.copy(displayName = displayName),
+        return ReportVersionViewModel(reportDetails.copy(displayName = displayName),
                 focalArtefactUrl,
                 isAdmin,
                 artefacts,

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/SecurityController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/SecurityController.kt
@@ -2,12 +2,10 @@ package org.vaccineimpact.orderlyweb.controllers.web
 
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.Controller
-import org.vaccineimpact.orderlyweb.viewmodels.AppViewModel
+import org.vaccineimpact.orderlyweb.viewmodels.WebloginViewModel
 
 class SecurityController(actionContext: ActionContext) : Controller(actionContext)
 {
-    class WebloginViewModel(context: ActionContext, val requestedUrl: String) : AppViewModel(context)
-
     @Template("weblogin.ftl")
     fun weblogin(): WebloginViewModel
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
@@ -1,0 +1,6 @@
+package org.vaccineimpact.orderlyweb.viewmodels
+
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.models.Report
+
+open class IndexViewModel(context: ActionContext, open val reports: List<Report>) : AppViewModel(context)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -1,0 +1,22 @@
+package org.vaccineimpact.orderlyweb.viewmodels
+
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.controllers.web.Serialise
+import org.vaccineimpact.orderlyweb.models.Artefact
+import org.vaccineimpact.orderlyweb.models.ReportVersionDetails
+
+open class ReportVersionViewModel(@Serialise("reportJson") open val report: ReportVersionDetails,
+                                  open val focalArtefactUrl: String?,
+                                  open val isAdmin: Boolean,
+                                  open val artefacts: List<ArtefactViewModel>,
+                                  open val dataLinks: List<InputDataViewModel>,
+                                  open val resources: List<DownloadableFileViewModel>,
+                                  open val zipFile: DownloadableFileViewModel,
+                                  context: ActionContext) : AppViewModel(context)
+
+
+class ArtefactViewModel(val artefact: Artefact, val files: List<DownloadableFileViewModel>, val inlineArtefactFigure: String?)
+
+class InputDataViewModel(val key: String, val csv: DownloadableFileViewModel, val rds: DownloadableFileViewModel)
+
+class DownloadableFileViewModel(val name: String, val url: String)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/WebloginViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/WebloginViewModel.kt
@@ -1,0 +1,5 @@
+package org.vaccineimpact.orderlyweb.viewmodels
+
+import org.vaccineimpact.orderlyweb.ActionContext
+
+class WebloginViewModel(context: ActionContext, val requestedUrl: String) : AppViewModel(context)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
@@ -12,13 +12,13 @@ import org.pac4j.core.profile.CommonProfile
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.Serializer
 import org.vaccineimpact.orderlyweb.app_start.TemplateObjectWrapper
-import org.vaccineimpact.orderlyweb.controllers.web.HomeController.IndexViewModel
 import org.vaccineimpact.orderlyweb.controllers.web.Serialise
 import org.vaccineimpact.orderlyweb.models.Artefact
 import org.vaccineimpact.orderlyweb.models.ArtefactFormat
 import org.vaccineimpact.orderlyweb.models.Report
 import org.vaccineimpact.orderlyweb.models.ReportVersionDetails
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 import java.time.Instant
 
 class TemplateObjectWrapperTests : TeamcityTests()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/security/clients/GithubIndirectClientTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/security/clients/GithubIndirectClientTests.kt
@@ -31,7 +31,7 @@ class GithubIndirectClientTests : TeamcityTests()
         assertThat(profileCreator is GithubOAuthProfileCreator).isTrue()
 
         val ags = sut.authorizationGenerators
-        Assertions.assertThat((ags as List<AuthorizationGenerator<CommonProfile>>).count()).isEqualTo(1)
+        Assertions.assertThat(ags.count()).isEqualTo(1)
         assertThat(ags[0] is OrderlyAuthorizationGenerator).isTrue()
 
         assertThat(sut.callbackUrl).isEqualTo("http://localhost:8888/login")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/APIEndpointTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/APIEndpointTests.kt
@@ -166,7 +166,6 @@ class APIEndpointTests: TeamcityTests()
     fun `does not add security filter if not secure`()
     {
         val set = setOf("help")
-        val aclass = set::class.java
 
         val mockSpark = mock<SparkWrapper>()
         val sut = APIEndpoint(urlFragment = "/test", actionName = "test", controller = TestController::class,

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/IndexTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/IndexTests.kt
@@ -1,18 +1,15 @@
 package org.vaccineimpact.orderlyweb.tests.unit_tests.templates
 
-import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import org.assertj.core.api.Assertions.*
 import org.junit.ClassRule
 import org.junit.Test
-import org.vaccineimpact.orderlyweb.controllers.web.HomeController
 import org.vaccineimpact.orderlyweb.models.Report
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
 import org.vaccineimpact.orderlyweb.tests.unit_tests.templates.rules.FreemarkerTestRule
-import org.xmlmatchers.XmlMatchers.hasXPath
+import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 
-class IndexTests: TeamcityTests()
+class IndexTests : TeamcityTests()
 {
     companion object
     {
@@ -24,23 +21,16 @@ class IndexTests: TeamcityTests()
     @Test
     fun `renders correctly`()
     {
-        val mockModel = mock<HomeController.IndexViewModel> {
-            on { appName } doReturn "testApp"
-            on { reports } doReturn listOf(Report("r1", "r1 display", "v1"),
-                                            Report("r2", "r2 display", "v2"))
-        }
+        val testModel = IndexViewModel(mock(), listOf(Report("r1", "r1 display", "v1"),
+                Report("r2", "r2 display", "v2")))
 
-        val xmlResponse = template.xmlResponseFor(mockModel)
+        val doc = template.jsoupDocFor(testModel)
 
-        assertThat(xmlResponse, hasXPath("//h1/text()", equalToCompressingWhiteSpace("All reports")))
-
-        assertThat(xmlResponse, hasXPath("//div[@id='content']/a[1]/text()",
-                equalToCompressingWhiteSpace("r1")))
-        assertThat(xmlResponse, hasXPath("//div[@id='content']/a[1]/@href", equalTo("reports/r1/v1")))
-
-        assertThat(xmlResponse, hasXPath("//div[@id='content']/a[2]/text()",
-                equalToCompressingWhiteSpace("r2")))
-        assertThat(xmlResponse, hasXPath("//div[@id='content']/a[2]/@href", equalTo("reports/r2/v2")))
+        assertThat(doc.select("h1").text()).isEqualTo("All reports")
+        assertThat(doc.selectFirst("#content a").attr("href")).isEqualTo("reports/r1/v1")
+        assertThat(doc.selectFirst("#content a").text()).isEqualTo("r1")
+        assertThat(doc.select("#content a")[1].attr("href")).isEqualTo("reports/r2/v2")
+        assertThat(doc.select("#content a")[1].text()).isEqualTo("r2")
 
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -1,25 +1,25 @@
 package org.vaccineimpact.orderlyweb.tests.unit_tests.templates
 
-import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.equalToCompressingWhiteSpace
 import org.junit.ClassRule
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ActionContext
-import org.vaccineimpact.orderlyweb.controllers.web.ReportController
 import org.vaccineimpact.orderlyweb.models.Artefact
 import org.vaccineimpact.orderlyweb.models.ArtefactFormat
 import org.vaccineimpact.orderlyweb.models.ReportVersionDetails
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
 import org.vaccineimpact.orderlyweb.tests.unit_tests.templates.rules.FreemarkerTestRule
+import org.vaccineimpact.orderlyweb.viewmodels.*
 import org.xmlmatchers.XmlMatchers.hasXPath
 import java.sql.Timestamp
 
 //This will also test the partials which the report-page template includes
 
-class ReportPageTests : TeamcityTests()
+class VersionPageTests : TeamcityTests()
 {
     companion object
     {
@@ -41,66 +41,65 @@ class ReportPageTests : TeamcityTests()
             dataHashes = mapOf())
 
     private val testArtefactViewModels = listOf(
-            ReportController.ArtefactViewModel(
+            ArtefactViewModel(
                     Artefact(ArtefactFormat.DATA, "artefact1", listOf()),
                     listOf(
-                            ReportController.DownloadableFileViewModel("a1file1.png", "http://a1file1"),
-                            ReportController.DownloadableFileViewModel("a1file2.pdf", "http://a1file2")
+                            DownloadableFileViewModel("a1file1.png", "http://a1file1"),
+                            DownloadableFileViewModel("a1file2.pdf", "http://a1file2")
                     ),
                     "inlinesrc.png"
-                ),
-            ReportController.ArtefactViewModel(
+            ),
+            ArtefactViewModel(
                     Artefact(ArtefactFormat.DATA, "artefact2", listOf()),
                     listOf(
-                            ReportController.DownloadableFileViewModel("a2file1.xls", "http://a2file1")
+                            DownloadableFileViewModel("a2file1.xls", "http://a2file1")
                     ),
                     null
             )
     )
 
     private val testDataLinks = listOf(
-            ReportController.InputDataViewModel("key1",
-                    ReportController.DownloadableFileViewModel("key1.csv", "http://key1/csv"),
-                    ReportController.DownloadableFileViewModel("key1.rds", "http://key1/rds")),
-            ReportController.InputDataViewModel("key2",
-                    ReportController.DownloadableFileViewModel("key2.csv", "http://key2/csv"),
-                    ReportController.DownloadableFileViewModel("key2.rds", "http://key2/rds"))
+            InputDataViewModel("key1",
+                    DownloadableFileViewModel("key1.csv", "http://key1/csv"),
+                    DownloadableFileViewModel("key1.rds", "http://key1/rds")),
+            InputDataViewModel("key2",
+                    DownloadableFileViewModel("key2.csv", "http://key2/csv"),
+                    DownloadableFileViewModel("key2.rds", "http://key2/rds"))
     )
 
     private val testResources = listOf(
-            ReportController.DownloadableFileViewModel("resource1.csv", "http://resource1/csv"),
-            ReportController.DownloadableFileViewModel("resource2.csv", "http://resource2/csv")
+            DownloadableFileViewModel("resource1.csv", "http://resource1/csv"),
+            DownloadableFileViewModel("resource2.csv", "http://resource2/csv")
     )
 
-    // Mock the wrapper serialization in the real model class
-    private open class TestReportViewModel(open val reportJson: String,
-                                           report: ReportVersionDetails,
-                                           focalArtefactUrl: String?,
-                                           isAdmin: Boolean,
-                                           artefacts: List<ReportController.ArtefactViewModel>,
-                                           dataLinks: List<ReportController.InputDataViewModel>,
-                                           resources: List<ReportController.DownloadableFileViewModel>,
-                                           zipFile: ReportController.DownloadableFileViewModel,
-                                           context: ActionContext) :
-            ReportController.ReportViewModel(report, focalArtefactUrl, isAdmin, artefacts, dataLinks, resources, zipFile,  context)
+    data class TestReportViewModel(
+            val reportJson: String,
+            override val report: ReportVersionDetails,
+            override val focalArtefactUrl: String?,
+            override val isAdmin: Boolean,
+            override val artefacts: List<ArtefactViewModel>,
+            override val dataLinks: List<InputDataViewModel>,
+            override val resources: List<DownloadableFileViewModel>,
+            override val zipFile: DownloadableFileViewModel,
+            val context: ActionContext) :
+            ReportVersionViewModel(report, focalArtefactUrl, isAdmin, artefacts, dataLinks, resources, zipFile, context)
 
-
-    private val mockModel = mock<TestReportViewModel> {
-        on { appName } doReturn "testApp"
-        on { report } doReturn testReport
-        on { reportJson } doReturn "{}"
-        on { isAdmin } doReturn false
-        on { focalArtefactUrl } doReturn "/testFocalArtefactUrl"
-        on { artefacts } doReturn testArtefactViewModels
-        on { dataLinks } doReturn testDataLinks
-        on { resources } doReturn testResources
-        on { zipFile } doReturn ReportController.DownloadableFileViewModel("zipFileName", "http://zipFileUrl")
-    }
+    private val testModel = TestReportViewModel(
+            "{}",
+            testReport,
+            "/testFocalArtefactUrl",
+            false,
+            testArtefactViewModels,
+            testDataLinks,
+            testResources,
+            DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
+            mock()
+    )
 
     @Test
     fun `renders outline correctly`()
     {
-        val xmlResponse = template.xmlResponseFor(mockModel)
+        val xmlResponse = template.xmlResponseFor(testModel)
 
         assertThat(xmlResponse, hasXPath("//li[@class='nav-item'][1]/a[@role='tab']/text()",
                 equalToCompressingWhiteSpace("Report")))
@@ -115,7 +114,7 @@ class ReportPageTests : TeamcityTests()
     @Test
     fun `renders report tab correctly`()
     {
-        val xmlResponse = template.xmlResponseFor(mockModel)
+        val xmlResponse = template.xmlResponseFor(testModel)
 
         val xPathRoot = "//div[@id='report-tab']"
 
@@ -131,8 +130,9 @@ class ReportPageTests : TeamcityTests()
     }
 
     @Test
-    fun `renders download tab title correctly`() {
-        val xmlResponse = template.xmlResponseFor(mockModel)
+    fun `renders download tab title correctly`()
+    {
+        val xmlResponse = template.xmlResponseFor(testModel)
 
         val xPathRoot = "//div[@id='downloads-tab']"
 
@@ -144,7 +144,7 @@ class ReportPageTests : TeamcityTests()
     @Test
     fun `renders download tab artefacts correctly`()
     {
-        val jsoupDoc = template.jsoupDocFor(mockModel)
+        val jsoupDoc = template.jsoupDocFor(testModel)
 
         val artefactsEl = jsoupDoc.select("#artefacts")
         val artefactCards = artefactsEl.select(".card")
@@ -176,7 +176,7 @@ class ReportPageTests : TeamcityTests()
     @Test
     fun `renders download tab data links correctly`()
     {
-        val jsoupDoc = template.jsoupDocFor(mockModel)
+        val jsoupDoc = template.jsoupDocFor(testModel)
 
         val linksEl = jsoupDoc.select("#data-links")
         Assertions.assertThat(linksEl.select(".card-header").text()).isEqualTo("Input data to the report")
@@ -206,15 +206,7 @@ class ReportPageTests : TeamcityTests()
     @Test
     fun `does not render download tab data links if none in model`()
     {
-        val testModel = mock<TestReportViewModel> {
-            on { appName } doReturn "testApp"
-            on { report } doReturn testReport
-            on { reportJson } doReturn "{}"
-            on { isAdmin } doReturn false
-            on { focalArtefactUrl } doReturn "/testFocalArtefactUrl"
-            on { dataLinks } doReturn listOf<ReportController.InputDataViewModel>()
-            on { zipFile } doReturn ReportController.DownloadableFileViewModel("zipFileName", "http://zipFileUrl")
-        }
+        val testModel = testModel.copy(dataLinks = listOf())
 
         val jsoupDoc = template.jsoupDocFor(testModel)
 
@@ -225,7 +217,7 @@ class ReportPageTests : TeamcityTests()
     @Test
     fun `renders resources correctly`()
     {
-        val jsoupDoc = template.jsoupDocFor(mockModel)
+        val jsoupDoc = template.jsoupDocFor(testModel)
 
         val resourcesEl = jsoupDoc.select("#resources")
         Assertions.assertThat(resourcesEl.select(".card-header").text()).isEqualTo("Resources")
@@ -243,7 +235,7 @@ class ReportPageTests : TeamcityTests()
     @Test
     fun `renders zipfile correctly`()
     {
-        val jsoupDoc = template.jsoupDocFor(mockModel)
+        val jsoupDoc = template.jsoupDocFor(testModel)
 
         val zipFileEl = jsoupDoc.select("#zip-file")
         val zipFileLink = zipFileEl.select("a")
@@ -255,16 +247,7 @@ class ReportPageTests : TeamcityTests()
     @Test
     fun `does not render download tab resources if none in model`()
     {
-        val testModel = mock<TestReportViewModel> {
-            on { appName } doReturn "testApp"
-            on { report } doReturn testReport
-            on { reportJson } doReturn "{}"
-            on { isAdmin } doReturn false
-            on { focalArtefactUrl } doReturn "/testFocalArtefactUrl"
-            on { resources } doReturn listOf<ReportController.DownloadableFileViewModel>()
-            on { zipFile } doReturn ReportController.DownloadableFileViewModel("zipFileName", "http://zipFileUrl")
-        }
-
+        val testModel = testModel.copy(resources = listOf())
         val jsoupDoc = template.jsoupDocFor(testModel)
 
         val resourcesEl = jsoupDoc.select("#resources")
@@ -274,14 +257,7 @@ class ReportPageTests : TeamcityTests()
     @Test
     fun `admins see publish switch`()
     {
-        val mockModel = mock<TestReportViewModel> {
-            on { appName } doReturn "testApp"
-            on { report } doReturn testReport
-            on { reportJson } doReturn "{}"
-            on { isAdmin } doReturn true
-            on { focalArtefactUrl } doReturn "/testFocalArtefactUrl"
-            on { zipFile } doReturn ReportController.DownloadableFileViewModel("zipFileName", "http://zipFileUrl")
-        }
+        val mockModel = testModel.copy(isAdmin = true)
 
         val htmlResponse = template.htmlPageResponseFor(mockModel)
 
@@ -292,14 +268,7 @@ class ReportPageTests : TeamcityTests()
     @Test
     fun `non admins do not see publish switch`()
     {
-        val mockModel = mock<TestReportViewModel> {
-            on { appName } doReturn "testApp"
-            on { report } doReturn testReport
-            on { reportJson } doReturn "{}"
-            on { isAdmin } doReturn false
-            on { focalArtefactUrl } doReturn "/testFocalArtefactUrl"
-            on { zipFile } doReturn ReportController.DownloadableFileViewModel("zipFileName", "http://zipFileUrl")
-        }
+        val mockModel = testModel.copy(isAdmin = false)
 
         val htmlResponse = template.htmlPageResponseFor(mockModel)
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/rules/FreemarkerTestRule.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/rules/FreemarkerTestRule.kt
@@ -13,7 +13,6 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import org.vaccineimpact.orderlyweb.app_start.buildFreemarkerConfig
-import org.vaccineimpact.orderlyweb.tests.unit_tests.templates.ReportPageTests
 import org.xmlmatchers.transform.XmlConverters.the
 import java.io.File
 import java.io.StringWriter
@@ -103,7 +102,7 @@ class FreemarkerTestRule(val templateName: String, val templatePath: String = "t
 
     fun jsoupDocFor(dataModel: Any): Document
     {
-        val stringResponse = ReportPageTests.template.stringResponseFor(dataModel)
+        val stringResponse = stringResponseFor(dataModel)
         return Jsoup.parse(stringResponse)
     }
 }


### PR DESCRIPTION
* moved all ViewModel classes to their own files in the viewmodels directory as having them as children of other classes was making for verbose code and crowded controllers
* removed mocking from tests where unnecessary and replaced some xml parsing with jsoup