### PR TITLE
mrc-1290 basic admin page and route

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/RouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/RouteConfig.kt
@@ -4,6 +4,7 @@ import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.app_start.routing.api.*
 import org.vaccineimpact.orderlyweb.app_start.routing.web.*
 import org.vaccineimpact.orderlyweb.controllers.web.IndexController
+import org.vaccineimpact.orderlyweb.controllers.web.UserGroupController
 
 interface RouteConfig
 {
@@ -25,11 +26,14 @@ object WebRouteConfig : RouteConfig
     private val metricsEndpoint = WebEndpoint("/metrics/", IndexController::class, "metrics")
             .json()
 
+    private val adminEndpoint = WebEndpoint("/admin/", UserGroupController:: class, "admin")
+            .secure(setOf("*/users.manage"))
+
     override val endpoints: List<EndpointDefinition> =
             WebAuthRouteConfig.endpoints +
                     WebReportRouteConfig.endpoints +
                     WebVersionRouteConfig.endpoints +
                     WebUserRouteConfig.endpoints +
-                    WebRoleRouteConfig.endpoints + metricsEndpoint
+                    WebRoleRouteConfig.endpoints + metricsEndpoint + adminEndpoint
 }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/UserGroupController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/UserGroupController.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.orderlyweb.controllers.web
 
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.Controller
+import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.AuthorizationRepository
 import org.vaccineimpact.orderlyweb.db.OrderlyAuthorizationRepository
 import org.vaccineimpact.orderlyweb.db.OrderlyUserRepository
@@ -9,11 +10,19 @@ import org.vaccineimpact.orderlyweb.errors.MissingParameterError
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.viewmodels.AdminViewModel
+import org.vaccineimpact.orderlyweb.viewmodels.ReportVersionPageViewModel
 
 class UserGroupController(context: ActionContext,
                           private val authRepo: AuthorizationRepository) : Controller(context)
 {
     constructor(context: ActionContext) : this(context, OrderlyAuthorizationRepository())
+
+    @Template("admin.ftl")
+    fun admin(): AdminViewModel
+    {
+        return AdminViewModel(context)
+    }
 
     fun addUserGroup(): String {
         val name = context.postData()["name"] ?: throw MissingParameterError("name")

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AdminViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AdminViewModel.kt
@@ -1,0 +1,15 @@
+package org.vaccineimpact.orderlyweb.viewmodels
+
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.db.AppConfig
+
+data class AdminViewModel(val appViewModel: AppViewModel)
+    : AppViewModel by appViewModel
+{
+    constructor(context: ActionContext) : this(DefaultViewModel(context, IndexViewModel.breadcrumb, breadcrumb))
+
+    companion object
+    {
+        val breadcrumb = Breadcrumb("Admin", "${AppConfig()["app.url"]}/admin")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/AdminPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/AdminPageTests.kt
@@ -1,0 +1,31 @@
+package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
+
+import org.assertj.core.api.Assertions
+import org.jsoup.Jsoup
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
+
+class AdminPageTests : IntegrationTest()
+{
+    private val manageUsers = setOf(ReifiedPermission("users.manage", Scope.Global()))
+
+    @Test
+    fun `only user managers can see the page`()
+    {
+        val url = "/admin"
+        assertWebUrlSecured(url, manageUsers)
+    }
+
+    @Test
+    fun `correct page is served`()
+    {
+        val sessionCookie = webRequestHelper.webLoginWithMontagu(manageUsers)
+        val response = webRequestHelper.requestWithSessionCookie("/", sessionCookie)
+        Assertions.assertThat(response.statusCode).isEqualTo(200)
+
+        val page = Jsoup.parse(response.text)
+        Assertions.assertThat(page.selectFirst("h1").text()).isEqualTo("Manage users, roles and permissions")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/AdminPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/AdminPageTests.kt
@@ -22,7 +22,7 @@ class AdminPageTests : IntegrationTest()
     fun `correct page is served`()
     {
         val sessionCookie = webRequestHelper.webLoginWithMontagu(manageUsers)
-        val response = webRequestHelper.requestWithSessionCookie("/", sessionCookie)
+        val response = webRequestHelper.requestWithSessionCookie("/admin", sessionCookie)
         Assertions.assertThat(response.statusCode).isEqualTo(200)
 
         val page = Jsoup.parse(response.text)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/UserGroupControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/UserGroupControllerTests.kt
@@ -9,12 +9,11 @@ import org.mockito.internal.verification.Times
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.web.UserGroupController
 import org.vaccineimpact.orderlyweb.db.AuthorizationRepository
-import org.vaccineimpact.orderlyweb.db.UserRepository
 import org.vaccineimpact.orderlyweb.errors.MissingParameterError
-import org.vaccineimpact.orderlyweb.models.User
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
-import org.vaccineimpact.orderlyweb.models.permissions.Role
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+import org.vaccineimpact.orderlyweb.viewmodels.Breadcrumb
+import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 
 class UserGroupControllerTests : TeamcityTests()
 {
@@ -112,6 +111,15 @@ class UserGroupControllerTests : TeamcityTests()
 
         val sut = UserGroupController(actionContext, mock())
         Assertions.assertThatThrownBy { sut.addUserGroup() }.isInstanceOf(MissingParameterError::class.java)
+    }
+
+    @Test
+    fun `returns correct breadcrumbs for admin page`()
+    {
+        val sut = UserGroupController(mock(), mock())
+        val model = sut.admin()
+        assertThat(model.breadcrumbs).containsExactly(IndexViewModel.breadcrumb,
+                Breadcrumb("Admin", "http://localhost:8888/admin"))
     }
 
 }

--- a/src/app/templates/admin.ftl
+++ b/src/app/templates/admin.ftl
@@ -1,0 +1,8 @@
+<@layout>
+    <#macro styles>
+        <link rel="stylesheet" href="${appUrl}/css/style.min.css"/>
+    </#macro>
+    <h1>Manage users, roles and permissions</h1>
+    <#macro scripts>
+    </#macro>
+</@layout>


### PR DESCRIPTION
Adding an admin page template and route. The VM has nothing in it because I figured we'd retrieve the roles etc asynchronously via the Vue components.

This doesn't really depend on https://github.com/vimc/orderly-web/pull/123 but I accidentally branched off of it so that one should be merged first!