### PR TITLE
mrc-341 make index route more accessible

### DIFF
--- a/dev/add-test-users.sh
+++ b/dev/add-test-users.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+here=$(dirname $0)
+
+$here/cli.sh add-users test.user@example.com
+$here/cli.sh grant test.user@example.com */reports.read

--- a/dev/run-dependencies.sh
+++ b/dev/run-dependencies.sh
@@ -14,9 +14,6 @@ export MONTAGU_ORDERLY_PATH=$(realpath $here/../src/customConfigTests/git)
 export ORDERLY_SERVER_USER_ID=$UID
 $here/../scripts/run-dependencies.sh
 
-$here/cli.sh add-users test.user@example.com
-$here/cli.sh grant test.user@example.com */reports.read
-
 echo "Dependencies are now running; press Ctrl+C to teardown"
 
 # From now on, if the user presses Ctrl+C we should teardown

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/WebEndpoint.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/WebEndpoint.kt
@@ -65,7 +65,6 @@ data class WebEndpoint(
                 config.authorizers.map { it.key }.joinToString(","),
                 SkipOptionsMatcher.name
         ))
-
     }
 
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/RouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/RouteConfig.kt
@@ -3,10 +3,7 @@ package org.vaccineimpact.orderlyweb.app_start
 import org.vaccineimpact.orderlyweb.EndpointDefinition
 import org.vaccineimpact.orderlyweb.WebEndpoint
 import org.vaccineimpact.orderlyweb.app_start.routing.api.*
-import org.vaccineimpact.orderlyweb.app_start.routing.web.WebVersionRouteConfig
-import org.vaccineimpact.orderlyweb.app_start.routing.web.WebReportRouteConfig
-import org.vaccineimpact.orderlyweb.app_start.routing.web.WebUserGroupRouteConfig
-import org.vaccineimpact.orderlyweb.app_start.routing.web.WebUserRouteConfig
+import org.vaccineimpact.orderlyweb.app_start.routing.web.*
 import org.vaccineimpact.orderlyweb.controllers.web.IndexController
 import org.vaccineimpact.orderlyweb.controllers.web.SecurityController
 import org.vaccineimpact.orderlyweb.secure
@@ -28,16 +25,10 @@ object APIRouteConfig : RouteConfig
 
 object WebRouteConfig : RouteConfig
 {
-    override val endpoints: List<EndpointDefinition> = listOf(
-            WebEndpoint("/", IndexController::class, "index")
-                    .secure(setOf("*/reports.read")),
-            WebEndpoint("/weblogin", SecurityController::class, "weblogin"),
-            WebEndpoint("/weblogin/external", SecurityController::class, "webloginExternal")
-                    .secure(externalAuth = true)
-    ) +
+    override val endpoints: List<EndpointDefinition> =
+            WebAuthRouteConfig.endpoints +
             WebReportRouteConfig.endpoints +
             WebVersionRouteConfig.endpoints +
             WebUserRouteConfig.endpoints +
             WebUserGroupRouteConfig.endpoints
-
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebAuthRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebAuthRouteConfig.kt
@@ -1,0 +1,17 @@
+package org.vaccineimpact.orderlyweb.app_start.routing.web
+
+import org.vaccineimpact.orderlyweb.EndpointDefinition
+import org.vaccineimpact.orderlyweb.WebEndpoint
+import org.vaccineimpact.orderlyweb.app_start.RouteConfig
+import org.vaccineimpact.orderlyweb.controllers.web.SecurityController
+import org.vaccineimpact.orderlyweb.secure
+
+object WebAuthRouteConfig : RouteConfig
+{
+    override val endpoints: List<EndpointDefinition> =
+            listOf(
+                    WebEndpoint("/weblogin", SecurityController::class, "weblogin"),
+                    WebEndpoint("/weblogin/external", SecurityController::class, "webloginExternal")
+                            .secure(externalAuth = true)
+            )
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.orderlyweb.app_start.routing.web
 
 import org.vaccineimpact.orderlyweb.WebEndpoint
 import org.vaccineimpact.orderlyweb.app_start.RouteConfig
+import org.vaccineimpact.orderlyweb.controllers.web.IndexController
 import org.vaccineimpact.orderlyweb.controllers.web.ReportController
 import org.vaccineimpact.orderlyweb.json
 import org.vaccineimpact.orderlyweb.secure
@@ -12,6 +13,9 @@ object WebReportRouteConfig : RouteConfig
     private val readReports = setOf("report:<name>/reports.read")
     private val runReports = setOf("*/reports.run")
     override val endpoints = listOf(
+            WebEndpoint("/", IndexController::class, "index")
+                    // more specific permission checking in the controller action
+                    .secure(),
             WebEndpoint("/report/:name/:version/",
                     ReportController::class, "getByNameAndVersion")
                     .secure(readReports),

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/IndexController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/IndexController.kt
@@ -6,25 +6,22 @@ import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
 import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 
-class IndexController: OrderlyDataController
+class IndexController : OrderlyDataController
 {
     constructor(actionContext: ActionContext,
-                orderly: OrderlyClient): super(actionContext, orderly)
+                orderly: OrderlyClient) : super(actionContext, orderly)
 
-    constructor(actionContext: ActionContext): super(actionContext)
+    constructor(actionContext: ActionContext) : super(actionContext)
 
     @Template("index.ftl")
     fun index(): IndexViewModel
     {
-        if (!canReadReports())
-        {
-            throw MissingRequiredPermissionError(PermissionSet("*/reports.read"))
-        }
-
         val reports = orderly.getAllReportVersions()
                 .filter { canReadReport(it.name) }
 
-        return IndexViewModel.build(reports,
-                orderly.getGlobalPinnedReports(), context)
+        val pinnedReports = orderly.getGlobalPinnedReports()
+                .filter { canReadReport(it.name) }
+
+        return IndexViewModel.build(reports, pinnedReports, context)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/IndexController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/IndexController.kt
@@ -2,6 +2,8 @@ package org.vaccineimpact.orderlyweb.controllers.web
 
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.db.OrderlyClient
+import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 
 class IndexController: OrderlyDataController
@@ -14,7 +16,15 @@ class IndexController: OrderlyDataController
     @Template("index.ftl")
     fun index(): IndexViewModel
     {
-        return IndexViewModel.build(orderly.getAllReportVersions(),
+        if (!canReadReports())
+        {
+            throw MissingRequiredPermissionError(PermissionSet("*/reports.read"))
+        }
+
+        val reports = orderly.getAllReportVersions()
+                .filter { canReadReport(it.name) }
+
+        return IndexViewModel.build(reports,
                 orderly.getGlobalPinnedReports(), context)
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/IndexPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/IndexPageTests.kt
@@ -26,6 +26,15 @@ class IndexPageTests : IntegrationTest()
     }
 
     @Test
+    fun `unauthenticated users cannot get index page`()
+    {
+        val response = webRequestHelper.getWebPage("/")
+
+        val page = Jsoup.parse(response.text)
+        assertThat(page.selectFirst(".siteTitle").text()).isEqualTo("Montagu") // user has been redirected to login
+    }
+
+    @Test
     fun `can download pinned report zip file`()
     {
         insertGlobalPinnedReport("minimal", 0)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/IndexPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/IndexPageTests.kt
@@ -1,13 +1,14 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
 
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.jsoup.Jsoup
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
-import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
 import org.vaccineimpact.orderlyweb.test_helpers.insertGlobalPinnedReport
+import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
 
 class IndexPageTests : IntegrationTest()
 {
@@ -15,9 +16,9 @@ class IndexPageTests : IntegrationTest()
     private val url = "/"
 
     @Test
-    fun `only report readers can get index page`()
+    fun `all authenticated users can get index page`()
     {
-        assertWebUrlSecured(url, readReports)
+        assertWebUrlSecured(url, setOf())
     }
 
     @Test


### PR DESCRIPTION
All logged in users should be able to see the index page. They just won't see any reports unless they have permission to do so.