### PR TITLE
mrc-311 don't check permissions if fine grained auth is turned off

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/Controller.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/Controller.kt
@@ -5,9 +5,11 @@ import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.encompass
 import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.db.Config
 
 
-abstract class Controller(val context: ActionContext)
+abstract class Controller(val context: ActionContext, val appConfig: Config = AppConfig())
 {
     protected fun passThroughResponse(response: Response): String
     {
@@ -17,9 +19,34 @@ abstract class Controller(val context: ActionContext)
 
     protected fun okayResponse() = "OK"
 
-    protected val reportReadingScopes by lazy {
+    private val reportReadingScopes by lazy {
         context.permissions
                 .filter { it.name == "reports.read" }
                 .map { it.scope }
     }
+
+    protected fun canReadReports(): Boolean
+    {
+        return if (appConfig.authorizationEnabled)
+        {
+            reportReadingScopes.any()
+        }
+        else
+        {
+            true
+        }
+    }
+
+    protected fun canReadReport(reportName: String): Boolean
+    {
+        return if (appConfig.authorizationEnabled)
+        {
+            reportReadingScopes.encompass(Scope.Specific("report", reportName))
+        }
+        else
+        {
+            true
+        }
+    }
+
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/HomeController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/HomeController.kt
@@ -13,7 +13,7 @@ class HomeController(context: ActionContext, private val config: Config)
     constructor(context: ActionContext) :
             this(context, AppConfig())
 
-    fun index() = Index("montagu-reports", this.config["app.version"], OrderlyWeb.urls)
+    fun index() = Index(this.config["app.name"], this.config["app.version"], OrderlyWeb.urls)
 
     data class Index(val name: String, val version: String, val endpoints: List<String>)
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
@@ -53,24 +53,24 @@ class ReportController(context: ActionContext,
 
     fun getAllReports(): List<Report>
     {
-        if (!reportReadingScopes.any())
+        if (!canReadReports())
         {
             throw MissingRequiredPermissionError(PermissionSet("*/reports.read"))
         }
 
         val reports = orderly.getAllReports()
-        return reports.filter { reportReadingScopes.encompass(Scope.Specific("report", it.name)) }
+        return reports.filter { canReadReport(it.name) }
     }
 
     fun getAllVersions(): List<ReportVersion>
     {
-        if (!reportReadingScopes.any())
+        if (!canReadReports())
         {
             throw MissingRequiredPermissionError(PermissionSet("*/reports.read"))
         }
 
         val reports = orderly.getAllReportVersions()
-        return reports.filter { reportReadingScopes.encompass(Scope.Specific("report", it.name)) }
+        return reports.filter { canReadReport(it.name) }
     }
 
     fun getVersionsByName(): List<String>

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
@@ -19,7 +19,7 @@ class ReportController(context: ActionContext,
                        private val orderly: OrderlyClient,
                        private val zip: ZipClient,
                        private val orderlyServerAPI: OrderlyServerAPI,
-                       private val config: Config) : Controller(context)
+                       private val config: Config) : Controller(context, config)
 {
     constructor(context: ActionContext) :
             this(context,


### PR DESCRIPTION
Fixes the bug with `MissingPermissonError` being thrown even when fine grained auth is turned off. Tidied up the `ReportController` test class a bit and added tests for the bug cases.