### PR TITLE
Distinguish identity groups

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/UserGroupViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/UserGroupViewModel.kt
@@ -2,15 +2,23 @@ package org.vaccineimpact.orderlyweb.viewmodels
 
 import org.vaccineimpact.orderlyweb.models.permissions.UserGroup
 
-data class UserGroupViewModel(val name: String, val members: List<ReportReaderViewModel>)
+sealed class UserGroupViewModel(val name: String, val members: List<ReportReaderViewModel>)
 {
+    class IdentityGroupViewModel(name: String) : UserGroupViewModel(name, listOf())
+    class MembersGroupViewModel(name: String, members: List<ReportReaderViewModel>) : UserGroupViewModel(name, members)
+
     companion object
     {
         fun build(userGroup: UserGroup): UserGroupViewModel
         {
-           return UserGroupViewModel(userGroup.name, userGroup.members.map {
-               ReportReaderViewModel.build(it, canRemove = false)
-           }.sortedBy { it.displayName })
+            if (userGroup.members.all { it.email == userGroup.name })
+            {
+                return IdentityGroupViewModel(userGroup.name)
+            }
+
+            return MembersGroupViewModel(userGroup.name, userGroup.members.map {
+                ReportReaderViewModel.build(it, canRemove = false)
+            }.sortedBy { it.displayName })
         }
 
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/UserRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/UserRepositoryTests.kt
@@ -11,6 +11,7 @@ import org.vaccineimpact.orderlyweb.models.UserSource
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.models.permissions.UserGroupPermission
 import org.vaccineimpact.orderlyweb.test_helpers.CleanDatabaseTests
+import org.vaccineimpact.orderlyweb.test_helpers.giveUserGlobalPermission
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.*
 import java.time.Instant
@@ -252,6 +253,20 @@ class UserRepositoryTests : CleanDatabaseTests()
         val result = sut.getGlobalReportReaderGroups()
 
         assertThat(result.count()).isEqualTo(0)
+    }
+
+    @Test
+    fun `getGlobalReportReaderGroups returns identity groups`()
+    {
+        insertUser("test.user@example.com", "Test User")
+        giveUserGroupPermission("test.user@example.com", "reports.read", Scope.Global())
+
+        val sut = OrderlyUserRepository()
+        val result = sut.getGlobalReportReaderGroups()
+
+        assertThat(result.count()).isEqualTo(1)
+        assertThat(result[0].name).isEqualTo("test.user@example.com")
+        assertThat(result[0].members.all { it.email == "test.user@example.com" }).isTrue()
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/UserGroupControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/UserGroupControllerTests.kt
@@ -13,6 +13,7 @@ import org.vaccineimpact.orderlyweb.models.User
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.models.permissions.UserGroup
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+import org.vaccineimpact.orderlyweb.viewmodels.UserGroupViewModel
 
 class UserGroupControllerTests : TeamcityTests()
 {
@@ -90,7 +91,7 @@ class UserGroupControllerTests : TeamcityTests()
     }
 
     @Test
-    fun `getGlobalReportReaderGroups builds user group view model`()
+    fun `getGlobalReportReaderGroups builds members user group view model`()
     {
         val repo = mock<UserRepository> {
             on { getGlobalReportReaderGroups() } doReturn listOf(UserGroup("Funders",
@@ -103,6 +104,7 @@ class UserGroupControllerTests : TeamcityTests()
         val sut = UserGroupController(mock(), mock(), repo)
         val result = sut.getGlobalReportReaders()
         assertThat(result.count()).isEqualTo(1)
+        assertThat(result[0] is UserGroupViewModel.MembersGroupViewModel).isTrue()
         assertThat(result[0].name).isEqualTo("Funders")
 
         val members = result[0].members
@@ -147,6 +149,25 @@ class UserGroupControllerTests : TeamcityTests()
         val sut = UserGroupController(mock(), mock(), repo)
         val members = sut.getGlobalReportReaders()[0].members
         assertThat(members.map { it.username }).containsExactly("a.user", "b.user", "c.user")
+    }
+
+
+    @Test
+    fun `getGlobalReportReaderGroups builds identity group view models`()
+    {
+        val repo = mock<UserRepository> {
+            on { getGlobalReportReaderGroups() } doReturn listOf(
+                    UserGroup("test.user@example.com", listOf(
+                            User("test.user", "Test User", "test.user@example.com"))
+                    )
+            )
+        }
+
+        val sut = UserGroupController(mock(), mock(), repo)
+        val result = sut.getGlobalReportReaders()
+        assertThat(result[0] is UserGroupViewModel.IdentityGroupViewModel).isTrue()
+        assertThat(result[0].members.count()).isEqualTo(0)
+        assertThat(result[0].name).isEqualTo("test.user@example.com")
     }
 
 }


### PR DESCRIPTION
Perhaps we should distinguish identity groups as follows? To avoid weirdness of having groups where the only member is the user whose email is the group id.