### PR TITLE
add fully qualified favicon link

### DIFF
--- a/src/app/templates/index.ftl
+++ b/src/app/templates/index.ftl
@@ -13,7 +13,7 @@
         <a href="#" class="mr-2" id="collapse">Collapse all reports</a>/<a href="#" class="ml-2" id="expand">Expand all
             reports</a>
     </div>
-    <table id="reports-table" class="table display table-striped" style="width:100%">
+    <table id="reports-table" class="table display table-striped" style="width:100%; table-layout: fixed">
         <thead>
         <tr>
             <th>
@@ -25,8 +25,7 @@
 
             </th>
             <#if isReviewer>
-                <th><label for="status-filter">Status</label>
-
+                <th style="width:100px"><label for="status-filter">Status</label>
                 </th>
             </#if>
             <th>

--- a/src/app/templates/partials/header.ftl
+++ b/src/app/templates/partials/header.ftl
@@ -2,13 +2,15 @@
 <#-- @ftlvariable name="loggedIn" type="Boolean" -->
 <#-- @ftlvariable name="user" type="String" -->
 <#-- @ftlvariable name="logo" type="String" -->
+<#-- @ftlvariable name="appUrl" type="String" -->
 <head>
     <#if styles??>
         <@styles></@styles>
     <#else>
         <link rel="stylesheet" type="text/css" href="${appUrl}/css/style.css">
     </#if>
-
+    <link rel="icon" href="${appUrl}/favicon.ico" type="image/ico"/>
+    <link rel="shortcut icon" href="${appUrl}/favicon.ico" type="image/x-icon"/>
     <title>${appName}</title>
 </head>
     <body>


### PR DESCRIPTION
As with other static assets, need to be explicit about the app url otherwise will resolve relative to the domain and not work when deployed at domain/reports

I've also opportunistically fixed the report table layout, as the column widths were jumping around when the values were filtered.