### PR TITLE
mrc-330 Update spec

### DIFF
--- a/docs/spec/Version.schema.json
+++ b/docs/spec/Version.schema.json
@@ -1,19 +1,15 @@
 {
-	"id": "Version",
-	"type": "object",
-	"properties": {
-		"name": {"type" :"string"},
-		"id": {"type" :"string"},
-		"display_name": {"type": [ "string", "null"] },
-		"description": {"type": [ "string", "null"] },
-        "date": {"type" :"string"},
-        "published":  {"type" :"boolean"},
-        "requester":  {"type" :"string"},
-        "author":  {"type" :"string"},
-        "artefacts": { "type": "array", "items": { "$ref": "Artefact.schema.json"}},
-        "resources": {"type": "array", "items": {"type": "string"}},
-        "data_hashes": {"$ref" :"Dictionary.schema.json"}
-	},
-	"additionalProperties": false,
-	"required": ["name", "id", "display_name", "description", "date", "published", "requester", "author"]
+  "id": "Version",
+  "type": "object",
+  "properties": {
+    "name": {"type" :"string"},
+    "id": {"type" :"string"},
+    "display_name": {"type": [ "string", "null"] },
+    "date": {"type" :"string"},
+    "published":  {"type" :"boolean"},
+    "requester":  {"type" :"string"},
+    "author":  {"type" :"string"}
+  },
+  "additionalProperties": false,
+  "required": ["name", "id", "display_name", "date", "published", "requester", "author"]
 }

--- a/docs/spec/VersionDetails.schema.json
+++ b/docs/spec/VersionDetails.schema.json
@@ -1,0 +1,19 @@
+{
+	"id": "VersionDetails",
+	"type": "object",
+	"properties": {
+		"name": {"type" :"string"},
+		"id": {"type" :"string"},
+		"display_name": {"type": [ "string", "null"] },
+		"description": {"type": [ "string", "null"] },
+        "date": {"type" :"string"},
+        "published":  {"type" :"boolean"},
+        "requester":  {"type" :"string"},
+        "author":  {"type" :"string"},
+        "artefacts": { "type": "array", "items": { "$ref": "Artefact.schema.json"}},
+        "resources": {"type": "array", "items": {"type": "string"}},
+        "data_hashes": {"$ref" :"Dictionary.schema.json"}
+	},
+	"additionalProperties": false,
+	"required": ["name", "id", "display_name", "description", "date", "published", "requester", "author"]
+}

--- a/docs/spec/VersionIds.schema.json
+++ b/docs/spec/VersionIds.schema.json
@@ -1,0 +1,7 @@
+{
+  "id": "VersionIds",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}

--- a/docs/spec/Versions.schema.json
+++ b/docs/spec/Versions.schema.json
@@ -1,7 +1,5 @@
 {
   "id": "Versions",
   "type": "array",
-  "items": {
-    "type": "string"
-  }
+  "items": { "$ref": "Version.schema.json" }
 }

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -277,7 +277,7 @@ Required permissions: `reports.run`.
 ```
 ## GET /reports/:name/versions/:version/data/
 
-Gets a dict of data names to hashes.
+Gets a dictionary of data names to hashes.
 
 Required permissions: `reports.read`.
 
@@ -299,9 +299,13 @@ Required permissions: `reports.read`.
 
 ## GET /reports/:name/versions/:version/artefacts/
 
-Gets a dict of artefact names to hashes.
+Gets a dictionary of artefact names to hashes.
 
 Required permissions: `reports.read`.
+
+Schema: [`Dictionary.schema.json`](Dictionary.schema.json)
+
+## Example
 
 ```json
 {
@@ -317,9 +321,13 @@ Required permissions: `reports.read`.
 
 ## GET /reports/:name/versions/:version/resources/
 
-Gets a dict of resource names to hashes.
+Gets a dictionary of resource names to hashes.
 
 Required permissions: `reports.read`.
+
+Schema: [`Dictionary.schema.json`](Dictionary.schema.json)
+
+## Example
 
 ```json
 {
@@ -335,7 +343,7 @@ Required permissions: `reports.read`.
 
 ## GET /reports/:name/versions/:version/all/
 
-Downloads a zip file of everything (including data).
+Downloads a zip file of all files associated with a report version (including data).
 
 Required permissions: `reports.read`.
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -281,6 +281,9 @@ Gets a dict of data names to hashes.
 
 Required permissions: `reports.read`.
 
+Schema: [`Dictionary.schema.json`](Dictionary.schema.json)
+
+## Example
 
 ```json
 {  

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -4,8 +4,8 @@ Follows the general points in the [montagu api](https://github.com/vimc/montagu-
 
 * all data is returned in JSON format following the standard response schema defined above
 * `POST` data must be sent in JSON format
-* All API endpoints can be found relative to `[base-url]/api/[version]`, where `[base-url]` is the home url for the OrderlyWeb
-web portal, and `[version]` is the required version of the api/
+* All API endpoints can be found relative to `https://[base-url]/api/[version]`, where `[base-url]` is the home url for the 
+OrderlyWeb web portal, and `[version]` is the required version of the api.
 * The only available version currently is `v1` so all api endpoints can be found relative to
 `https://[base-url]/api/v1/` e.g. `https://[base-url]/api/v1/reports/`
 * API endpoints can be accessed with or without trailing slashes e.g. both `https://[base-url]/api/v1/reports/` and 
@@ -14,10 +14,17 @@ web portal, and `[version]` is the required version of the api/
 In addition
 
 * Query parameters that accept booleans are case insensitive and accept `true` and `false`.
-* Authentication is via tokens issued by the Montagu API or by GitHub (see [below](## post-login) for details).
+* Authentication is via tokens issued by the Montagu API or by GitHub (see [below](#post-login) for details).
+* Here are the JSON formats of some response types not covered by the standard data responses described below:
+  
+  * [`Error.schema.json`](Error.schema.json) 
+  * [`ErrorCode.schema.json`](ErrorCode.schema.json)
+  * [`Index.schema.json`](Index.schema.json)
+  * [`Response.schema.json`](Response.schema.json)
 
-For each endpoint, if the user does not have the `reports.review` permission then only published reports will be 
+* For each endpoint, if the user does not have the `reports.review` permission then only published reports' data will be 
 accessible. If the user does have `reports.review` then all reports will be accessible.
+
 
 ## POST /login/
 To login and retrieve a bearer token that can be used to authenticate all other requests
@@ -56,8 +63,8 @@ Schema: [`LoginSuccessful.schema.json`](../schemas/LoginSuccessful.schema.json)
         "expires_in": 3600
     }
 
-Otherwise an error response is returned with status code 401 if the token was invalid, or 403 if the user is not
- a member of the configured GitHub organization or team.
+Otherwise an error response is returned with status code 401 if the token was invalid, or 403 if the authentication 
+provider is GitHub and the user is not a member of the configured GitHub organization or team.
 
 ## GET /reports/
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -143,7 +143,7 @@ Schema: [`Version.schema.json`](Version.schema.json)
 
 ## POST /reports/:name/run/
 
-Try and run a report `:name`.
+Starts a new Orderly run of a report named `:name`.
 
 Required permissions: `reports.run`.
 
@@ -171,7 +171,7 @@ Get the status of a report.
 
 Required permissions: `reports.run`.
 
-This works only for reports that were queued by the runner itself/
+This works only for reports that were queued by the runner itself.
 
 Schema: [`Status.schema.json`](Status.schema.json)
 
@@ -227,7 +227,7 @@ true
 
 ## GET /reports/git/status/
 
-Get git status.  This does not quite map onto `git status` but includes output from `git status --porcelain=v1` along with branch and hash informationl.  When running on a server, ideally the `output` section will be an empty array (otherwise branch changing is disabled)
+Get git status.  This does not quite map onto `git status` but includes output from `git status --porcelain=v1` along with branch and hash information.  When running on a server, ideally the `output` section will be an empty array (otherwise branch changing is disabled)
 
 Required permissions: `reports.run`.
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -350,9 +350,12 @@ Required permissions: `reports.read`.
 ## GET /reports/:name/versions/:version/changelog/
 
 Returns the changelog for a report version, the report creator's record of changes made during the development
-of this version.
+of this version. 
 
-Required permissions: `reports.review`.
+`Reports.read` is the minimum permission required. Users who have `reports.read` permission only will be able to see
+public changelog entries. Users with `reports.review` permission will also see internal changelog entries. 
+
+Required permissions: `reports.read`.
 
 Schema: [`Changelog.schema.json`]( Changelog.schema.json)
 
@@ -375,6 +378,39 @@ Schema: [`Changelog.schema.json`]( Changelog.schema.json)
 ]
 ```
 
+## GET /reports/:name/latest/changelog/
+
+Returns the changelog for latest version of the named report. 
+
+`Reports.read` is the minimum permission required. Users who have `reports.read` permission only will be able to see
+public changelog entries. Users with `reports.review` permission will also see internal changelog entries. 
+
+The changelog returned will belong to the the latest report version which is accessible to the user. For readers with 
+`report.read` permission only, this will be the latest public version. For readers with `report.review` permission it
+will be the latest published or unpublished version. 
+
+Required permissions: `reports.read`.
+
+Schema: [`Changelog.schema.json`]( Changelog.schema.json)
+
+### Example
+
+```json
+[
+  {
+    "label": "public",
+    "value": "Added graphs",
+    "from_file": true,
+    "report_version": "20171220-234033-f97cc4f3"
+  },
+  {
+    "label": "internal",
+    "value": "Fixed typos in text",
+    "from_file": true,
+    "report_version": "20171202-074745-4f66ded4"
+  }
+]
+```
 
 ## GET /data/csv/:id/
 
@@ -388,29 +424,3 @@ Download a data set in rds format.
 
 Required permissions: `reports.read`.
 
-## GET /reports/:name/latest/changelog/
-
-Returns the changelog for latest version of the named report. 
-
-Required permissions: `reports.review`.
-
-Schema: [`Changelog.schema.json`]( Changelog.schema.json)
-
-### Example
-
-```json
-[
-  {
-    "label": "public",
-    "value": "Added graphs",
-    "from_file": true,
-    "report_version": "20171220-234033-f97cc4f3"
-  },
-  {
-    "label": "internal",
-    "value": "Fixed typos in text",
-    "from_file": true,
-    "report_version": "20171202-074745-4f66ded4"
-  }
-]
-```

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -100,7 +100,7 @@ Returns a list of version names for the named report.
 
 Required permissions: `reports.read`.
 
-Schema: [`Versions.schema.json`](Versions.schema.json)
+Schema: [`VersionIds.schema.json`](VersionIds.schema.json)
 
 ### Example
 
@@ -114,11 +114,11 @@ Schema: [`Versions.schema.json`](Versions.schema.json)
 
 ## GET /reports/:name/versions/:version/
 
-Returns metadata about a single report version.
+Returns full metadata about a single report version.
 
 Required permissions: `reports.read`.
 
-Schema: [`Version.schema.json`](Version.schema.json)
+Schema: [`VersionDetails.schema.json`](VersionDetails.schema.json)
 
 ### Example
 
@@ -398,7 +398,7 @@ will be the latest published or unpublished version.
 
 Required permissions: `reports.read`.
 
-Schema: [`Changelog.schema.json`]( Changelog.schema.json)
+Schema: [`Changelog.schema.json`](Changelog.schema.json)
 
 ### Example
 
@@ -418,6 +418,43 @@ Schema: [`Changelog.schema.json`]( Changelog.schema.json)
   }
 ]
 ```
+
+## GET /versions/
+
+Gets metadata of all report versions accessible to the user. 
+
+Required permissions: `reports.read`
+
+Schema: [`Versions.schema.json`](Versions.schema.json)
+
+### Example
+
+```json
+{
+    "id": "20161006-142357-e80edf58",
+    "name": "minimal",
+    "displayname": null,
+    "description": null,
+    "artefacts": [
+      {        
+          "format": "staticgraph",
+          "description": "A graph of things",
+          "files": [
+            "mygraph.png"
+          ]        
+      }
+    ],
+    "resources": ["source/inputdata.csv"],
+    "date": "2016-10-06 14:23:57.0",   
+    "data_hashes": {
+      "dat": "386f507375907a60176b717016f0a648"
+    },
+    "published": false,
+    "requester": "Funder McFunderface",
+    "author": "Researcher McResearcherface"
+  }
+```
+
 
 ## GET /data/csv/:id/
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -238,6 +238,8 @@ Get git status.  This does not quite map onto `git status` but includes output f
 
 Required permissions: `reports.run`.
 
+Schema: [`GitStatus.schema.json`](GitStatus.schema.json)
+
 ## Example
 
 ```json
@@ -255,6 +257,8 @@ Fetch from remote git.  This is required before accessing an updated reference (
 
 Required permissions: `reports.run`.
 
+Schema: [`GitFetch.schema.json`](GitFetch.schema.json)
+
 ## Example
 
 ```json
@@ -264,12 +268,13 @@ Required permissions: `reports.run`.
 ]
 ```
 
-
 ## POST /reports/git/pull/
 
 Pull from remote git.  This updates the working tree.
 
 Required permissions: `reports.run`.
+
+Schema: [`GitPull.schema.json`](GitPull.schema.json)
 
 ## Example
 
@@ -282,6 +287,7 @@ Required permissions: `reports.run`.
   " create mode 100644 new"
 ]
 ```
+
 ## GET /reports/:name/versions/:version/data/
 
 Gets a dictionary of data names to hashes.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -436,29 +436,28 @@ Schema: [`Versions.schema.json`](Versions.schema.json)
 ### Example
 
 ```json
-{
+[
+  {
     "id": "20161006-142357-e80edf58",
     "name": "minimal",
-    "displayname": null,
-    "description": null,
-    "artefacts": [
-      {        
-          "format": "staticgraph",
-          "description": "A graph of things",
-          "files": [
-            "mygraph.png"
-          ]        
-      }
-    ],
+    "displayname": null,  
     "resources": ["source/inputdata.csv"],
     "date": "2016-10-06 14:23:57.0",   
-    "data_hashes": {
-      "dat": "386f507375907a60176b717016f0a648"
-    },
     "published": false,
     "requester": "Funder McFunderface",
     "author": "Researcher McResearcherface"
-  }
+  },
+  {
+      "id": "20161106-152357-e80edf92",
+      "name": "another name",
+      "displayname": null,  
+      "resources": ["source/inputdata.csv"],
+      "date": "2016-11-06 15:23:57.0",   
+      "published": true,
+      "requester": "Funder McFunderface",
+      "author": "Researcher McResearcherface"
+    }
+]  
 ```
 
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -460,7 +460,6 @@ Schema: [`Versions.schema.json`](Versions.schema.json)
 ]  
 ```
 
-
 ## GET /data/csv/:id/
 
 Downloads a data set in csv format.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -19,7 +19,6 @@ In addition
   
   * [`Error.schema.json`](Error.schema.json) - Schema of error responses
   * [`ErrorCode.schema.json`](ErrorCode.schema.json) - Schema of error codes (provided as part of error responses)
-  * [`Index.schema.json`](Index.schema.json) - Schema of response found at root url `/` which lists all available endpoints
   * [`Response.schema.json`](Response.schema.json) - The wrapper schema of all responses. 
 
 * For each endpoint, if the user does not have the `reports.review` permission then only published report versions' data 
@@ -67,6 +66,14 @@ Schema: [`LoginSuccessful.schema.json`](../schemas/LoginSuccessful.schema.json)
 
 Otherwise an error response is returned with status code 401 if the token was invalid, or 403 if the authentication 
 provider is GitHub and the user is not a member of the configured GitHub organization or team.
+
+## GET /
+
+Return a description of all endpoint available over the api. 
+
+Required permissions: none
+
+Schema: [`Index.schema.json`](Index.schema.json)
 
 ## GET /reports/
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1,23 +1,20 @@
 # OrderlyWeb API
 
-Follows the general points in the [montagu api](https://github.com/vimc/montagu-api/blob/master/spec/spec.md)
+Follows the general points in the [montagu api](https://github.com/vimc/montagu-api/blob/master/docs/spec/spec.md)
 
 * all data is returned in JSON format following the standard response schema defined above
 * `POST` data must be sent in JSON format
-* The canonical form for all URLs (not including query string) ends in a slash: `/`
-* The API will be versioned via URL. So for version 1, all URLs will begin /v1/. e.g. http://.../v1/reports/
+* All API endpoints can be found relative to `[base-url]/api/[version]`, where `[base-url]` is the home url for the OrderlyWeb
+web portal, and `[version]` is the required version of the api/
+* The only available version currently is `v1` so all api endpoints can be found relative to
+`https://[base-url]/api/v1/` e.g. `https://[base-url]/api/v1/reports/`
+* API endpoints can be accessed with or without trailing slashes e.g. both `https://[base-url]/api/v1/reports/` and 
+`https://[base-url]/api/v1/reports` will work. 
 
 In addition
 
 * Query parameters that accept booleans are case insensitive and accept `true` and `false`.
-* Authentication is via tokens issues by the Montagu API
-
-Some files are directly copied over (with only whitespace changes) from `montagu-api`:
-
-* `Error.schema.json`
-* `ErrorCode.schema.json`
-* `Index.schema.json`
-* `Response.schema.json`
+* Authentication is via tokens issued by the Montagu API or by GitHub (see [below](## post-login) for details).
 
 For each endpoint, if the user does not have the `reports.review` permission then only published reports will be 
 accessible. If the user does have `reports.review` then all reports will be accessible.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -15,12 +15,12 @@ In addition
 
 * Query parameters that accept booleans are case insensitive and accept `true` and `false`.
 * Authentication is via tokens issued by the Montagu API or by GitHub (see [below](#post-login) for details).
-* Here are the JSON formats of some response types not covered by the standard data responses described below:
+* Here are the JSON schema of some response types not covered by the standard data responses described below:
   
-  * [`Error.schema.json`](Error.schema.json) 
-  * [`ErrorCode.schema.json`](ErrorCode.schema.json)
-  * [`Index.schema.json`](Index.schema.json)
-  * [`Response.schema.json`](Response.schema.json)
+  * [`Error.schema.json`](Error.schema.json) - Schema of error responses
+  * [`ErrorCode.schema.json`](ErrorCode.schema.json) - Schema of error codes (provided as part of error responses)
+  * [`Index.schema.json`](Index.schema.json) - Schema of response found at root url `/` which lists all available endpoints
+  * [`Response.schema.json`](Response.schema.json) - The wrapper schema of all responses. 
 
 * For each endpoint, if the user does not have the `reports.review` permission then only published reports' data will be 
 accessible. If the user does have `reports.review` then all reports will be accessible.
@@ -68,8 +68,7 @@ provider is GitHub and the user is not a member of the configured GitHub organiz
 
 ## GET /reports/
 
-Return a list of all reports with minimal metadata - the id, human readable name, latest version of each and
-whether that version is published.
+Return a list of all reports with minimal metadata - the id, human readable name and latest version of each.
 
 Required permissions: `reports.read`.
 
@@ -80,8 +79,8 @@ Schema: [`Reports.schema.json`](Reports.schema.json)
 ```json
 
   [
-    {"name": "minimal", "display_name": "Minimal example", "latest_version": "20161010-121958-d5f0ea63", "published": "true"},
-    {"name": "use_resource", "display_name": "Use resources example", "latest_version": "20171011-121958-effh734", "published": "false"}       
+    {"name": "minimal", "display_name": "Minimal example", "latest_version": "20161010-121958-d5f0ea63"},
+    {"name": "use_resource", "display_name": "Use resources example", "latest_version": "20171011-121958-effh734"}       
   ]
 
 ```

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -22,8 +22,10 @@ In addition
   * [`Index.schema.json`](Index.schema.json) - Schema of response found at root url `/` which lists all available endpoints
   * [`Response.schema.json`](Response.schema.json) - The wrapper schema of all responses. 
 
-* For each endpoint, if the user does not have the `reports.review` permission then only published reports' data will be 
-accessible. If the user does have `reports.review` then all reports will be accessible.
+* For each endpoint, if the user does not have the `reports.review` permission then only published report versions' data 
+will be accessible. If the user does have `reports.review` then both published and unpublished report versions will be accessible. 
+* In addition, users may have permission scoped at the report level, and will not be able to access reports for which they
+do not have read or review permission. 
 
 
 ## POST /login/
@@ -91,7 +93,7 @@ Returns a list of version names for the named report.
 
 Required permissions: `reports.read`.
 
-Schema: [`Versions.schema.json`](Version.schema.json)
+Schema: [`Versions.schema.json`](Versions.schema.json)
 
 ### Example
 
@@ -109,7 +111,7 @@ Returns metadata about a single report version.
 
 Required permissions: `reports.read`.
 
-Schema: [`Report.schema.json`](Version.schema.json)
+Schema: [`Version.schema.json`](Version.schema.json)
 
 ### Example
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/VersionTests.kt
@@ -145,7 +145,7 @@ class VersionTests : IntegrationTest()
 
         assertSuccessful(response)
         assertJsonContentType(response)
-        JSONValidator.validateAgainstSchema(response.text, "Versions")
+        JSONValidator.validateAgainstSchema(response.text, "VersionIds")
     }
 
     @Test
@@ -157,7 +157,7 @@ class VersionTests : IntegrationTest()
 
         assertSuccessful(response)
         assertJsonContentType(response)
-        JSONValidator.validateAgainstSchema(response.text, "Versions")
+        JSONValidator.validateAgainstSchema(response.text, "VersionIds")
     }
 
     @Test
@@ -171,14 +171,14 @@ class VersionTests : IntegrationTest()
     }
 
     @Test
-    fun `can get report by name and version with global permissionss`()
+    fun `can get report by name and version with global permissions`()
     {
         insertReport("testname", "testversion")
         val response = apiRequestHelper.get("/reports/testname/versions/testversion",
                 userEmail = fakeGlobalReportReader())
         assertSuccessful(response)
         assertJsonContentType(response)
-        JSONValidator.validateAgainstSchema(response.text, "Version")
+        JSONValidator.validateAgainstSchema(response.text, "VersionDetails")
     }
 
     @Test
@@ -189,7 +189,7 @@ class VersionTests : IntegrationTest()
                 userEmail = fakeReportReader("testname"))
         assertSuccessful(response)
         assertJsonContentType(response)
-        JSONValidator.validateAgainstSchema(response.text, "Version")
+        JSONValidator.validateAgainstSchema(response.text, "VersionDetails")
     }
 
     @Test
@@ -210,7 +210,7 @@ class VersionTests : IntegrationTest()
 
         assertSuccessful(response)
         assertJsonContentType(response)
-        JSONValidator.validateAgainstSchema(response.text, "Version")
+        JSONValidator.validateAgainstSchema(response.text, "VersionDetails")
     }
 
     @Test


### PR DESCRIPTION
One outcome of the change to /report/.. rather than /reports/.. in the web endpoints is that there's now a discrepancy with the API endpoints, which are all still prefixed /reports/ - I'm assuming we're ok with that? I guess for Montagu it means that our api endpoints will look like https://whatever:port/reports/api/v1/reports/etc ..? Which is kind of weird but then API paths are often pretty horrible!

We also haven't listed the onetime_token endpoint. Do we still need that?