### PR TITLE
Mrc 307 Make a report reader removable only if permission is not from a user group 

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/AuthorizationRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/AuthorizationRepository.kt
@@ -8,6 +8,7 @@ import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.User
 import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.permissions.UserGroupPermission
 
 interface AuthorizationRepository
 {
@@ -16,7 +17,7 @@ interface AuthorizationRepository
     fun ensureUserGroupHasPermission(userGroup: String, permission: ReifiedPermission)
     fun ensureUserGroupDoesNotHavePermission(userGroup: String, permission: ReifiedPermission)
     fun getPermissionsForUser(email: String): PermissionSet
-    fun getReportReaders(reportName: String): Map<User, List<ReifiedPermission>>
+    fun getReportReaders(reportName: String): Map<User, List<UserGroupPermission>>
 }
 
 class OrderlyAuthorizationRepository : AuthorizationRepository
@@ -184,7 +185,7 @@ class OrderlyAuthorizationRepository : AuthorizationRepository
         }
     }
 
-    override fun getReportReaders(reportName: String): Map<User, List<ReifiedPermission>>
+    override fun getReportReaders(reportName: String): Map<User, List<UserGroupPermission>>
     {
         //Returns all users which can read the report, along with the set of all relevant permissions
         // (global or report-specific, and the user groups from which they are derived)
@@ -209,7 +210,7 @@ class OrderlyAuthorizationRepository : AuthorizationRepository
 
                     .fetch()
 
-            return result.map{ it.into(User::class.java) to mapPermission(it) }
+            return result.map{ it.into(User::class.java) to UserGroupPermission(it[ORDERLYWEB_USER_GROUP.ID], mapPermission(it)) }
                     .groupBy({ it.first }, {it.second})
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/AuthorizationRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/AuthorizationRepository.kt
@@ -195,6 +195,8 @@ class OrderlyAuthorizationRepository : AuthorizationRepository
                     ORDERLYWEB_USER.EMAIL,
                     ORDERLYWEB_USER.USER_SOURCE,
                     ORDERLYWEB_USER.LAST_LOGGED_IN,
+                    ORDERLYWEB_USER_GROUP.ID,
+                    ORDERLYWEB_USER_GROUP_PERMISSION_ALL.PERMISSION,
                     ORDERLYWEB_USER_GROUP_PERMISSION_ALL.SCOPE_PREFIX,
                     ORDERLYWEB_USER_GROUP_PERMISSION_ALL.SCOPE_ID)
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/UserGroupPermission.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/UserGroupPermission.kt
@@ -1,0 +1,3 @@
+package org.vaccineimpact.orderlyweb.models.permissions
+
+data class UserGroupPermission(val userGroup: String, val permission: ReifiedPermission)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportReaderViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportReaderViewModel.kt
@@ -2,13 +2,17 @@ package org.vaccineimpact.orderlyweb.viewmodels
 
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.User
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 
 data class ReportReaderViewModel(val email: String, val username: String, val displayName: String, val canRemove: Boolean)
 {
     companion object
     {
-        fun build(user: User, scope: Scope): ReportReaderViewModel
+        fun build(user: User, permissions: List<ReifiedPermission>): ReportReaderViewModel
         {
+            //the report reader can only be removed if they only have read permission for this report which is scoped to
+            //the report (not global) and do not have permission through belonging to a user group other than their
+            //identity group
             val canRemove = scope is Scope.Specific
             val displayName = when
             {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportReaderViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportReaderViewModel.kt
@@ -2,18 +2,18 @@ package org.vaccineimpact.orderlyweb.viewmodels
 
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.User
-import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.models.permissions.UserGroupPermission
 
 data class ReportReaderViewModel(val email: String, val username: String, val displayName: String, val canRemove: Boolean)
 {
     companion object
     {
-        fun build(user: User, permissions: List<ReifiedPermission>): ReportReaderViewModel
+        fun build(user: User, permissions: List<UserGroupPermission>): ReportReaderViewModel
         {
             //the report reader can only be removed if they only have read permission for this report which is scoped to
             //the report (not global) and do not have permission through belonging to a user group other than their
             //identity group
-            val canRemove = scope is Scope.Specific
+            val canRemove = permissions.all{ it.userGroup == user.email && it.permission.scope is Scope.Specific}
             val displayName = when
             {
                 isNotEmptyOrUnknown(user.displayName) -> user.displayName

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/InsertHelpers.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/InsertHelpers.kt
@@ -120,14 +120,30 @@ fun insertUser(email: String,
                 .onDuplicateKeyIgnore()
                 .execute()
 
+
+    }
+
+    insertUserGroup(email)
+
+    giveUserGroupMember(email, email)
+}
+
+fun insertUserGroup(id: String)
+{
+    JooqContext().use {
         it.dsl.insertInto(ORDERLYWEB_USER_GROUP)
-                .set(ORDERLYWEB_USER_GROUP.ID, email)
+                .set(ORDERLYWEB_USER_GROUP.ID, id)
                 .onDuplicateKeyIgnore()
                 .execute()
+    }
+}
 
+fun giveUserGroupMember(groupName: String, userEmail: String)
+{
+    JooqContext().use {
         it.dsl.insertInto(ORDERLYWEB_USER_GROUP_USER)
-                .set(ORDERLYWEB_USER_GROUP_USER.EMAIL, email)
-                .set(ORDERLYWEB_USER_GROUP_USER.USER_GROUP, email)
+                .set(ORDERLYWEB_USER_GROUP_USER.EMAIL, userEmail)
+                .set(ORDERLYWEB_USER_GROUP_USER.USER_GROUP, groupName)
                 .onDuplicateKeyIgnore()
                 .execute()
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/AuthorizationRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/AuthorizationRepositoryTests.kt
@@ -413,7 +413,7 @@ class OrderlyWebAuthorizationRepositoryTests : CleanDatabaseTests()
         permissions = result[result.firstKey()]!!
         assertThat(permissions.count()).isEqualTo(1)
         assertThat(permissions[0].userGroup).isEqualTo("global.readers")
-        assertThat(permissions[0].permission).isInstanceOf(Scope.Global::class.java)
+        assertThat(permissions[0].permission.scope).isInstanceOf(Scope.Global::class.java)
 
         result.remove(result.firstKey())
         assertThat(result.firstKey().username).isEqualTo("report1 reader")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/AuthorizationRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/AuthorizationRepositoryTests.kt
@@ -16,6 +16,9 @@ import org.vaccineimpact.orderlyweb.test_helpers.CleanDatabaseTests
 import org.vaccineimpact.orderlyweb.tests.giveUserGroupPermission
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.insertUser
+import org.vaccineimpact.orderlyweb.tests.insertUserGroup
+import org.vaccineimpact.orderlyweb.tests.giveUserGroupMember
+import org.vaccineimpact.orderlyweb.tests.giveUserGroupPermission
 
 class OrderlyWebAuthorizationRepositoryTests : CleanDatabaseTests()
 {
@@ -321,7 +324,7 @@ class OrderlyWebAuthorizationRepositoryTests : CleanDatabaseTests()
     }
 
     @Test
-    fun `getReportReaders gets all users and scopes which can read report`()
+    fun `getReportReaders gets all readers with identity permissions`()
     {
         JooqContext().use {
             insertReport("report1", "version1")
@@ -337,6 +340,7 @@ class OrderlyWebAuthorizationRepositoryTests : CleanDatabaseTests()
             giveUserGroupPermission("another.scoped.reader@email.com", "reports.read", Scope.Specific("report", "report2"))
 
             insertUser("non.reader@email.com", "non.reader.name")
+
         }
 
         val sut = OrderlyAuthorizationRepository()
@@ -345,13 +349,79 @@ class OrderlyWebAuthorizationRepositoryTests : CleanDatabaseTests()
         assertThat(result.count()).isEqualTo(2)
 
         assertThat(result.firstKey().username).isEqualTo("global.reader.name")
-        val globalScope = result[result.firstKey()]!!
-        assertThat(globalScope).isInstanceOf(Scope.Global::class.java)
+        val globalUserPermissions = result[result.firstKey()]!!
+        assertThat(globalUserPermissions.count()).isEqualTo(1)
+        assertThat(globalUserPermissions[0].userGroup).isEqualTo("global.reader@email.com")
+        assertThat(globalUserPermissions[0].permission.name).isEqualTo("reports.read")
+        assertThat(globalUserPermissions[0].permission.scope).isInstanceOf(Scope.Global::class.java)
 
         assertThat(result.lastKey().username).isEqualTo("scoped.reader.name")
-        val reportScope = result[result.lastKey()]!!
-        assertThat(reportScope).isInstanceOf(Scope.Specific::class.java)
-        assertThat(reportScope.value).isEqualTo("report:report1")
+        val reportUserPermissions = result[result.lastKey()]!!
+        assertThat(reportUserPermissions.count()).isEqualTo(1)
+        assertThat(reportUserPermissions[0].userGroup).isEqualTo("scope.reader@email.com")
+        assertThat(reportUserPermissions[0].permission.name).isEqualTo("reports.read")
+        assertThat(reportUserPermissions[0].permission.scope).isInstanceOf(Scope.Specific::class.java)
+        assertThat(reportUserPermissions[0].permission.scope.value).isEqualTo("report:report1")
+    }
+
+    @Test
+    fun `getReportReaders gets all readers with permissions from non-identity groups`()
+    {
+        insertReport("report1", "version1")
+        insertReport("report2", "version2")
+
+        insertUserGroup("global.readers")
+        giveUserGroupPermission("global.readers", "reports.read", Scope.Global())
+
+        insertUserGroup("report1.readers")
+        giveUserGroupPermission("report1.readers", "reports.read", Scope.Specific("report", "report1"))
+
+        insertUserGroup("report2.readers")
+        giveUserGroupPermission("report2.readers", "reports.read", Scope.Specific("report", "report2"))
+
+        insertUser("global@reader.com", "global reader")
+        giveUserGroupMember("global.readers", "global@reader.com")
+
+        insertUser("report1@reader.com", "report1 reader")
+        giveUserGroupMember("report1.readers", "report1.reader.com")
+
+        insertUser("report2@reader.com", "report2 reader")
+        giveUserGroupMember("report2.readers", "report2.reader.com")
+
+        insertUser("all.groups@reader.com", "all groups reader")
+        giveUserGroupMember("global.readers", "all.groups@reader.com")
+        giveUserGroupMember("report1.readers", "all.groups@reader.com")
+        giveUserGroupMember("report2.readers", "all.groups@reader.com")
+        //also give permission at user level
+        giveUserGroupPermission("all.groups@reader.com", "reports.read", Scope.Global())
+
+        val sut = OrderlyAuthorizationRepository()
+        val result = sut.getReportReaders("report1").toSortedMap(compareBy { it.username })
+
+        assertThat(result.count()).isEqualTo(3)
+
+        assertThat(result.firstKey().username).isEqualTo("all groups reader")
+        var permissions = result[result.firstKey()]!!
+        assertThat(permissions.count()).isEqualTo(3)
+        assertThat(permissions.any{ it.userGroup == "global.readers" && it.permission.scope is Scope.Global })
+        assertThat(permissions.any{ it.userGroup == "report1.readers" && it.permission.scope is Scope.Specific
+                                        && it.permission.scope.value == "report:report1"})
+        assertThat(permissions.any{ it.userGroup == "all.groups@reader.com" && it.permission.scope is Scope.Global })
+
+        result.remove(result.firstKey())
+        assertThat(result.firstKey().username).isEqualTo("global reader")
+        permissions = result[result.firstKey()]!!
+        assertThat(permissions.count()).isEqualTo(1)
+        assertThat(permissions[0].userGroup).isEqualTo("global.readers")
+        assertThat(permissions[0].permission).isInstanceOf(Scope.Global::class.java)
+
+        result.remove(result.firstKey())
+        assertThat(result.firstKey().username).isEqualTo("report1 reader")
+        permissions = result[result.firstKey()]!!
+        assertThat(permissions.count()).isEqualTo(1)
+        assertThat(permissions[0].userGroup).isEqualTo("report1.readers")
+        assertThat(permissions[0].permission.scope).isInstanceOf(Scope.Specific::class.java)
+        assertThat(permissions[0].permission.scope.value).isEqualTo("report:report1")
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/AuthorizationRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/AuthorizationRepositoryTests.kt
@@ -358,7 +358,7 @@ class OrderlyWebAuthorizationRepositoryTests : CleanDatabaseTests()
         assertThat(result.lastKey().username).isEqualTo("scoped.reader.name")
         val reportUserPermissions = result[result.lastKey()]!!
         assertThat(reportUserPermissions.count()).isEqualTo(1)
-        assertThat(reportUserPermissions[0].userGroup).isEqualTo("scope.reader@email.com")
+        assertThat(reportUserPermissions[0].userGroup).isEqualTo("scoped.reader@email.com")
         assertThat(reportUserPermissions[0].permission.name).isEqualTo("reports.read")
         assertThat(reportUserPermissions[0].permission.scope).isInstanceOf(Scope.Specific::class.java)
         assertThat(reportUserPermissions[0].permission.scope.value).isEqualTo("report:report1")
@@ -383,7 +383,7 @@ class OrderlyWebAuthorizationRepositoryTests : CleanDatabaseTests()
         giveUserGroupMember("global.readers", "global@reader.com")
 
         insertUser("report1@reader.com", "report1 reader")
-        giveUserGroupMember("report1.readers", "report1.reader.com")
+        giveUserGroupMember("report1.readers", "report1@reader.com")
 
         insertUser("report2@reader.com", "report2 reader")
         giveUserGroupMember("report2.readers", "report2.reader.com")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/AuthorizationRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/AuthorizationRepositoryTests.kt
@@ -386,7 +386,7 @@ class OrderlyWebAuthorizationRepositoryTests : CleanDatabaseTests()
         giveUserGroupMember("report1.readers", "report1@reader.com")
 
         insertUser("report2@reader.com", "report2 reader")
-        giveUserGroupMember("report2.readers", "report2.reader.com")
+        giveUserGroupMember("report2.readers", "report2@reader.com")
 
         insertUser("all.groups@reader.com", "all groups reader")
         giveUserGroupMember("global.readers", "all.groups@reader.com")

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
@@ -255,7 +255,7 @@ class ReportPageTests : SeleniumTest()
 
         assertThat(listItems[1].findElement(By.cssSelector("span.reader-display-name")).text).isEqualTo("user.with.group.perm@example.com")
         assertThat(listItems[1].findElement(By.cssSelector("div")).text).isEqualTo("user.with.group.perm@example.com")
-        assertThat(listItems[1].findElements(By.cssSelector("span.remove-reader")).count()).isEqualTo(1)
+        assertThat(listItems[1].findElements(By.cssSelector("span.remove-reader")).count()).isEqualTo(0)
     }
 
     @Test

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
@@ -306,8 +306,8 @@ class ReportPageTests : SeleniumTest()
                 ReifiedPermission("users.manage", Scope.Global())
         ))
 
-        addUserWithPermissions(listOf(), "no.perms@example.com")
-        addUserGroupWithPermissions("test-group", listOf("no.perms@example.com"), listOf())
+        addUserWithPermissions(listOf(), "no.individual.perms@example.com")
+        addUserGroupWithPermissions("test-group", listOf("no.individual.perms@example.com"), listOf())
 
         insertReport("testreport", "20170103-143015-1234abcd")
 
@@ -328,8 +328,8 @@ class ReportPageTests : SeleniumTest()
         val listItems = driver.findElements(By.cssSelector("#reportReadersListVueApp li"))
         assertThat(listItems.count()).isEqualTo(2)
 
-        assertThat(listItems[0].findElement(By.cssSelector("span.reader-display-name")).text).isEqualTo("no.perms@example.com")
-        assertThat(listItems[0].findElement(By.cssSelector("div")).text).isEqualTo("no.perms@example.com")
+        assertThat(listItems[0].findElement(By.cssSelector("span.reader-display-name")).text).isEqualTo("no.individual.perms@example.com")
+        assertThat(listItems[0].findElement(By.cssSelector("div")).text).isEqualTo("no.individual.perms@example.com")
         assertThat(listItems[0].findElements(By.cssSelector("span.remove-reader")).count()).isEqualTo(0)
 
         assertThat(listItems[1].findElement(By.cssSelector("span.reader-display-name")).text).isEqualTo("Test User")

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
@@ -323,7 +323,7 @@ class ReportPageTests : SeleniumTest()
         val addReaderButton = driver.findElement(By.cssSelector("#reportReadersListVueApp button"))
         addReaderButton.click()
 
-        wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("li[id='no.perms@example.com']")))
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("li[id='no.individual.perms@example.com']")))
 
         val listItems = driver.findElements(By.cssSelector("#reportReadersListVueApp li"))
         assertThat(listItems.count()).isEqualTo(2)


### PR DESCRIPTION
This change will make a test added in https://github.com/vimc/orderly-web/pull/79 fail, so after that branch is merged, master should be merged into here, and the test updated to the behaviour introduced here (a report reader who has permission through belonging to a group is 'removable' in mrc-306, but not in this branch).