### PR TITLE
small refactor: rename addPermission to addReportReader

### DIFF
--- a/src/app/static/src/js/components/permissions/addReportReader.vue
+++ b/src/app/static/src/js/components/permissions/addReportReader.vue
@@ -19,8 +19,8 @@
     import ErrorInfo from "../errorInfo.vue";
 
     export default {
-        name: 'addPermission',
-        props: ['permission', 'availableUserGroups', 'type'],
+        name: 'addReportReader',
+        props: ['reportName', 'availableUserGroups', 'type'],
         data() {
             return {
                 newUserGroup: "",
@@ -52,7 +52,9 @@
                 }
 
                 const data = {
-                    ...this.permission,
+                    name: "reports.read",
+                    scope_prefix: "report",
+                    scope_id: this.reportName,
                     action: "add"
                 };
 

--- a/src/app/static/src/js/components/permissions/roleList.vue
+++ b/src/app/static/src/js/components/permissions/roleList.vue
@@ -35,7 +35,7 @@
 
     export default {
         name: 'roleList',
-        props: ["roles", "canRemoveRoles", "canRemoveMembers", "canAddMembers", "permission", "availableUsers"],
+        props: ["roles", "canRemoveRoles", "canRemoveMembers", "canAddMembers", "availableUsers"],
         data() {
             return {
                 error: null,

--- a/src/app/static/src/js/components/permissions/roleList.vue
+++ b/src/app/static/src/js/components/permissions/roleList.vue
@@ -35,7 +35,7 @@
 
     export default {
         name: 'roleList',
-        props: ["roles", "canRemoveRoles", "canRemoveMembers", "canAddMembers", "availableUsers"],
+        props: ["roles", "canRemoveRoles", "canRemoveMembers", "canAddMembers", "availableUsers", "permission"],
         data() {
             return {
                 error: null,

--- a/src/app/static/src/js/components/reports/globalReportReadersList.vue
+++ b/src/app/static/src/js/components/reports/globalReportReadersList.vue
@@ -8,10 +8,8 @@
 
 <script>
     import {api} from "../../utils/api";
-    import VueBootstrapTypeahead from 'vue-bootstrap-typeahead'
     import ErrorInfo from "../errorInfo.vue";
     import UserList from "../permissions/userList.vue";
-    import AddPermission from "../permissions/addPermission.vue";
 
     export default {
         name: 'globalReportReadersList',

--- a/src/app/static/src/js/components/reports/reportReadersList.vue
+++ b/src/app/static/src/js/components/reports/reportReadersList.vue
@@ -1,9 +1,9 @@
 <template>
     <div id="scoped-report-readers-list">
-        <add-permission :permission="permission"
-                        type="user"
-                        :available-user-groups="availableUsers"
-                        @added="getReaders"></add-permission>
+        <add-report-reader :report-name="report.name"
+                           type="user"
+                           :available-user-groups="availableUsers"
+                           @added="getReaders"></add-report-reader>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>
         <user-list :users="readers"
                    :can-remove="true"
@@ -16,7 +16,7 @@
     import VueBootstrapTypeahead from 'vue-bootstrap-typeahead'
     import ErrorInfo from "../errorInfo.vue";
     import UserList from "../permissions/userList.vue";
-    import AddPermission from "../permissions/addPermission.vue";
+    import AddReportReader from "../permissions/addReportReader";
 
     export default {
         name: 'reportReadersList',
@@ -34,7 +34,7 @@
             this.getUserEmails();
         },
         components: {
-            AddPermission,
+            AddReportReader,
             UserList,
             ErrorInfo,
             VueBootstrapTypeahead
@@ -43,13 +43,6 @@
             availableUsers: function () {
                 return this.allUsers.filter(x =>
                     !(new Set(this.readers.map(r => r.email))).has(x));
-            },
-            permission: function () {
-                return {
-                    name: "reports.read",
-                    scope_prefix: "report",
-                    scope_id: this.report.name
-                };
             }
         },
         methods: {
@@ -69,7 +62,7 @@
                         this.defaultMessage = "could not fetch list of users";
                     })
             },
-            removeUser: function(email) {
+            removeUser: function (email) {
                 const data = {
                     ...this.permission,
                     action: "remove"

--- a/src/app/static/src/js/components/reports/reportReadersList.vue
+++ b/src/app/static/src/js/components/reports/reportReadersList.vue
@@ -43,6 +43,13 @@
             availableUsers: function () {
                 return this.allUsers.filter(x =>
                     !(new Set(this.readers.map(r => r.email))).has(x));
+            },
+            permission: function () {
+                return {
+                    name: "reports.read",
+                    scope_prefix: "report",
+                    scope_id: this.report.name
+                }
             }
         },
         methods: {

--- a/src/app/static/src/js/components/reports/scopedReportReaderRolesList.vue
+++ b/src/app/static/src/js/components/reports/scopedReportReaderRolesList.vue
@@ -34,6 +34,13 @@
             availableRoles: function () {
                 return this.allRoles.filter(x =>
                     !(new Set(this.currentRoles.map(r => r.name))).has(x));
+            },
+            permission: function () {
+                return {
+                    name: "reports.read",
+                    scope_prefix: "report",
+                    scope_id: this.report.name
+                }
             }
         },
         methods: {

--- a/src/app/static/src/js/components/reports/scopedReportReaderRolesList.vue
+++ b/src/app/static/src/js/components/reports/scopedReportReaderRolesList.vue
@@ -1,9 +1,9 @@
 <template>
     <div id="scoped-roles-list">
-        <add-permission :permission="permission"
-                        type="role"
-                        :available-user-groups="availableRoles"
-                        @added="getCurrentRoles"></add-permission>
+        <add-report-reader :report-name="report.name"
+                           type="role"
+                           :available-user-groups="availableRoles"
+                           @added="getCurrentRoles"></add-report-reader>
         <role-list :can-remove-members="false"
                    :can-remove-roles="true"
                    :roles="currentRoles"
@@ -15,7 +15,7 @@
 <script>
     import {api} from "../../utils/api";
     import RoleList from "../permissions/roleList.vue";
-    import AddPermission from "../permissions/addPermission.vue";
+    import AddReportReader from "../permissions/addReportReader";
 
     export default {
         name: 'scopedReaderRolesList',
@@ -34,13 +34,6 @@
             availableRoles: function () {
                 return this.allRoles.filter(x =>
                     !(new Set(this.currentRoles.map(r => r.name))).has(x));
-            },
-            permission: function () {
-                return {
-                    name: "reports.read",
-                    scope_prefix: "report",
-                    scope_id: this.report.name
-                }
             }
         },
         methods: {
@@ -58,8 +51,8 @@
             }
         },
         components: {
-            RoleList,
-            AddPermission
+            AddReportReader,
+            RoleList
         }
     };
 

--- a/src/app/static/src/tests/components/permissions/addReportReader.test.js
+++ b/src/app/static/src/tests/components/permissions/addReportReader.test.js
@@ -1,10 +1,10 @@
 import {mount} from '@vue/test-utils';
-import AddPermission from "../../../js/components/permissions/addPermission.vue";
+import AddReportReader from "../../../js/components/permissions/addReportReader.vue";
 import ErrorInfo from "../../../js/components/errorInfo.vue";
 import {mockAxios} from "../../mockAxios";
 import Vue from "vue";
 
-describe("addPermission", () => {
+describe("addReportReader", () => {
 
     const availableUserGroups = [
         "testGroup1",
@@ -24,13 +24,9 @@ describe("addPermission", () => {
     }
 
     function createSut(type) {
-        return mount(AddPermission, {
+        return mount(AddReportReader, {
             propsData: {
-                permission: {
-                    name: "reports.read",
-                    scope_prefix: "report",
-                    scope_id: "report1"
-                },
+                reportName: "report1",
                 availableUserGroups: availableUserGroups,
                 type: type
             }

--- a/src/app/static/src/tests/components/reports/reportReadersList.test.js
+++ b/src/app/static/src/tests/components/reports/reportReadersList.test.js
@@ -3,7 +3,7 @@ import {mount, shallowMount} from '@vue/test-utils';
 import ReportReadersList from "../../../js/components/reports/reportReadersList.vue";
 import ErrorInfo from "../../../js/components/errorInfo.vue";
 import UserList from "../../../js/components/permissions/userList.vue";
-import AddPermission from "../../../js/components/permissions/addPermission.vue";
+import AddReportReader from "../../../js/components/permissions/addReportReader.vue";
 import {mockAxios} from "../../mockAxios";
 
 describe("reportReadersList", () => {
@@ -63,7 +63,7 @@ describe("reportReadersList", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(AddPermission).props().type).toBe("user");
+        expect(wrapper.find(AddReportReader).props().type).toBe("user");
         expect(wrapper.find(UserList).props().canRemove).toBe(true);
         expect(wrapper.find(ErrorInfo).props().apiError).toBe("test error");
         expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("default error");
@@ -85,7 +85,7 @@ describe("reportReadersList", () => {
 
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(2);
-            expect(wrapper.find(AddPermission).props().availableUserGroups)
+            expect(wrapper.find(AddReportReader).props().availableUserGroups)
                 .toEqual(expect.arrayContaining(userEmails));
 
             expectWrapperToHaveRenderedReaders(wrapper);
@@ -241,8 +241,8 @@ describe("reportReadersList", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(AddPermission).props().availableUserGroups.length).toBe(1);
-        expect(wrapper.find(AddPermission).props().availableUserGroups[0]).toBe("another.user@example.com");
+        expect(wrapper.find(AddReportReader).props().availableUserGroups.length).toBe(1);
+        expect(wrapper.find(AddReportReader).props().availableUserGroups[0]).toBe("another.user@example.com");
     });
 
 });

--- a/src/app/static/src/tests/components/reports/scopedReaderRolesList.test.js
+++ b/src/app/static/src/tests/components/reports/scopedReaderRolesList.test.js
@@ -65,6 +65,12 @@ describe("scopedReaderRolesList", () => {
         expect(wrapper.find(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
         expect(wrapper.find(RoleList).props().canRemoveRoles).toBe(true);
         expect(wrapper.find(RoleList).props().canRemoveMembers).toBe(false);
+        expect(wrapper.find(RoleList).props().permission).toStrictEqual({
+            name: "reports.read",
+            scope_id : "report1",
+            scope_prefix: "report"
+        });
+
     });
 
     it('renders add report reader component', async () => {

--- a/src/app/static/src/tests/components/reports/scopedReaderRolesList.test.js
+++ b/src/app/static/src/tests/components/reports/scopedReaderRolesList.test.js
@@ -2,7 +2,7 @@ import {mount} from '@vue/test-utils';
 import ScopedReaderRoleList from "../../../js/components/reports/scopedReportReaderRolesList.vue";
 import {mockAxios} from "../../mockAxios";
 import RoleList from "../../../js/components/permissions/roleList.vue"
-import AddPermission from "../../../js/components/permissions/addPermission.vue";
+import AddReportReader from "../../../js/components/permissions/addReportReader.vue";
 import Vue from "vue";
 
 describe("scopedReaderRolesList", () => {
@@ -65,15 +65,9 @@ describe("scopedReaderRolesList", () => {
         expect(wrapper.find(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
         expect(wrapper.find(RoleList).props().canRemoveRoles).toBe(true);
         expect(wrapper.find(RoleList).props().canRemoveMembers).toBe(false);
-        expect(wrapper.find(RoleList).props().permission).toStrictEqual({
-            name: "reports.read",
-            scope_id : "report1",
-            scope_prefix: "report"
-        });
-
     });
 
-    it('renders add permission component', async () => {
+    it('renders add report reader component', async () => {
 
         const wrapper = getSut();
 
@@ -84,16 +78,10 @@ describe("scopedReaderRolesList", () => {
 
         await Vue.nextTick();
 
-        const expectedPermission = {
-            name: "reports.read",
-            scope_prefix: "report",
-            scope_id: "report1"
-        };
-
-        expect(wrapper.find(AddPermission).props().type).toBe("role");
-        expect(wrapper.find(AddPermission).props().permission).toStrictEqual(expectedPermission);
-        expect(wrapper.find(AddPermission).props().availableUserGroups.length).toBe(2);
-        expect(wrapper.find(AddPermission).props().availableUserGroups)
+        expect(wrapper.find(AddReportReader).props().type).toBe("role");
+        expect(wrapper.find(AddReportReader).props().reportName).toBe("report1");
+        expect(wrapper.find(AddReportReader).props().availableUserGroups.length).toBe(2);
+        expect(wrapper.find(AddReportReader).props().availableUserGroups)
             .toEqual(expect.arrayContaining(["Tech", "Admin"]));
 
     });
@@ -158,7 +146,7 @@ describe("scopedReaderRolesList", () => {
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(2);
             expect(wrapper.find(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
-            expect(wrapper.find(AddPermission).props().availableUserGroups)
+            expect(wrapper.find(AddReportReader).props().availableUserGroups)
                 .toEqual(expect.arrayContaining(["Tech", "Admin"]));
 
             done();


### PR DESCRIPTION
A rename and slight refactor of the existing `addPermission` vue component to the more appropriate `addReportReader`.