### PR TITLE
RESTful refactor

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
@@ -10,7 +10,7 @@ import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.errors.MissingParameterError
 import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
 import org.vaccineimpact.orderlyweb.models.Scope
-import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionDTO
 import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.security.authorization.orderlyWebPermissions
@@ -115,7 +115,7 @@ open class DirectActionContext(private val context: SparkWebContext,
 fun ActionContext.permissionFromPostData(): ReifiedPermission
 {
     val postData = this.postData()
-    val associatePermission = AssociatePermission(
+    val associatePermission = PermissionDTO(
             postData["name"] ?: throw MissingParameterError("name"),
             postData["scope_prefix"],
             postData["scope_id"]

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
@@ -124,3 +124,10 @@ fun ActionContext.permissionFromPostData(): ReifiedPermission
     return ReifiedPermission(associatePermission.name,
             Scope.parse(associatePermission))
 }
+
+fun ActionContext.permissionFromRouteParams(): ReifiedPermission {
+    val name = this.params(":name")
+    val scopePrefix = this.queryParams("scopePrefix")
+    val scopeId = this.queryParams("scopeId")
+    return ReifiedPermission(name, Scope.parse(scopePrefix, scopeId))
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
@@ -5,20 +5,21 @@ import com.google.gson.GsonBuilder
 import org.pac4j.core.profile.CommonProfile
 import org.pac4j.core.profile.ProfileManager
 import org.pac4j.sparkjava.SparkWebContext
-import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.errors.MissingParameterError
 import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
 import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
 import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.security.authorization.orderlyWebPermissions
 import spark.Request
 import spark.Response
 
 open class DirectActionContext(private val context: SparkWebContext,
                                private val appConfig: Config = AppConfig(),
-                               private val profileManager: ProfileManager<CommonProfile>? = null ) : ActionContext
+                               private val profileManager: ProfileManager<CommonProfile>? = null) : ActionContext
 {
     private val request
         get() = context.sparkRequest
@@ -49,7 +50,7 @@ open class DirectActionContext(private val context: SparkWebContext,
     }
 
     override val permissions by lazy {
-        userProfile?.orderlyWebPermissions?: PermissionSet()
+        userProfile?.orderlyWebPermissions ?: PermissionSet()
     }
 
     override fun isGlobalReader() = hasPermission(ReifiedPermission("reports.read", Scope.Global()))
@@ -109,4 +110,17 @@ open class DirectActionContext(private val context: SparkWebContext,
     {
         return postData()[key] ?: throw MissingParameterError(key);
     }
+}
+
+fun ActionContext.permissionFromPostData(): ReifiedPermission
+{
+    val postData = this.postData()
+    val associatePermission = AssociatePermission(
+            postData["name"] ?: throw MissingParameterError("name"),
+            postData["scope_prefix"],
+            postData["scope_id"]
+    )
+
+    return ReifiedPermission(associatePermission.name,
+            Scope.parse(associatePermission))
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebRoleRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebRoleRouteConfig.kt
@@ -50,9 +50,15 @@ object WebRoleRouteConfig : RouteConfig
                     .json()
                     .transform()
                     .secure(usersManage),
-            WebEndpoint("/roles/:role-id/actions/associate-permission/",
-                    RoleController::class, "associatePermission",
+            WebEndpoint("/roles/:role-id/permissions/",
+                    RoleController::class, "addPermission",
                     method = HttpMethod.post)
+                    .json()
+                    .transform()
+                    .secure(usersManage),
+            WebEndpoint("/roles/:role-id/permissions/:name",
+                    RoleController::class, "removePermission",
+                    method = HttpMethod.delete)
                     .json()
                     .transform()
                     .secure(usersManage)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebUserRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebUserRouteConfig.kt
@@ -36,6 +36,18 @@ object WebUserRouteConfig : RouteConfig
                     contentType = ContentTypes.json)
                     .json()
                     .transform()
+                    .secure(usersManage),
+            WebEndpoint("/users/:user-id/permissions/",
+                    UserController::class, "addPermission",
+                    method = HttpMethod.post)
+                    .json()
+                    .transform()
+                    .secure(usersManage),
+            WebEndpoint("/users/:user-id/permissions/:name",
+                    UserController::class, "removePermission",
+                    method = HttpMethod.delete)
+                    .json()
+                    .transform()
                     .secure(usersManage)
     )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebUserRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebUserRouteConfig.kt
@@ -25,12 +25,6 @@ object WebUserRouteConfig : RouteConfig
                     .json()
                     .transform()
                     .secure(usersManage),
-            WebEndpoint("/users/:user-id/actions/associate-permission/",
-                    UserController::class, "associatePermission",
-                    method = HttpMethod.post)
-                    .json()
-                    .transform()
-                    .secure(usersManage),
             WebEndpoint("/typeahead/emails/",
                     UserController::class, "getUserEmails",
                     contentType = ContentTypes.json)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/AdminController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/AdminController.kt
@@ -2,15 +2,7 @@ package org.vaccineimpact.orderlyweb.controllers.web
 
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.Controller
-import org.vaccineimpact.orderlyweb.db.AppConfig
-import org.vaccineimpact.orderlyweb.db.AuthorizationRepository
-import org.vaccineimpact.orderlyweb.db.OrderlyAuthorizationRepository
-import org.vaccineimpact.orderlyweb.errors.MissingParameterError
-import org.vaccineimpact.orderlyweb.models.Scope
-import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
-import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.viewmodels.AdminViewModel
-import org.vaccineimpact.orderlyweb.viewmodels.ReportVersionPageViewModel
 
 class AdminController(context: ActionContext) : Controller(context)
 {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/RoleController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/RoleController.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.models.permissions.Role
 import org.vaccineimpact.orderlyweb.permissionFromPostData
+import org.vaccineimpact.orderlyweb.permissionFromRouteParams
 import org.vaccineimpact.orderlyweb.viewmodels.RoleViewModel
 
 class RoleController(context: ActionContext,
@@ -58,10 +59,7 @@ class RoleController(context: ActionContext,
     fun removePermission(): String
     {
         val roleId = roleId()
-        val name = context.params(":name")
-        val scopePrefix = context.queryParams("scopePrefix")
-        val scopeId = context.queryParams("scopeId")
-        val permission = ReifiedPermission(name, Scope.parse(scopePrefix, scopeId))
+        val permission = context.permissionFromRouteParams()
         authRepo.ensureUserGroupDoesNotHavePermission(roleId, permission)
 
         return okayResponse()

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/RoleController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/RoleController.kt
@@ -2,11 +2,11 @@ package org.vaccineimpact.orderlyweb.controllers.web
 
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.Controller
-import org.vaccineimpact.orderlyweb.db.*
+import org.vaccineimpact.orderlyweb.db.AuthorizationRepository
+import org.vaccineimpact.orderlyweb.db.OrderlyAuthorizationRepository
+import org.vaccineimpact.orderlyweb.db.OrderlyRoleRepository
+import org.vaccineimpact.orderlyweb.db.RoleRepository
 import org.vaccineimpact.orderlyweb.errors.MissingParameterError
-import org.vaccineimpact.orderlyweb.models.Scope
-import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
-import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.models.permissions.Role
 import org.vaccineimpact.orderlyweb.permissionFromPostData
 import org.vaccineimpact.orderlyweb.permissionFromRouteParams

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/UserController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/UserController.kt
@@ -12,6 +12,7 @@ import org.vaccineimpact.orderlyweb.models.User
 import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.permissionFromPostData
+import org.vaccineimpact.orderlyweb.permissionFromRouteParams
 import org.vaccineimpact.orderlyweb.viewmodels.UserViewModel
 
 class UserController(context: ActionContext,
@@ -65,10 +66,7 @@ class UserController(context: ActionContext,
     fun removePermission(): String
     {
         val userId = userId()
-        val name = context.params(":name")
-        val scopePrefix = context.queryParams("scopePrefix")
-        val scopeId = context.queryParams("scopeId")
-        val permission = ReifiedPermission(name, Scope.parse(scopePrefix, scopeId))
+        val permission = context.permissionFromRouteParams()
         authRepo.ensureUserGroupDoesNotHavePermission(userId, permission)
 
         return okayResponse()

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/UserController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/UserController.kt
@@ -6,11 +6,7 @@ import org.vaccineimpact.orderlyweb.db.AuthorizationRepository
 import org.vaccineimpact.orderlyweb.db.OrderlyAuthorizationRepository
 import org.vaccineimpact.orderlyweb.db.OrderlyUserRepository
 import org.vaccineimpact.orderlyweb.db.UserRepository
-import org.vaccineimpact.orderlyweb.errors.MissingParameterError
-import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.User
-import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
-import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.permissionFromPostData
 import org.vaccineimpact.orderlyweb.permissionFromRouteParams
 import org.vaccineimpact.orderlyweb.viewmodels.UserViewModel

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Scope.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Scope.kt
@@ -58,14 +58,26 @@ sealed class Scope(val value: String)
 
         fun parse(associatePermission: AssociatePermission): Scope
         {
-            if (associatePermission.scopePrefix.isNullOrEmpty())
+            return if (associatePermission.scopePrefix.isNullOrEmpty())
             {
-                return Scope.Global()
+                Scope.Global()
             }
             else
             {
 
-                return Scope.Specific(associatePermission.scopePrefix, associatePermission.scopeId!!)
+                Scope.Specific(associatePermission.scopePrefix, associatePermission.scopeId!!)
+            }
+        }
+
+        fun parse(scopePrefix: String?, scopeId: String?): Scope
+        {
+            return if (scopePrefix.isNullOrEmpty())
+            {
+                Global()
+            }
+            else
+            {
+                Specific(scopePrefix, scopeId!!)
             }
         }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Scope.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Scope.kt
@@ -1,6 +1,6 @@
 package org.vaccineimpact.orderlyweb.models
 
-import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionDTO
 
 sealed class Scope(val value: String)
 {
@@ -56,16 +56,16 @@ sealed class Scope(val value: String)
             }
         }
 
-        fun parse(associatePermission: AssociatePermission): Scope
+        fun parse(permissionDTO: PermissionDTO): Scope
         {
-            return if (associatePermission.scopePrefix.isNullOrEmpty())
+            return if (permissionDTO.scopePrefix.isNullOrEmpty())
             {
                 Scope.Global()
             }
             else
             {
 
-                Scope.Specific(associatePermission.scopePrefix, associatePermission.scopeId!!)
+                Scope.Specific(permissionDTO.scopePrefix, permissionDTO.scopeId!!)
             }
         }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/AssociatePermission.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/AssociatePermission.kt
@@ -1,5 +1,0 @@
-package org.vaccineimpact.orderlyweb.models.permissions
-
-data class AssociatePermission(val name: String,
-                               val scopePrefix: String?,
-                               val scopeId: String?)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/AssociatePermission.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/AssociatePermission.kt
@@ -1,6 +1,5 @@
 package org.vaccineimpact.orderlyweb.models.permissions
 
-data class AssociatePermission(val action: String,
-                         val name: String,
-                         val scopePrefix: String?,
-                         val scopeId: String?)
+data class AssociatePermission(val name: String,
+                               val scopePrefix: String?,
+                               val scopeId: String?)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/PermissionDTO.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/permissions/PermissionDTO.kt
@@ -1,0 +1,5 @@
+package org.vaccineimpact.orderlyweb.models.permissions
+
+data class PermissionDTO(val name: String,
+                         val scopePrefix: String?,
+                         val scopeId: String?)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RolesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RolesTests.kt
@@ -83,7 +83,7 @@ class RolesTests : IntegrationTest()
         assertWebUrlSecured(url, setOf(ReifiedPermission("users.manage", Scope.Global())),
                 contentType = ContentTypes.json)
     }
-    
+
     @Test
     fun `only user managers can add new user groups`()
     {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RolesTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RolesTests.kt
@@ -1,7 +1,9 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ContentTypes
+import org.vaccineimpact.orderlyweb.db.OrderlyAuthorizationRepository
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.tests.addMembers
@@ -83,17 +85,6 @@ class RolesTests : IntegrationTest()
     }
 
     @Test
-    fun `only user managers can associate permission`()
-    {
-        createGroup("Funder", ReifiedPermission("reports.read", Scope.Global()))
-        val url = "/roles/Funders/actions/associate-permission/"
-
-        assertWebUrlSecured(url, setOf(ReifiedPermission("users.manage", Scope.Global())),
-                contentType = ContentTypes.json, method = HttpMethod.post, postData = mapOf("action" to "add",
-                "name" to "users.manage"))
-    }
-
-    @Test
     fun `only user managers can add new user groups`()
     {
         val url = "/roles/"
@@ -131,5 +122,80 @@ class RolesTests : IntegrationTest()
         assertWebUrlSecured(url, setOf(ReifiedPermission("users.manage", Scope.Global())),
                 method = HttpMethod.delete, contentType = ContentTypes.json)
     }
+    @Test
+    fun `only user managers can add permission`()
+    {
+        createGroup("Funder", ReifiedPermission("reports.read", Scope.Global()))
+        val url = "/roles/Funder/permissions/"
 
+        assertWebUrlSecured(url, setOf(ReifiedPermission("users.manage", Scope.Global())),
+                contentType = ContentTypes.json, method = HttpMethod.post, postData = mapOf("name" to "users.manage"))
+    }
+
+    @Test
+    fun `only user managers can remove permission`()
+    {
+        createGroup("Funder", ReifiedPermission("reports.read", Scope.Global()))
+        val url = "/roles/Funder/permissions/reports.read/"
+
+        assertWebUrlSecured(url, setOf(ReifiedPermission("users.manage", Scope.Global())),
+                contentType = ContentTypes.json, method = HttpMethod.delete, postData = mapOf("name" to "users.manage"))
+    }
+
+    @Test
+    fun `can remove global permission`()
+    {
+        createGroup("Funder", ReifiedPermission("reports.read", Scope.Global()))
+
+        var perms = OrderlyAuthorizationRepository().getPermissionsForGroup("Funder")
+        assertThat(perms.count()).isEqualTo(1)
+
+        val url = "/roles/Funder/permissions/reports.read/"
+
+        webRequestHelper.loginWithMontaguAndMakeRequest(url,
+                setOf(ReifiedPermission("users.manage", Scope.Global())),
+                method = HttpMethod.delete,
+                contentType = ContentTypes.json)
+
+        perms = OrderlyAuthorizationRepository().getPermissionsForGroup("Funder")
+        assertThat(perms.count()).isEqualTo(0)
+    }
+
+    @Test
+    fun `can remove specific permission`()
+    {
+        createGroup("Funder", ReifiedPermission("reports.read", Scope.Specific("report", "minimal")))
+
+        var perms = OrderlyAuthorizationRepository().getPermissionsForGroup("Funder")
+        assertThat(perms.count()).isEqualTo(1)
+
+        val url = "/roles/Funder/permissions/reports.read/?scopePrefix=report&scopeId=minimal"
+
+        webRequestHelper.loginWithMontaguAndMakeRequest(url,
+                setOf(ReifiedPermission("users.manage", Scope.Global())),
+                method = HttpMethod.delete,
+                contentType = ContentTypes.json)
+
+        perms = OrderlyAuthorizationRepository().getPermissionsForGroup("Funder")
+        assertThat(perms.count()).isEqualTo(0)
+    }
+
+    @Test
+    fun `can add permission`()
+    {
+        createGroup("Funder", ReifiedPermission("reports.read", Scope.Global()))
+
+        var perms = OrderlyAuthorizationRepository().getPermissionsForGroup("Funder")
+        assertThat(perms.count()).isEqualTo(1)
+
+        val url = "/roles/Funder/permissions/"
+
+        webRequestHelper.loginWithMontaguAndMakeRequest(url,
+                setOf(ReifiedPermission("users.manage", Scope.Global())),
+                method = HttpMethod.post, postData = mapOf("name" to "users.manage"),
+                contentType = ContentTypes.json)
+
+        perms = OrderlyAuthorizationRepository().getPermissionsForGroup("Funder")
+        assertThat(perms.count()).isEqualTo(2)
+    }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/UsersTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/UsersTests.kt
@@ -1,15 +1,15 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
 
+import org.assertj.core.api.Assertions
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ContentTypes
+import org.vaccineimpact.orderlyweb.db.OrderlyAuthorizationRepository
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
-import org.vaccineimpact.orderlyweb.tests.addMembers
-import org.vaccineimpact.orderlyweb.tests.createGroup
+import org.vaccineimpact.orderlyweb.tests.giveUserGroupPermission
 import org.vaccineimpact.orderlyweb.tests.insertUser
 import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
 import spark.route.HttpMethod
-import java.net.URLEncoder
 
 class UsersTests : IntegrationTest()
 {
@@ -36,7 +36,6 @@ class UsersTests : IntegrationTest()
         JSONValidator.validateAgainstSchema(response.text, "Users")
     }
 
-
     @Test
     fun `only user managers can get report readers`()
     {
@@ -47,12 +46,81 @@ class UsersTests : IntegrationTest()
     }
 
     @Test
-    fun `only user managers can associate permission`()
+    fun `only user managers can add permission`()
     {
-        val url = "/users/test.user%40example.com/actions/associate-permission/"
+        val url = "/users/test.user%40example.com/permissions/"
 
         assertWebUrlSecured(url, setOf(ReifiedPermission("users.manage", Scope.Global())),
-                contentType = ContentTypes.json, method = HttpMethod.post, postData = mapOf("action" to "add",
-                "name" to "users.manage"))
+                contentType = ContentTypes.json, method = HttpMethod.post, postData = mapOf("name" to "users.manage"))
+    }
+
+    @Test
+    fun `only user managers can remove permission`()
+    {
+        insertUser("a.user", "A user")
+        giveUserGroupPermission("a.user", "reports.read", Scope.Global())
+        val url = "/users/a.user/permissions/reports.read"
+
+        assertWebUrlSecured(url, setOf(ReifiedPermission("users.manage", Scope.Global())),
+                contentType = ContentTypes.json, method = HttpMethod.delete, postData = mapOf("name" to "users.manage"))
+    }
+
+    @Test
+    fun `can remove global permission`()
+    {
+        insertUser("a.user", "A user")
+        giveUserGroupPermission("a.user", "reports.read", Scope.Global())
+
+        var perms = OrderlyAuthorizationRepository().getPermissionsForGroup("a.user")
+        Assertions.assertThat(perms.count()).isEqualTo(1)
+
+        val url = "/users/a.user/permissions/reports.read/"
+
+        webRequestHelper.loginWithMontaguAndMakeRequest(url,
+                setOf(ReifiedPermission("users.manage", Scope.Global())),
+                method = HttpMethod.delete,
+                contentType = ContentTypes.json)
+
+        perms = OrderlyAuthorizationRepository().getPermissionsForGroup("a.user")
+        Assertions.assertThat(perms.count()).isEqualTo(0)
+    }
+
+    @Test
+    fun `can remove specific permission`()
+    {
+        insertUser("a.user", "A user")
+        giveUserGroupPermission("a.user", "reports.read", Scope.Specific("report", "minimal"))
+
+        var perms = OrderlyAuthorizationRepository().getPermissionsForGroup("a.user")
+        Assertions.assertThat(perms.count()).isEqualTo(1)
+
+        val url = "/users/a.user/permissions/reports.read/?scopePrefix=report&scopeId=minimal"
+
+        webRequestHelper.loginWithMontaguAndMakeRequest(url,
+                setOf(ReifiedPermission("users.manage", Scope.Global())),
+                method = HttpMethod.delete,
+                contentType = ContentTypes.json)
+
+        perms = OrderlyAuthorizationRepository().getPermissionsForGroup("a.user")
+        Assertions.assertThat(perms.count()).isEqualTo(0)
+    }
+
+    @Test
+    fun `can add permission`()
+    {
+        insertUser("a.user", "A user")
+
+        var perms = OrderlyAuthorizationRepository().getPermissionsForGroup("a.user")
+        Assertions.assertThat(perms.count()).isEqualTo(0)
+
+        val url = "/users/a.user/permissions/"
+
+        webRequestHelper.loginWithMontaguAndMakeRequest(url,
+                setOf(ReifiedPermission("users.manage", Scope.Global())),
+                method = HttpMethod.post, postData = mapOf("name" to "users.manage"),
+                contentType = ContentTypes.json)
+
+        perms = OrderlyAuthorizationRepository().getPermissionsForGroup("a.user")
+        Assertions.assertThat(perms.count()).isEqualTo(1)
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/RoleControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/RoleControllerTests.kt
@@ -227,7 +227,6 @@ class RoleControllerTests : TeamcityTests()
         val actionContext = mock<ActionContext> {
             on { this.params(":role-id") } doReturn "test"
             on { this.postData() } doReturn mapOf(
-                    "action" to "add",
                     "name" to "test.permission",
                     "scope_prefix" to "report",
                     "scope_id" to "report1"
@@ -236,7 +235,7 @@ class RoleControllerTests : TeamcityTests()
 
         val authRepo = mock<AuthorizationRepository>()
         val sut = RoleController(actionContext, mock(), authRepo)
-        val result = sut.associatePermission()
+        val result = sut.addPermission()
 
         assertThat(result).isEqualTo("OK")
 
@@ -244,8 +243,8 @@ class RoleControllerTests : TeamcityTests()
         verify(authRepo).ensureUserGroupHasPermission(eq("test"), capture(permissionCaptor))
 
         val permission = permissionCaptor.value
-        Assertions.assertThat(permission.name).isEqualTo("test.permission")
-        Assertions.assertThat(permission.scope.value).isEqualTo("report:report1")
+        assertThat(permission.name).isEqualTo("test.permission")
+        assertThat(permission.scope.value).isEqualTo("report:report1")
     }
 
     @Test
@@ -254,16 +253,13 @@ class RoleControllerTests : TeamcityTests()
         val actionContext = mock<ActionContext> {
             on { this.params(":role-id") } doReturn "test"
             on { this.postData() } doReturn mapOf(
-                    "action" to "remove",
-                    "name" to "test.permission",
-                    "scope_prefix" to "report",
-                    "scope_id" to "report1"
+                    "name" to "test.permission"
             )
         }
 
         val authRepo = mock<AuthorizationRepository>()
         val sut = RoleController(actionContext, mock(), authRepo)
-        val result = sut.associatePermission()
+        val result = sut.removePermission()
 
         assertThat(result).isEqualTo("OK")
 
@@ -271,25 +267,8 @@ class RoleControllerTests : TeamcityTests()
         verify(authRepo).ensureUserGroupDoesNotHavePermission(eq("test"), capture(permissionCaptor))
 
         val permission = permissionCaptor.value
-        Assertions.assertThat(permission.name).isEqualTo("test.permission")
-        Assertions.assertThat(permission.scope.value).isEqualTo("report:report1")
-    }
-
-    @Test
-    fun `throws exception if associate permission with unknown action`()
-    {
-        val actionContext = mock<ActionContext> {
-            on { this.params(":user-group-id") } doReturn "user1@example.com"
-            on { this.postData() } doReturn mapOf(
-                    "action" to "addx",
-                    "name" to "test.permission",
-                    "scope_prefix" to "report",
-                    "scope_id" to "report1"
-            )
-        }
-
-        val sut = RoleController(actionContext, mock(), mock())
-        Assertions.assertThatThrownBy { sut.associatePermission() }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(permission.name).isEqualTo("test.permission")
+        assertThat(permission.scope.value).isEqualTo("*")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/RoleControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/RoleControllerTests.kt
@@ -248,13 +248,11 @@ class RoleControllerTests : TeamcityTests()
     }
 
     @Test
-    fun `removes permission from user group`()
+    fun `removes permission from role`()
     {
         val actionContext = mock<ActionContext> {
             on { this.params(":role-id") } doReturn "test"
-            on { this.postData() } doReturn mapOf(
-                    "name" to "test.permission"
-            )
+            on { this.params(":name") } doReturn "test.permission"
         }
 
         val authRepo = mock<AuthorizationRepository>()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/UserControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/UserControllerTests.kt
@@ -195,9 +195,8 @@ class UserControllerTests : TeamcityTests()
     {
         val actionContext = mock<ActionContext> {
             on { this.params(":user-id") } doReturn "user1@example.com"
-            on { this.postData() } doReturn mapOf(
-                    "name" to "test.permission"
-            )
+            on { this.params(":name") } doReturn "test.permission"
+
             on { this.queryParams("scopeId") } doReturn "report1"
             on { this.queryParams("scopePrefix") } doReturn "report"
         }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/models/ScopeTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/models/ScopeTests.kt
@@ -63,10 +63,10 @@ class ScopeTests: TeamcityTests()
     @Test
     fun `can parse from AssociatePermission`()
     {
-        val globalAssocPerm = AssociatePermission("add", "perm", null, null)
+        val globalAssocPerm = AssociatePermission("perm", null, null)
         assertThat(Scope.parse(globalAssocPerm)).isInstanceOf(Scope.Global::class.java)
 
-        val specificAssocPerm = AssociatePermission("add", "perm", "testPrefix", "testId")
+        val specificAssocPerm = AssociatePermission("perm", "testPrefix", "testId")
         val specificScope = Scope.parse(specificAssocPerm)
         assertThat(specificScope).isInstanceOf(Scope.Specific::class.java)
         assertThat((specificScope as Scope.Specific).databaseScopePrefix).isEqualTo("testPrefix")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/models/ScopeTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/models/ScopeTests.kt
@@ -3,7 +3,7 @@ package org.vaccineimpact.orderlyweb.tests.unit_tests.models
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.models.Scope
-import org.vaccineimpact.orderlyweb.models.permissions.AssociatePermission
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionDTO
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
 
 class ScopeTests: TeamcityTests()
@@ -63,10 +63,10 @@ class ScopeTests: TeamcityTests()
     @Test
     fun `can parse from AssociatePermission`()
     {
-        val globalAssocPerm = AssociatePermission("perm", null, null)
+        val globalAssocPerm = PermissionDTO("perm", null, null)
         assertThat(Scope.parse(globalAssocPerm)).isInstanceOf(Scope.Global::class.java)
 
-        val specificAssocPerm = AssociatePermission("perm", "testPrefix", "testId")
+        val specificAssocPerm = PermissionDTO("perm", "testPrefix", "testId")
         val specificScope = Scope.parse(specificAssocPerm)
         assertThat(specificScope).isInstanceOf(Scope.Specific::class.java)
         assertThat((specificScope as Scope.Specific).databaseScopePrefix).isEqualTo("testPrefix")

--- a/src/app/static/src/js/components/permissions/addPermission.vue
+++ b/src/app/static/src/js/components/permissions/addPermission.vue
@@ -56,7 +56,7 @@
                     action: "add"
                 };
 
-                api.post(`/${this.type}s/${encodeURIComponent(this.newUserGroup)}/actions/associate-permission/`, data)
+                api.post(`/${this.type}s/${encodeURIComponent(this.newUserGroup)}/permissions/`, data)
                     .then(() => {
                         this.newUserGroup = "";
                         this.error = null;

--- a/src/app/static/src/js/components/permissions/roleList.vue
+++ b/src/app/static/src/js/components/permissions/roleList.vue
@@ -66,7 +66,7 @@
                 const scopePrefix = this.permission.scope_prefix;
                 const query = (scopeId && scopePrefix) ? `?scopePrefix=${scopePrefix}&scopeId=${scopeId}` : "";
 
-                api.post(`/roles/${encodeURIComponent(roleName)}/permissions/${this.permission.name}/${query}`)
+                api.delete(`/roles/${encodeURIComponent(roleName)}/permissions/${this.permission.name}/${query}`)
                     .then(() => {
                         this.$emit("removed", roleName);
                         this.error = null;

--- a/src/app/static/src/js/components/permissions/roleList.vue
+++ b/src/app/static/src/js/components/permissions/roleList.vue
@@ -62,11 +62,11 @@
                     });
             },
             removeRole: function (roleName) {
-                const scopeId = this.permission.scopeId;
+                const scopeId = this.permission.scope_id;
                 const scopePrefix = this.permission.scope_prefix;
                 const query = (scopeId && scopePrefix) ? `?scopePrefix=${scopePrefix}&scopeId=${scopeId}` : "";
 
-                api.post(`/roles/${encodeURIComponent(roleName)}/actions/associate-permission/${query}`)
+                api.post(`/roles/${encodeURIComponent(roleName)}/permissions/${this.permission.name}/${query}`)
                     .then(() => {
                         this.$emit("removed", roleName);
                         this.error = null;

--- a/src/app/static/src/js/components/permissions/roleList.vue
+++ b/src/app/static/src/js/components/permissions/roleList.vue
@@ -62,11 +62,11 @@
                     });
             },
             removeRole: function (roleName) {
-                const data = {
-                    ...this.permission,
-                    action: "remove"
-                };
-                api.post(`/roles/${encodeURIComponent(roleName)}/actions/associate-permission/`, data)
+                const scopeId = this.permission.scopeId;
+                const scopePrefix = this.permission.scope_prefix;
+                const query = (scopeId && scopePrefix) ? `?scopePrefix=${scopePrefix}&scopeId=${scopeId}` : "";
+
+                api.post(`/roles/${encodeURIComponent(roleName)}/actions/associate-permission/${query}`)
                     .then(() => {
                         this.$emit("removed", roleName);
                         this.error = null;

--- a/src/app/static/src/js/components/reports/reportReadersList.vue
+++ b/src/app/static/src/js/components/reports/reportReadersList.vue
@@ -70,11 +70,11 @@
                     })
             },
             removeUser: function(email) {
-                const scopeId = this.permission.scopeId;
+                const scopeId = this.permission.scope_id;
                 const scopePrefix = this.permission.scope_prefix;
                 const query = (scopeId && scopePrefix) ? `?scopePrefix=${scopePrefix}&scopeId=${scopeId}` : "";
 
-                api.post(`/users/${encodeURIComponent(email)}/actions/associate-permission/${query}`)
+                api.post(`/users/${encodeURIComponent(email)}/permissions/${this.permission.name}/${query}`)
                     .then(() => {
                         this.getReaders();
                         this.error = null;

--- a/src/app/static/src/js/components/reports/reportReadersList.vue
+++ b/src/app/static/src/js/components/reports/reportReadersList.vue
@@ -70,11 +70,11 @@
                     })
             },
             removeUser: function(email) {
-                const data = {
-                    ...this.permission,
-                    action: "remove"
-                };
-                api.post(`/users/${encodeURIComponent(email)}/actions/associate-permission/`, data)
+                const scopeId = this.permission.scopeId;
+                const scopePrefix = this.permission.scope_prefix;
+                const query = (scopeId && scopePrefix) ? `?scopePrefix=${scopePrefix}&scopeId=${scopeId}` : "";
+
+                api.post(`/users/${encodeURIComponent(email)}/actions/associate-permission/${query}`)
                     .then(() => {
                         this.getReaders();
                         this.error = null;

--- a/src/app/static/src/js/components/reports/reportReadersList.vue
+++ b/src/app/static/src/js/components/reports/reportReadersList.vue
@@ -74,7 +74,7 @@
                 const scopePrefix = this.permission.scope_prefix;
                 const query = (scopeId && scopePrefix) ? `?scopePrefix=${scopePrefix}&scopeId=${scopeId}` : "";
 
-                api.post(`/users/${encodeURIComponent(email)}/permissions/${this.permission.name}/${query}`)
+                api.delete(`/users/${encodeURIComponent(email)}/permissions/${this.permission.name}/${query}`)
                     .then(() => {
                         this.getReaders();
                         this.error = null;

--- a/src/app/static/src/tests/components/permissions/addPermission.test.js
+++ b/src/app/static/src/tests/components/permissions/addPermission.test.js
@@ -39,7 +39,7 @@ describe("addPermission", () => {
 
     it('add sets error and does not emit added event', async (done) => {
         const testError = {test: "something"};
-        mockAxios.onPost(`http://app/users/testGroup1/actions/associate-permission/`)
+        mockAxios.onPost(`http://app/users/testGroup1/permissions/`)
             .reply(500, testError);
 
         const wrapper = createSut("user");
@@ -60,9 +60,9 @@ describe("addPermission", () => {
         });
     });
 
-    it('add calls associate permission endpoint and emits added event', async (done) => {
+    it('adds permission and emits added event', async (done) => {
 
-        mockAxios.onPost(`http://app/users/testGroup1/actions/associate-permission/`)
+        mockAxios.onPost(`http://app/users/testGroup1/permissions/`)
             .reply(200);
 
         const wrapper = createSut("user");

--- a/src/app/static/src/tests/components/permissions/roleList.test.js
+++ b/src/app/static/src/tests/components/permissions/roleList.test.js
@@ -137,11 +137,16 @@ describe("roleList", () => {
 
     it('removes role and emits removed event', (done) => {
 
-        mockAxios.onPost('http://app/roles/Funders/actions/associate-permission/')
+        mockAxios.onPost('http://app/roles/Funders/permissions/reports.read/?scopePrefix=report&scopeId=r1')
             .reply(200);
 
         const wrapper = shallowMount(RoleList, {
             propsData: {
+                permission: {
+                    scope_id: "r1",
+                    scope_prefix: "report",
+                    name: "reports.read"
+                },
                 roles: mockRoles,
                 canRemoveRoles: true,
                 canRemoveMembers: true
@@ -158,11 +163,16 @@ describe("roleList", () => {
 
     it('sets error if removing role fails', (done) => {
 
-        mockAxios.onPost('http://app/roles/Funders/actions/associate-permission/')
+        mockAxios.onPost('http://app/roles/Funders/permissions/reports.read/?&scopePrefix=report&scopeId=r1')
             .reply(500);
 
         const wrapper = shallowMount(RoleList, {
             propsData: {
+                permission: {
+                    scope_id: "r1",
+                    scope_prefix: "report",
+                    name: "reports.read"
+                },
                 roles: mockRoles,
                 canRemoveRoles: true,
                 canRemoveMembers: true

--- a/src/app/static/src/tests/components/permissions/roleList.test.js
+++ b/src/app/static/src/tests/components/permissions/roleList.test.js
@@ -137,7 +137,7 @@ describe("roleList", () => {
 
     it('removes role and emits removed event', (done) => {
 
-        mockAxios.onPost('http://app/roles/Funders/permissions/reports.read/?scopePrefix=report&scopeId=r1')
+        mockAxios.onDelete('http://app/roles/Funders/permissions/reports.read/?scopePrefix=report&scopeId=r1')
             .reply(200);
 
         const wrapper = shallowMount(RoleList, {
@@ -163,7 +163,7 @@ describe("roleList", () => {
 
     it('sets error if removing role fails', (done) => {
 
-        mockAxios.onPost('http://app/roles/Funders/permissions/reports.read/?&scopePrefix=report&scopeId=r1')
+        mockAxios.onDelete('http://app/roles/Funders/permissions/reports.read/?&scopePrefix=report&scopeId=r1')
             .reply(500);
 
         const wrapper = shallowMount(RoleList, {

--- a/src/app/static/src/tests/components/reports/reportReadersList.test.js
+++ b/src/app/static/src/tests/components/reports/reportReadersList.test.js
@@ -120,7 +120,7 @@ describe("reportReadersList", () => {
 
     it('refreshes data when added event is emitted', async (done) => {
 
-        mockAxios.onPost(`http://app/users/test.user%40example.com/actions/associate-permission/`)
+        mockAxios.onPost(`http://app/users/test.user%40example.com/permissions/`)
             .reply(200);
 
         mockAxios.onGet('http://app/users/report-readers/report1/')
@@ -157,7 +157,7 @@ describe("reportReadersList", () => {
 
     it('removes user and refreshes list of readers', (done) => {
 
-        mockAxios.onPost(`http://app/users/bob/permissions/reports.read/?scopePrefix=report&scopeId=report1`)
+        mockAxios.onDelete(`http://app/users/bob/permissions/reports.read/?scopePrefix=report&scopeId=report1`)
             .reply(200);
 
         mockAxios.onGet('http://app/users/report-readers/report1/')
@@ -188,7 +188,7 @@ describe("reportReadersList", () => {
 
     it('sets error if removing user fails', (done) => {
 
-        mockAxios.onPost("http://app/users/bob/permissions/reports.read/?scopePrefix=report&scopeId=report1")
+        mockAxios.onDelete("http://app/users/bob/permissions/reports.read/?scopePrefix=report&scopeId=report1")
             .reply(500);
 
         mockAxios.onGet('http://app/users/report-readers/report1/')

--- a/src/app/static/src/tests/components/reports/reportReadersList.test.js
+++ b/src/app/static/src/tests/components/reports/reportReadersList.test.js
@@ -157,7 +157,7 @@ describe("reportReadersList", () => {
 
     it('removes user and refreshes list of readers', (done) => {
 
-        mockAxios.onPost(`http://app/users/bob/actions/associate-permission/`)
+        mockAxios.onPost(`http://app/users/bob/permissions/reports.read/?scopePrefix=report&scopeId=report1`)
             .reply(200);
 
         mockAxios.onGet('http://app/users/report-readers/report1/')
@@ -188,7 +188,7 @@ describe("reportReadersList", () => {
 
     it('sets error if removing user fails', (done) => {
 
-        mockAxios.onPost(`http://app/users/bob/actions/associate-permission/`)
+        mockAxios.onPost("http://app/users/bob/permissions/reports.read/?scopePrefix=report&scopeId=report1")
             .reply(500);
 
         mockAxios.onGet('http://app/users/report-readers/report1/')

--- a/src/app/static/src/tests/components/reports/scopedReaderRolesList.test.js
+++ b/src/app/static/src/tests/components/reports/scopedReaderRolesList.test.js
@@ -100,7 +100,7 @@ describe("scopedReaderRolesList", () => {
 
     it('refreshes data when added event is emitted', async (done) => {
 
-        mockAxios.onPost(`http://app/roles/Tech/actions/associate-permission/`)
+        mockAxios.onPost(`http://app/roles/Tech/permissions/`)
             .reply(200);
 
         mockAxios.onGet('http://app/roles/report-readers/report1/')
@@ -130,7 +130,7 @@ describe("scopedReaderRolesList", () => {
 
     it('refreshes data when removed event is emitted', async (done) => {
 
-        mockAxios.onPost(`http://app/roles/Tech/actions/associate-permission/`)
+        mockAxios.onPost(`http://app/roles/Tech/permissions/`)
             .reply(200);
 
         mockAxios.onGet('http://app/roles/report-readers/report1/')


### PR DESCRIPTION
Replaces the `associate-permission` endpoints with 2 separate POST and DELETE endpoints. Contains commits from https://github.com/vimc/orderly-web/pull/137