### PR TITLE
mrc-258 style fixes

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/SecurityController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/SecurityController.kt
@@ -9,7 +9,7 @@ class SecurityController(actionContext: ActionContext) : Controller(actionContex
     @Template("weblogin.ftl")
     fun weblogin(): WebloginViewModel
     {
-        //This action handles displaying the 'landing page' with links to the external auth providers e.g. Github
+        //This action handles displaying the 'landing page' with links to the external auth providers e.g. GitHub
         //This is the redirect location for the OrderlyWebIndirectClient, which secures the WebEndpoints of the app
         val requestedUrl = context.queryParams("requestedUrl")
         return WebloginViewModel(context, requestedUrl?:"")

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/AuthenticationConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/AuthenticationConfig.kt
@@ -15,7 +15,7 @@ open class AuthenticationConfig
         val configuredValue = AppConfig()["auth.provider"]
 
         return when (configuredValue.toLowerCase()) {
-            "github" -> AuthenticationProvider.Github
+            "github" -> AuthenticationProvider.GitHub
             "montagu" -> AuthenticationProvider.Montagu
             else -> throw UnknownAuthenticationProvider(configuredValue)
         }
@@ -33,7 +33,7 @@ open class AuthenticationConfig
     fun getAuthenticationIndirectClient() : IndirectClient<out Credentials, out CommonProfile>
     {
         return  when (getConfiguredProvider()) {
-            AuthenticationProvider.Github -> GithubIndirectClient(getGithubOAuthKey(), getGithubOAuthSecret())
+            AuthenticationProvider.GitHub -> GithubIndirectClient(getGithubOAuthKey(), getGithubOAuthSecret())
             AuthenticationProvider.Montagu -> MontaguIndirectClient()
         }
     }
@@ -43,7 +43,7 @@ open class AuthenticationConfig
 enum class AuthenticationProvider
 {
     Montagu,
-    Github
+    GitHub
 }
 
 class UnknownAuthenticationProvider(val provider: String) : Exception("Application is configured to use unknown authentication provider '$provider'")

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/AuthenticationConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/AuthenticationConfig.kt
@@ -31,7 +31,7 @@ open class AuthenticationConfig(val appConfig: Config = AppConfig())
         return appConfig["auth.github_secret"]
     }
 
-    fun getAuthenticationIndirectClient() : IndirectClient<out Credentials, out CommonProfile>
+    open fun getAuthenticationIndirectClient() : IndirectClient<out Credentials, out CommonProfile>
     {
         return  when (getConfiguredProvider()) {
             AuthenticationProvider.GitHub -> GithubIndirectClient(getGithubOAuthKey(), getGithubOAuthSecret())

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/AuthenticationConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/AuthenticationConfig.kt
@@ -4,15 +4,16 @@ import org.pac4j.core.client.IndirectClient
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.core.credentials.Credentials
 import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.security.clients.MontaguIndirectClient
 import org.vaccineimpact.orderlyweb.security.clients.GithubIndirectClient
 
-open class AuthenticationConfig
+open class AuthenticationConfig(val appConfig: Config = AppConfig())
 {
 
     open fun getConfiguredProvider(): AuthenticationProvider {
 
-        val configuredValue = AppConfig()["auth.provider"]
+        val configuredValue = appConfig["auth.provider"]
 
         return when (configuredValue.toLowerCase()) {
             "github" -> AuthenticationProvider.GitHub
@@ -23,11 +24,11 @@ open class AuthenticationConfig
 
     private fun getGithubOAuthKey(): String {
         // AKA the Client ID
-        return AppConfig()["auth.github_key"]
+        return appConfig["auth.github_key"]
     }
 
     private fun getGithubOAuthSecret(): String {
-        return AppConfig()["auth.github_secret"]
+        return appConfig["auth.github_secret"]
     }
 
     fun getAuthenticationIndirectClient() : IndirectClient<out Credentials, out CommonProfile>

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/providers/GithubApiClientAuthHelper.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/providers/GithubApiClientAuthHelper.kt
@@ -15,8 +15,8 @@ interface GithubAuthHelper
 {
     fun authenticate(token: String)
 
-    //Checks that the Github user associated with the given token is permitted to authenticate with OrderlyWeb by
-    //getting org/team membership for the user from Github API and comparing with permitted values in AppConfig.
+    //Checks that the GitHub user associated with the given token is permitted to authenticate with OrderlyWeb by
+    //getting org/team membership for the user from GitHub API and comparing with permitted values in AppConfig.
     //Throws CredentialsException if check fails
     fun checkGithubUserHasOrderlyWebAccess()
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AppViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AppViewModel.kt
@@ -19,7 +19,7 @@ data class DefaultViewModel(override val loggedIn: Boolean,
 
     override val appName = AppConfig()["app.name"]
     override val appEmail = AppConfig()["app.email"]
-    override val authProvider = AuthenticationConfig().getConfiguredProvider().toString().toLowerCase()
+    override val authProvider = AuthenticationConfig().getConfiguredProvider().toString()
     override val logo = AppConfig()["app.logo"]
 
     init

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
@@ -85,7 +85,7 @@ class TemplateObjectWrapperTests : TeamcityTests()
         val sut = TemplateObjectWrapper()
         val result = sut.wrap(model) as SimpleHash
         assertThat(result["appName"].toString()).isEqualTo("Reporting portal")
-        assertThat(result["authProvider"].toString()).isEqualTo("montagu")
+        assertThat(result["authProvider"].toString()).isEqualTo("Montagu")
         assertThat(result["appEmail"].toString()).isEqualTo("montagu-help@imperial.ac.uk")
         assertThat(result["user"].toString()).isEqualTo("user.name")
         assertThat((result["loggedIn"] as TemplateBooleanModel).asBoolean).isEqualTo(true)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationConfigTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationConfigTests.kt
@@ -1,0 +1,55 @@
+package org.vaccineimpact.orderlyweb.tests.unit_tests
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThatThrownBy
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.db.Config
+import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationConfig
+import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationProvider
+import org.vaccineimpact.orderlyweb.security.authentication.UnknownAuthenticationProvider
+import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+
+class AuthenticationConfigTests : TeamcityTests()
+{
+    @Test
+    fun `getConfiguredProvider is case insensitive`()
+    {
+        var fakeConfig = mock<Config>() {
+            on { get("auth.provider") } doReturn "Montagu"
+        }
+        var sut = AuthenticationConfig(fakeConfig)
+        var result = sut.getConfiguredProvider()
+
+        assertThat(result).isEqualTo(AuthenticationProvider.Montagu)
+
+        fakeConfig = mock {
+            on { get("auth.provider") } doReturn "montagu"
+        }
+        sut = AuthenticationConfig(fakeConfig)
+        result = sut.getConfiguredProvider()
+
+        assertThat(result).isEqualTo(AuthenticationProvider.Montagu)
+
+        fakeConfig = mock {
+            on { get("auth.provider") } doReturn "github"
+        }
+        sut = AuthenticationConfig(fakeConfig)
+        result = sut.getConfiguredProvider()
+
+        assertThat(result).isEqualTo(AuthenticationProvider.GitHub)
+    }
+
+    @Test
+    fun `getConfiguredProvider throws error if provider is not GitHub or Montagu`()
+    {
+        val fakeConfig = mock<Config> {
+            on { get("auth.provider") } doReturn "nonsense"
+        }
+        val sut = AuthenticationConfig(fakeConfig)
+
+        assertThatThrownBy { sut.getConfiguredProvider() }
+                .isInstanceOf(UnknownAuthenticationProvider::class.java)
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationConfigTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationConfigTests.kt
@@ -9,6 +9,8 @@ import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationConfig
 import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationProvider
 import org.vaccineimpact.orderlyweb.security.authentication.UnknownAuthenticationProvider
+import org.vaccineimpact.orderlyweb.security.clients.GithubIndirectClient
+import org.vaccineimpact.orderlyweb.security.clients.MontaguIndirectClient
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
 
 class AuthenticationConfigTests : TeamcityTests()
@@ -51,5 +53,31 @@ class AuthenticationConfigTests : TeamcityTests()
 
         assertThatThrownBy { sut.getConfiguredProvider() }
                 .isInstanceOf(UnknownAuthenticationProvider::class.java)
+    }
+
+    @Test
+    fun `getAuthenticationIndirectClient returns Montagu client if provider is Montagu`()
+    {
+        val fakeConfig = mock<Config> {
+            on { get("auth.provider") } doReturn "montagu"
+        }
+        val sut = AuthenticationConfig(fakeConfig)
+        val result = sut.getAuthenticationIndirectClient()
+
+        assertThat(result is MontaguIndirectClient).isTrue()
+    }
+
+    @Test
+    fun `getAuthenticationIndirectClient returns GitHub client if provider is GitHub`()
+    {
+        val fakeConfig = mock<Config> {
+            on { get("auth.provider") } doReturn "github"
+            on { get("auth.github_key") } doReturn "key"
+            on { get("auth.github_secret") } doReturn "secret"
+        }
+        val sut = AuthenticationConfig(fakeConfig)
+        val result = sut.getAuthenticationIndirectClient()
+
+        assertThat(result is GithubIndirectClient).isTrue()
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationRouteBuilderTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationRouteBuilderTests.kt
@@ -7,6 +7,7 @@ import org.junit.Test
 import org.vaccineimpact.orderlyweb.app_start.OrderlyAuthenticationRouteBuilder
 import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationConfig
 import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationProvider
+import org.vaccineimpact.orderlyweb.security.clients.GithubIndirectClient
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
 
 class AuthenticationRouteBuilderTests : TeamcityTests()
@@ -16,6 +17,7 @@ class AuthenticationRouteBuilderTests : TeamcityTests()
     {
         val mockAuthConfig = mock<AuthenticationConfig>() {
             on { getConfiguredProvider() } doReturn AuthenticationProvider.GitHub
+            on { getAuthenticationIndirectClient() } doReturn GithubIndirectClient("fakekey", "fakesecret")
         }
         val sut = OrderlyAuthenticationRouteBuilder(mockAuthConfig)
         val result = sut.logout()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationRouteBuilderTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationRouteBuilderTests.kt
@@ -8,6 +8,7 @@ import org.vaccineimpact.orderlyweb.app_start.OrderlyAuthenticationRouteBuilder
 import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationConfig
 import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationProvider
 import org.vaccineimpact.orderlyweb.security.clients.GithubIndirectClient
+import org.vaccineimpact.orderlyweb.security.clients.MontaguIndirectClient
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
 
 class AuthenticationRouteBuilderTests : TeamcityTests()
@@ -33,6 +34,7 @@ class AuthenticationRouteBuilderTests : TeamcityTests()
     {
         val mockAuthConfig = mock<AuthenticationConfig>() {
             on { getConfiguredProvider() } doReturn AuthenticationProvider.Montagu
+            on { getAuthenticationIndirectClient() } doReturn MontaguIndirectClient()
         }
         val sut = OrderlyAuthenticationRouteBuilder(mockAuthConfig)
         val result = sut.logout()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationRouteBuilderTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/AuthenticationRouteBuilderTests.kt
@@ -15,7 +15,7 @@ class AuthenticationRouteBuilderTests : TeamcityTests()
     fun `creates GitHub logout callback`()
     {
         val mockAuthConfig = mock<AuthenticationConfig>() {
-            on { getConfiguredProvider() } doReturn AuthenticationProvider.Github
+            on { getConfiguredProvider() } doReturn AuthenticationProvider.GitHub
         }
         val sut = OrderlyAuthenticationRouteBuilder(mockAuthConfig)
         val result = sut.logout()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/WebEndpointTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/WebEndpointTests.kt
@@ -128,7 +128,7 @@ class WebEndpointTests: TeamcityTests()
         }
 
         val mockAuthConfig = mock<AuthenticationConfig>{
-            on { getConfiguredProvider() } doReturn AuthenticationProvider.Github
+            on { getConfiguredProvider() } doReturn AuthenticationProvider.GitHub
         }
 
         val requiredPermission=  PermissionRequirement.parse("*/testperm")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/401Tests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/401Tests.kt
@@ -25,7 +25,7 @@ class _401Tests: TeamcityTests()
     {
         val mockModel = mock<AppViewModel> {
             on { appName } doReturn "testApp"
-            on { authProvider } doReturn "montagu"
+            on { authProvider } doReturn "Montagu"
             on { logo } doReturn "logo.png"
         }
 
@@ -41,7 +41,7 @@ class _401Tests: TeamcityTests()
     {
         val mockModel = mock<AppViewModel> {
             on { appName } doReturn "testApp"
-            on { authProvider } doReturn "github"
+            on { authProvider } doReturn "GitHub"
             on { logo } doReturn "logo.png"
         }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/401Tests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/401Tests.kt
@@ -49,7 +49,7 @@ class _401Tests: TeamcityTests()
 
         assertThat(xmlResponse, hasXPath("//h1/text()", equalToCompressingWhiteSpace("Login failed")))
         assertThat(xmlResponse, hasXPath("//p/text()",
-                containsString("We have not been able to successfully identify you as a member of the app's configured Github org.")))
+                containsString("We have not been able to successfully identify you as a member of the app's configured GitHub org.")))
 
         assertThat(xmlResponse, hasXPath("//li[1]/a/text()",
                 equalToCompressingWhiteSpace("GitHub organization approval for \"testApp\" has been requested")))

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -89,17 +89,15 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `renders outline correctly`()
     {
-        val xmlResponse = template.xmlResponseFor(testModel)
+        val doc = template.jsoupDocFor(testModel)
 
-        assertThat(xmlResponse, hasXPath("//li[@class='nav-item'][1]/a[@role='tab']/text()",
-                equalToCompressingWhiteSpace("Report")))
+        Assertions.assertThat(doc.select(".nav-item")[0].text()).isEqualTo("Report")
+        Assertions.assertThat(doc.select(".nav-item")[1].text()).isEqualTo("Downloads")
+        Assertions.assertThat(doc.select(".nav-item")[2].text()).isEqualTo("Changelog")
 
-        assertThat(xmlResponse, hasXPath("//li[@class='nav-item'][2]/a[@role='tab']/text()",
-                equalToCompressingWhiteSpace("Downloads")))
-
-        assertThat(xmlResponse, hasXPath("//div[@class='tab-pane active pt-4 pt-md-1' and @id='report-tab']"))
-        assertThat(xmlResponse, hasXPath("//div[@class='tab-pane pt-4 pt-md-1' and @id='downloads-tab']"))
-        assertThat(xmlResponse, hasXPath("//div[@class='tab-pane pt-4 pt-md-1' and @id='changelog-tab']"))
+        Assertions.assertThat(doc.selectFirst("#report-tab").hasClass("tab-pane active pt-4 pt-md-1")).isTrue()
+        Assertions.assertThat(doc.selectFirst("#downloads-tab").hasClass("tab-pane pt-4 pt-md-1")).isTrue()
+        Assertions.assertThat(doc.selectFirst("#changelog-tab").hasClass("tab-pane pt-4 pt-md-1")).isTrue()
     }
 
     @Test

--- a/src/app/static/src/scss/partials/buttons.scss
+++ b/src/app/static/src/scss/partials/buttons.scss
@@ -17,6 +17,10 @@ button:disabled, .button.disabled {
   @include button-variant($gray-400, $gray-400);
 }
 
+.btn-xl {
+  @include button-size($btn-padding-y-lg, $btn-padding-x-lg, 2rem, $btn-line-height-lg, $btn-border-radius-lg);
+}
+
 .arrowDown:before {
   content: "\25be";
   float:right;

--- a/src/app/static/src/scss/partials/variables.scss
+++ b/src/app/static/src/scss/partials/variables.scss
@@ -16,6 +16,8 @@ $breadcrumb-bg-color: $gray-100;
 $breadcrumb-color: $theme-primary;
 $theme-table-border-color: $gray-300;
 $btn-border-radius: 0;
+$btn-border-radius-sm: 0;
+$btn-border-radius-lg: 0;
 $btn-primary-color: $theme-primary;
 
 // optional user overrides passed during deployment

--- a/src/app/static/src/scss/style.scss
+++ b/src/app/static/src/scss/style.scss
@@ -8,6 +8,10 @@ $success: #28a75e;
 @import "partials/logout";
 @import "partials/nav";
 
+html {
+  overflow-y: scroll;
+}
+
 html, body {
   height: 100%
 }

--- a/src/app/templates/401.ftl
+++ b/src/app/templates/401.ftl
@@ -3,10 +3,10 @@
 <#-- @ftlvariable name="authProvider" type="String" -->
 <@layout>
     <h1>Login failed</h1>
-    <#if authProvider == "montagu">
+    <#if authProvider.toLowerCase() == "montagu">
         <p>We have not been able to successfully identify you as a Montagu user.</p>
     </#if>
-    <#if authProvider == "github">
+    <#if authProvider.toLowerCase() == "github">
         <p>We have not been able to successfully identify you as a member of the app's configured Github org.
             If you think this is a mistake you should check the following steps have been taken</p>
         <ol>

--- a/src/app/templates/401.ftl
+++ b/src/app/templates/401.ftl
@@ -3,11 +3,11 @@
 <#-- @ftlvariable name="authProvider" type="String" -->
 <@layout>
     <h1>Login failed</h1>
-    <#if authProvider.toLowerCase() == "montagu">
+    <#if authProvider?lower_case == "montagu">
         <p>We have not been able to successfully identify you as a Montagu user.</p>
     </#if>
-    <#if authProvider.toLowerCase() == "github">
-        <p>We have not been able to successfully identify you as a member of the app's configured Github org.
+    <#if authProvider?lower_case== "github">
+        <p>We have not been able to successfully identify you as a member of the app's configured GitHub org.
             If you think this is a mistake you should check the following steps have been taken</p>
         <ol>
             <li><a href="https://help.github.com/en/articles/requesting-organization-approval-for-oauth-apps">

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -8,34 +8,44 @@
     <div class="row">
         <div class="col-12 col-md-4 col-xl-3">
             <div class="sidebar pb-4 pb-md-0">
-                <ul class="nav flex-column">
-                    <li class="nav-item">
-                        <a class="nav-link active" data-toggle="tab" href="#report-tab" role="tab">Report</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" data-toggle="tab" href="#downloads-tab" role="tab">Downloads</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" data-toggle="tab" href="#changelog-tab" role="tab">Changelog</a>
-                    </li>
-                </ul>
-                <hr/>
-            <#include "partials/version-picker.ftl">
-            <#if isAdmin>
-                <div id="publishSwitchVueApp" class="pt-3">
-                    <publish-switch :report=report @toggle="handleToggle"></publish-switch>
-                </div>
-            </#if>
-            <#if isUsersManager>
-                <div id="reportReadersListVueApp" class="pt-3">
-                    <report-readers-list :report=report></report-readers-list>
-                </div>
-            </#if>
-            <#if isRunner>
-                <div id="runReportVueApp">
-                    <run-report :report=report></run-report>
-                </div>
-            </#if>
+                <nav class="pl-0 pr-0 pr-md-4 navbar navbar-light">
+                    <button type="button" class="d-md-none navbar-toggler" data-toggle="collapse" data-target="#sidebar">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="d-md-block mt-4 mt-md-0 collapse navbar-collapse" id="sidebar">
+                        <ul class="list-unstyled mb-0">
+                            <li class="nav-item">
+                            <li class="nav-item">
+                                <a class="nav-link active" data-toggle="tab" href="#report-tab" role="tab">Report</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" data-toggle="tab" href="#downloads-tab" role="tab">Downloads</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" data-toggle="tab" href="#changelog-tab" role="tab">Changelog</a>
+                            </li>
+                        </ul>
+                        <hr/>
+                        <div class="pl-3">
+                            <#include "partials/version-picker.ftl">
+                            <#if isAdmin>
+                                <div id="publishSwitchVueApp" class="pt-3">
+                                    <publish-switch :report=report @toggle="handleToggle"></publish-switch>
+                                </div>
+                            </#if>
+                            <#if isUsersManager>
+                                <div id="reportReadersListVueApp" class="mt-5">
+                                    <report-readers-list :report=report></report-readers-list>
+                                </div>
+                            </#if>
+                            <#if isRunner>
+                                <div id="runReportVueApp" class="mt-5">
+                                    <run-report :report=report></run-report>
+                                </div>
+                            </#if>
+                        </div>
+                    </div>
+                </nav>
             </div>
         </div>
         <div class="col-12 col-md-8 tab-content">

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -13,7 +13,7 @@
                         <span class="navbar-toggler-icon"></span>
                     </button>
                     <div class="d-md-block mt-4 mt-md-0 collapse navbar-collapse" id="sidebar">
-                        <ul class="list-unstyled mb-0">
+                        <ul class="nav flex-column list-unstyled mb-0">
                             <li class="nav-item">
                                 <a class="nav-link active" data-toggle="tab" href="#report-tab" role="tab">Report</a>
                             </li>

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -15,7 +15,6 @@
                     <div class="d-md-block mt-4 mt-md-0 collapse navbar-collapse" id="sidebar">
                         <ul class="list-unstyled mb-0">
                             <li class="nav-item">
-                            <li class="nav-item">
                                 <a class="nav-link active" data-toggle="tab" href="#report-tab" role="tab">Report</a>
                             </li>
                             <li class="nav-item">
@@ -61,9 +60,9 @@
         </div>
     </div>
     <#macro scripts>
-        <script>
+        <script type="text/javascript">
             var report = ${reportJson};
         </script>
-        <script src="/js/report.bundle.js"></script>
+        <script type="text/javascript" src="/js/report.bundle.js"></script>
     </#macro>
 </@layoutwide>

--- a/src/app/templates/weblogin.ftl
+++ b/src/app/templates/weblogin.ftl
@@ -1,8 +1,7 @@
 <#-- @ftlvariable name="authProvider" type="String" -->
 <@layout>
-    <div class="card mx-auto" style="width:18rem;">
-        <div class="text-center p-3">
-            <a class="login-external-link" href="/weblogin/external?requestedUrl=${requestedUrl}">Log in with <br/>${authProvider}</a>
-        </div>
+    <div class="text-center p-3">
+        <a class="btn btn-success btn-xl"
+           href="/weblogin/external?requestedUrl=${requestedUrl}">Log in with <br/>${authProvider}</a>
     </div>
 </@layout>

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubWebTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubWebTests.kt
@@ -65,7 +65,7 @@ class GithubWebTests : SeleniumTest()
 
         val helpText = driver.findElements(By.cssSelector("p")).first()
         assertThat(helpText.text)
-                .contains("We have not been able to successfully identify you as a member of the app's configured Github org")
+                .contains("We have not been able to successfully identify you as a member of the app's configured GitHub org")
 
     }
 

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
@@ -1,8 +1,10 @@
+
 package org.vaccineimpact.orderlyweb.customConfigTests
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.openqa.selenium.By
+import org.openqa.selenium.Dimension
 import org.openqa.selenium.support.ui.ExpectedConditions
 import org.openqa.selenium.support.ui.Select
 import org.vaccineimpact.orderlyweb.db.JooqContext
@@ -180,6 +182,29 @@ class ReportPageTests : SeleniumTest()
         confirmTabActive("downloads-tab", false)
 
     }
+
+    @Test
+    fun `can toggle side nav in mobile view`()
+    {
+        startApp("auth.provider=montagu")
+
+        driver.manage().window().size = Dimension(300, 500)
+
+        addUserWithPermissions(listOf(ReifiedPermission("reports.read", Scope.Global())))
+
+        insertReport("testreport", "20170103-143015-1234abcd")
+
+        loginWithMontagu()
+        driver.get(RequestHelper.webBaseUrl + "/reports/testreport/20170103-143015-1234abcd/")
+
+        val sidebar = driver.findElement(By.id("sidebar"))
+        assertThat(sidebar.isDisplayed).isFalse()
+
+        driver.findElement(By.cssSelector("[data-toggle=collapse]")).click()
+        wait.until(ExpectedConditions.visibilityOf(sidebar))
+        assertThat(sidebar.isDisplayed).isTrue()
+    }
+
 
     @Test
     fun `can switch version`()

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/SeleniumTest.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/SeleniumTest.kt
@@ -57,7 +57,7 @@ abstract class SeleniumTest : CustomConfigTests()
     protected fun clickOnLandingPageLink()
     {
         //Click on the landing page link to navigate to auth provider
-        driver.findElement(By.className("login-external-link")).click()
+        driver.findElement(By.className("btn-xl")).click()
     }
 
     protected fun loginWithMontagu()


### PR DESCRIPTION
Fixes the sidebar styling mainly, also styles the login with GitHub button as a button and persists the vertical scrollbar to stop the page width jumping when content becomes long enough to scroll.

I also changed `GitHub` to the correct spelling everywhere and added tests for the auth config class to make sure it was case insensitive.