### PR TITLE
add tab deep linking behaviour and tests

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -95,9 +95,9 @@ class VersionPageTests : TeamcityTests()
         Assertions.assertThat(doc.select(".nav-item")[1].text()).isEqualTo("Downloads")
         Assertions.assertThat(doc.select(".nav-item")[2].text()).isEqualTo("Changelog")
 
-        Assertions.assertThat(doc.selectFirst("#report-tab").hasClass("tab-pane active pt-4 pt-md-1")).isTrue()
-        Assertions.assertThat(doc.selectFirst("#downloads-tab").hasClass("tab-pane pt-4 pt-md-1")).isTrue()
-        Assertions.assertThat(doc.selectFirst("#changelog-tab").hasClass("tab-pane pt-4 pt-md-1")).isTrue()
+        Assertions.assertThat(doc.selectFirst("#report").hasClass("tab-pane active pt-4 pt-md-1")).isTrue()
+        Assertions.assertThat(doc.selectFirst("#downloads").hasClass("tab-pane pt-4 pt-md-1")).isTrue()
+        Assertions.assertThat(doc.selectFirst("#changelog").hasClass("tab-pane pt-4 pt-md-1")).isTrue()
     }
 
     @Test
@@ -130,7 +130,7 @@ class VersionPageTests : TeamcityTests()
     {
         val xmlResponse = template.xmlResponseFor(testModel)
 
-        val xPathRoot = "//div[@id='report-tab']"
+        val xPathRoot = "//div[@id='report']"
 
         assertThat(xmlResponse, hasXPath("$xPathRoot/h1/text()",
                 equalToCompressingWhiteSpace("r1 display")))
@@ -148,7 +148,7 @@ class VersionPageTests : TeamcityTests()
     {
         val xmlResponse = template.xmlResponseFor(testModel)
 
-        val xPathRoot = "//div[@id='downloads-tab']"
+        val xPathRoot = "//div[@id='downloads']"
 
         assertThat(xmlResponse, hasXPath("$xPathRoot/h1/text()",
                 equalToCompressingWhiteSpace("r1 display")))
@@ -271,7 +271,7 @@ class VersionPageTests : TeamcityTests()
     fun `renders changelog tab title`()
     {
         val doc = template.jsoupDocFor(testModel)
-        Assertions.assertThat(doc.select("#changelog-tab h3").text()).isEqualTo("Changelog")
+        Assertions.assertThat(doc.select("#changelog h3").text()).isEqualTo("Changelog")
     }
 
     @Test
@@ -285,10 +285,10 @@ class VersionPageTests : TeamcityTests()
         val testModel = testModel.copy(changelog = changelog)
         val doc = template.jsoupDocFor(testModel)
 
-        val rows = doc.select("#changelog-tab table tbody tr")
+        val rows = doc.select("#changelog table tbody tr")
 
         Assertions.assertThat(rows.count()).isEqualTo(1)
-        Assertions.assertThat(doc.select("#changelog-tab p").count()).isEqualTo(0)
+        Assertions.assertThat(doc.select("#changelog p").count()).isEqualTo(0)
 
         val cells = rows[0].select("td")
         Assertions.assertThat(cells[0].selectFirst("a").attr("href")).isEqualTo("/reports/r1/v1")
@@ -309,8 +309,8 @@ class VersionPageTests : TeamcityTests()
     {
         val doc = template.jsoupDocFor(testModel)
 
-        Assertions.assertThat(doc.select("#changelog-tab table").count()).isEqualTo(0)
-        Assertions.assertThat(doc.selectFirst("#changelog-tab p").text()).isEqualTo("There is no changelog for this report version")
+        Assertions.assertThat(doc.select("#changelog table").count()).isEqualTo(0)
+        Assertions.assertThat(doc.selectFirst("#changelog p").text()).isEqualTo("There is no changelog for this report version")
     }
 
     @Test

--- a/src/app/static/src/js/report.js
+++ b/src/app/static/src/js/report.js
@@ -23,7 +23,7 @@ $(document).ready(() => {
                 publishSwitch: publishSwitch
             },
             methods: {
-                handleToggle: function() {
+                handleToggle: function () {
                     this.report.published = !this.report.published
                 }
             }
@@ -51,4 +51,13 @@ $(document).ready(() => {
     }
 
     $('[data-toggle="tooltip"]').tooltip();
+
+    if (location.hash) {
+        $('a[href="' + location.hash + '"]').tab("show");
+    }
+
+    $('a[data-toggle="tab"]').on("click", function () {
+        const hash = $(this).attr("href");
+        location.hash = hash.split("#")[1];
+    });
 });

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -16,13 +16,13 @@
                     <div class="d-md-block mt-4 mt-md-0 collapse navbar-collapse" id="sidebar">
                         <ul class="nav flex-column list-unstyled mb-0">
                             <li class="nav-item">
-                                <a class="nav-link active" data-toggle="tab" href="#report-tab" role="tab">Report</a>
+                                <a class="nav-link active" data-toggle="tab" href="#report" role="tab">Report</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" data-toggle="tab" href="#downloads-tab" role="tab">Downloads</a>
+                                <a class="nav-link" data-toggle="tab" href="#downloads" role="tab">Downloads</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" data-toggle="tab" href="#changelog-tab" role="tab">Changelog</a>
+                                <a class="nav-link" data-toggle="tab" href="#changelog" role="tab">Changelog</a>
                             </li>
                         </ul>
                         <hr/>
@@ -53,13 +53,13 @@
             </div>
         </div>
         <div class="col-12 col-md-8 tab-content">
-            <div class="tab-pane active pt-4 pt-md-1" role="tabpanel" id="report-tab">
+            <div class="tab-pane active pt-4 pt-md-1" role="tabpanel" id="report">
                 <#include "partials/report-tab.ftl">
             </div>
-            <div class="tab-pane pt-4 pt-md-1" role="tabpanel" id="downloads-tab">
+            <div class="tab-pane pt-4 pt-md-1" role="tabpanel" id="downloads">
                 <#include "partials/downloads.ftl">
             </div>
-            <div class="tab-pane pt-4 pt-md-1" role="tabpanel" id="changelog-tab">
+            <div class="tab-pane pt-4 pt-md-1" role="tabpanel" id="changelog">
                 <#include "partials/changelog.ftl">
             </div>
         </div>

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
@@ -162,23 +162,23 @@ class ReportPageTests : SeleniumTest()
         driver.get(RequestHelper.webBaseUrl + "/report/testreport/20170103-143015-1234abcd/")
 
         //Confirm that we've started on the Report tab
-        confirmTabActive("report-tab", true)
-        confirmTabActive("downloads-tab", false)
+        confirmTabActive("report", true)
+        confirmTabActive("downloads", false)
 
         //Change to Downloads tab
-        val downloadsLink = driver.findElement(By.cssSelector("a[href='#downloads-tab']"))
+        val downloadsLink = driver.findElement(By.cssSelector("a[href='#downloads']"))
         downloadsLink.click()
         Thread.sleep(500)
-        confirmTabActive("report-tab", false)
-        confirmTabActive("downloads-tab", true)
+        confirmTabActive("report", false)
+        confirmTabActive("downloads", true)
         assertThat(driver.currentUrl).isEqualTo(RequestHelper.webBaseUrl + "/report/testreport/20170103-143015-1234abcd/#downloads")
 
         //And back to Report
-        val reportLink = driver.findElement(By.cssSelector("a[href='#report-tab']"))
+        val reportLink = driver.findElement(By.cssSelector("a[href='#report']"))
         reportLink.click()
         Thread.sleep(500)
-        confirmTabActive("report-tab", true)
-        confirmTabActive("downloads-tab", false)
+        confirmTabActive("report", true)
+        confirmTabActive("downloads", false)
         assertThat(driver.currentUrl).isEqualTo(RequestHelper.webBaseUrl + "/report/testreport/20170103-143015-1234abcd/#report")
 
     }
@@ -196,8 +196,8 @@ class ReportPageTests : SeleniumTest()
         loginWithMontagu()
         driver.get(RequestHelper.webBaseUrl + "/report/testreport/20170103-143015-1234abcd/#downloads")
 
-        confirmTabActive("report-tab", false)
-        confirmTabActive("downloads-tab", true)
+        confirmTabActive("report", false)
+        confirmTabActive("downloads", true)
     }
 
     @Test

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/ReportPageTests.kt
@@ -171,6 +171,7 @@ class ReportPageTests : SeleniumTest()
         Thread.sleep(500)
         confirmTabActive("report-tab", false)
         confirmTabActive("downloads-tab", true)
+        assertThat(driver.currentUrl).isEqualTo(RequestHelper.webBaseUrl + "/report/testreport/20170103-143015-1234abcd/#downloads")
 
         //And back to Report
         val reportLink = driver.findElement(By.cssSelector("a[href='#report-tab']"))
@@ -178,7 +179,25 @@ class ReportPageTests : SeleniumTest()
         Thread.sleep(500)
         confirmTabActive("report-tab", true)
         confirmTabActive("downloads-tab", false)
+        assertThat(driver.currentUrl).isEqualTo(RequestHelper.webBaseUrl + "/report/testreport/20170103-143015-1234abcd/#report")
 
+    }
+
+    @Test
+    fun `can deep link to tabs`()
+    {
+        startApp("auth.provider=montagu")
+
+        addUserWithPermissions(listOf(ReifiedPermission("reports.read"
+                , Scope.Global())))
+
+        insertReport("testreport", "20170103-143015-1234abcd")
+
+        loginWithMontagu()
+        driver.get(RequestHelper.webBaseUrl + "/report/testreport/20170103-143015-1234abcd/#downloads")
+
+        confirmTabActive("report-tab", false)
+        confirmTabActive("downloads-tab", true)
     }
 
     @Test


### PR DESCRIPTION
Fixes regression from the old reportle - should be able to link to a particular tab on the report page.