### PR TITLE
Fix selenium tests

### DIFF
--- a/scripts/install-chromedriver.sh
+++ b/scripts/install-chromedriver.sh
@@ -3,7 +3,7 @@
 sudo apt-get update
 sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
 
-wget https://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip
+wget https://chromedriver.storage.googleapis.com/76.0.3809.68/chromedriver_linux64.zip
 unzip chromedriver_linux64.zip
 sudo mv chromedriver /usr/bin/chromedriver
 sudo chown root:root /usr/bin/chromedriver

--- a/scripts/release/tag_images.py
+++ b/scripts/release/tag_images.py
@@ -71,6 +71,7 @@ def set_image_tags(version):
     for name in containers:
         print("  - " + name)
         set_image_tag(name, version, sha)
+        set_image_tag(name, current_release_tag, sha)
 
 
 def publish_images(version):
@@ -111,7 +112,7 @@ if __name__ == "__main__":
         set_image_tags(version)
         # The --publish option is not currently available in Usage, to
         # enforce 2-step publish
-        if args["--publish"]:
+        if args["publish"]:
             publish_images(version)
     elif args["publish"]:
         publish_images(version)


### PR DESCRIPTION
Update chromedriver to match latest chrome version.

This also accidentally contains a couple of fixes to the `tag_images` script - they were intended for another branch but I figure no harm in including them here!