### PR TITLE
mrc-1327 wire up admin link

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -16,16 +16,11 @@ class ReportController: OrderlyDataController
     @Template("report-page.ftl")
     fun getByNameAndVersion(): ReportVersionPageViewModel
     {
-        return getByNameAndVersion(AppConfig())
-    }
-
-    fun getByNameAndVersion(appConfig: Config): ReportVersionPageViewModel
-    {
         val reportName = context.params(":name")
         val version = context.params(":version")
         val reportDetails = orderly.getDetailsByNameAndVersion(reportName, version)
         val versions = orderly.getReportsByName(reportName)
         val changelog = orderly.getChangelogByNameAndVersion(reportName, version)
-        return ReportVersionPageViewModel.build(reportDetails, versions, changelog, context, appConfig)
+        return ReportVersionPageViewModel.build(reportDetails, versions, changelog, context)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AppViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AppViewModel.kt
@@ -4,21 +4,23 @@ import org.pac4j.core.profile.CommonProfile
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config
-import org.vaccineimpact.orderlyweb.db.MissingConfigurationKey
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.security.authentication.AuthenticationConfig
 
 data class Breadcrumb(val name: String, val url: String?)
 
 data class DefaultViewModel(override val loggedIn: Boolean,
-                       override val user: String?,
-                       override val breadcrumbs: List<Breadcrumb>,
-                       private val appConfig: Config = AppConfig()) : AppViewModel
+                            override val user: String?,
+                            override val isAdmin: Boolean,
+                            override val breadcrumbs: List<Breadcrumb>,
+                            private val appConfig: Config = AppConfig()) : AppViewModel
 {
-    constructor(userProfile: CommonProfile?, breadcrumbs: List<Breadcrumb>) :
-            this(userProfile != null, userProfile?.id, breadcrumbs)
+    constructor(userProfile: CommonProfile?, isAdmin: Boolean, breadcrumbs: List<Breadcrumb>) :
+            this(userProfile != null, userProfile?.id, isAdmin, breadcrumbs)
 
     constructor(context: ActionContext, vararg breadcrumbs: Breadcrumb) :
-            this(context.userProfile, breadcrumbs.toList())
+            this(context.userProfile, context.hasPermission(ReifiedPermission("reports.review", Scope.Global())), breadcrumbs.toList())
 
     override val appName = appConfig["app.name"]
     override val appUrl = appConfig["app.url"]
@@ -48,5 +50,7 @@ interface AppViewModel
     val logo: String
     val montaguUrl: String
     val appUrl: String
+
+    val isAdmin: Boolean
 }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AppViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AppViewModel.kt
@@ -13,7 +13,7 @@ data class Breadcrumb(val name: String, val url: String?)
 data class DefaultViewModel(override val loggedIn: Boolean,
                             override val user: String?,
                             override val isReviewer: Boolean,
-                            val isAdmin: Boolean,
+                            override val isAdmin: Boolean,
                             override val breadcrumbs: List<Breadcrumb>,
                             private val appConfig: Config = AppConfig()) : AppViewModel
 {
@@ -32,7 +32,7 @@ data class DefaultViewModel(override val loggedIn: Boolean,
     override val logo = appConfig["app.logo"]
     override val montaguUrl = appConfig["montagu.url"]
 
-    override val showPermissionManagement = isAdmin && appConfig.authorizationEnabled
+    override val fineGrainedAuth = appConfig.authorizationEnabled
 
     override val authProvider = AuthenticationConfig().getConfiguredProvider().toString()
 
@@ -58,6 +58,8 @@ interface AppViewModel
     val appUrl: String
 
     val isReviewer: Boolean
-    val showPermissionManagement: Boolean
+    val isAdmin: Boolean
+
+    val fineGrainedAuth: Boolean
 }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AppViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/AppViewModel.kt
@@ -12,21 +12,27 @@ data class Breadcrumb(val name: String, val url: String?)
 
 data class DefaultViewModel(override val loggedIn: Boolean,
                             override val user: String?,
-                            override val isAdmin: Boolean,
+                            override val isReviewer: Boolean,
+                            val isAdmin: Boolean,
                             override val breadcrumbs: List<Breadcrumb>,
                             private val appConfig: Config = AppConfig()) : AppViewModel
 {
-    constructor(userProfile: CommonProfile?, isAdmin: Boolean, breadcrumbs: List<Breadcrumb>) :
-            this(userProfile != null, userProfile?.id, isAdmin, breadcrumbs)
+    constructor(userProfile: CommonProfile?, isReviewer: Boolean, isAdmin: Boolean, breadcrumbs: List<Breadcrumb>, appConfig: Config) :
+            this(userProfile != null, userProfile?.id, isReviewer, isAdmin, breadcrumbs, appConfig)
 
-    constructor(context: ActionContext, vararg breadcrumbs: Breadcrumb) :
-            this(context.userProfile, context.hasPermission(ReifiedPermission("reports.review", Scope.Global())), breadcrumbs.toList())
+    constructor(context: ActionContext, vararg breadcrumbs: Breadcrumb, appConfig: Config = AppConfig()):
+            this(context.userProfile,
+                    context.hasPermission(ReifiedPermission("reports.review", Scope.Global())),
+                    context.hasPermission(ReifiedPermission("users.manage", Scope.Global())),
+                    breadcrumbs.toList(), appConfig)
 
     override val appName = appConfig["app.name"]
     override val appUrl = appConfig["app.url"]
     override val appEmail = appConfig["app.email"]
     override val logo = appConfig["app.logo"]
     override val montaguUrl = appConfig["montagu.url"]
+
+    override val showPermissionManagement = isAdmin && appConfig.authorizationEnabled
 
     override val authProvider = AuthenticationConfig().getConfiguredProvider().toString()
 
@@ -51,6 +57,7 @@ interface AppViewModel
     val montaguUrl: String
     val appUrl: String
 
-    val isAdmin: Boolean
+    val isReviewer: Boolean
+    val showPermissionManagement: Boolean
 }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
@@ -14,15 +14,13 @@ import java.time.format.DateTimeFormatter
 
 data class IndexViewModel(@Serialise("reportsJson") val reports: List<ReportRowViewModel>,
                           val pinnedReports: List<PinnedReportViewModel>,
-                          val isReviewer: Boolean,
                           val appViewModel: AppViewModel)
     : AppViewModel by appViewModel
 {
     constructor(context: ActionContext,
                 reports: List<ReportRowViewModel>,
-                pinnedReports: List<PinnedReportViewModel>,
-                isReviewer: Boolean)
-            : this(reports, pinnedReports, isReviewer, DefaultViewModel(context, breadcrumb))
+                pinnedReports: List<PinnedReportViewModel>)
+            : this(reports, pinnedReports, DefaultViewModel(context, breadcrumb))
 
     companion object
     {
@@ -47,8 +45,7 @@ data class IndexViewModel(@Serialise("reportsJson") val reports: List<ReportRowV
 
             val pinnedReportsViewModels = PinnedReportViewModel.buildList(pinnedReports)
 
-            return IndexViewModel(context, reportRows, pinnedReportsViewModels,
-                    context.hasPermission(ReifiedPermission("reports.review", Scope.Global())))
+            return IndexViewModel(context, reportRows, pinnedReportsViewModels)
         }
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -27,32 +27,6 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                                       val appViewModel: AppViewModel) :
         AppViewModel by appViewModel
 {
-//    constructor(report: ReportVersionDetails,
-//                focalArtefactUrl: String?,
-//                isReviewer: Boolean,
-//                isRunner: Boolean,
-//                showPermissionManagement: Boolean,
-//                artefacts: List<ArtefactViewModel>,
-//                dataLinks: List<InputDataViewModel>,
-//                resources: List<DownloadableFileViewModel>,
-//                zipFile: DownloadableFileViewModel,
-//                versions: List<VersionPickerViewModel>,
-//                changelog: List<ChangelogViewModel>,
-//                breadcrumbs: List<Breadcrumb>,
-//                loggedIn: Boolean,
-//                userName: String) :
-//
-//            this(report,
-//                    focalArtefactUrl,
-//                    isRunner,
-//                    artefacts,
-//                    dataLinks,
-//                    resources,
-//                    zipFile,
-//                    versions,
-//                    changelog,
-//                    DefaultViewModel(loggedIn, userName, isReviewer, showPermissionManagement, breadcrumbs))
-
     companion object
     {
         fun build(report: ReportVersionDetails,

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -27,39 +27,38 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                                       val appViewModel: AppViewModel) :
         AppViewModel by appViewModel
 {
-    constructor(report: ReportVersionDetails,
-                focalArtefactUrl: String?,
-                isReviewer: Boolean,
-                isRunner: Boolean,
-                showPermissionManagement: Boolean,
-                artefacts: List<ArtefactViewModel>,
-                dataLinks: List<InputDataViewModel>,
-                resources: List<DownloadableFileViewModel>,
-                zipFile: DownloadableFileViewModel,
-                versions: List<VersionPickerViewModel>,
-                changelog: List<ChangelogViewModel>,
-                breadcrumbs: List<Breadcrumb>,
-                loggedIn: Boolean,
-                userName: String) :
-
-            this(report,
-                    focalArtefactUrl,
-                    isRunner,
-                    artefacts,
-                    dataLinks,
-                    resources,
-                    zipFile,
-                    versions,
-                    changelog,
-                    DefaultViewModel(loggedIn, userName, isReviewer, showPermissionManagement, breadcrumbs))
+//    constructor(report: ReportVersionDetails,
+//                focalArtefactUrl: String?,
+//                isReviewer: Boolean,
+//                isRunner: Boolean,
+//                showPermissionManagement: Boolean,
+//                artefacts: List<ArtefactViewModel>,
+//                dataLinks: List<InputDataViewModel>,
+//                resources: List<DownloadableFileViewModel>,
+//                zipFile: DownloadableFileViewModel,
+//                versions: List<VersionPickerViewModel>,
+//                changelog: List<ChangelogViewModel>,
+//                breadcrumbs: List<Breadcrumb>,
+//                loggedIn: Boolean,
+//                userName: String) :
+//
+//            this(report,
+//                    focalArtefactUrl,
+//                    isRunner,
+//                    artefacts,
+//                    dataLinks,
+//                    resources,
+//                    zipFile,
+//                    versions,
+//                    changelog,
+//                    DefaultViewModel(loggedIn, userName, isReviewer, showPermissionManagement, breadcrumbs))
 
     companion object
     {
         fun build(report: ReportVersionDetails,
                   versions: List<String>,
                   changelog: List<Changelog>,
-                  context: ActionContext,
-                  appConfig: Config): ReportVersionPageViewModel
+                  context: ActionContext): ReportVersionPageViewModel
         {
             val fileViewModelBuilder = ReportFileViewModelBuilder(report.name, report.id)
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -18,7 +18,6 @@ import java.time.format.DateTimeFormatter
 data class ReportVersionPageViewModel(@Serialise("reportJson") val report: ReportVersionDetails,
                                       val focalArtefactUrl: String?,
                                       val isRunner: Boolean,
-                                      val showPermissionManagement: Boolean,
                                       val artefacts: List<ArtefactViewModel>,
                                       val dataLinks: List<InputDataViewModel>,
                                       val resources: List<DownloadableFileViewModel>,
@@ -30,7 +29,7 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
 {
     constructor(report: ReportVersionDetails,
                 focalArtefactUrl: String?,
-                isAdmin: Boolean,
+                isReviewer: Boolean,
                 isRunner: Boolean,
                 showPermissionManagement: Boolean,
                 artefacts: List<ArtefactViewModel>,
@@ -46,14 +45,13 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
             this(report,
                     focalArtefactUrl,
                     isRunner,
-                    showPermissionManagement,
                     artefacts,
                     dataLinks,
                     resources,
                     zipFile,
                     versions,
                     changelog,
-                    DefaultViewModel(loggedIn, userName, isAdmin, breadcrumbs))
+                    DefaultViewModel(loggedIn, userName, isReviewer, showPermissionManagement, breadcrumbs))
 
     companion object
     {
@@ -87,8 +85,6 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                     .buildZipFileViewModel()
 
             val isRunner = context.hasPermission(ReifiedPermission("reports.run", Scope.Global()))
-            val showPermissionManagement = context.hasPermission(ReifiedPermission("users.manage", Scope.Global()))
-                    && appConfig.authorizationEnabled
 
             val displayName = report.displayName ?: report.name
 
@@ -102,7 +98,6 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
             return ReportVersionPageViewModel(report.copy(displayName = displayName),
                     focalArtefactUrl,
                     isRunner,
-                    showPermissionManagement,
                     artefactViewModels,
                     dataViewModels,
                     resourceViewModels,

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -17,7 +17,6 @@ import java.time.format.DateTimeFormatter
 
 data class ReportVersionPageViewModel(@Serialise("reportJson") val report: ReportVersionDetails,
                                       val focalArtefactUrl: String?,
-                                      val isAdmin: Boolean,
                                       val isRunner: Boolean,
                                       val showPermissionManagement: Boolean,
                                       val artefacts: List<ArtefactViewModel>,
@@ -42,11 +41,10 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                 changelog: List<ChangelogViewModel>,
                 breadcrumbs: List<Breadcrumb>,
                 loggedIn: Boolean,
-                appName: String) :
+                userName: String) :
 
             this(report,
                     focalArtefactUrl,
-                    isAdmin,
                     isRunner,
                     showPermissionManagement,
                     artefacts,
@@ -55,7 +53,7 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                     zipFile,
                     versions,
                     changelog,
-                    DefaultViewModel(loggedIn, appName, breadcrumbs))
+                    DefaultViewModel(loggedIn, userName, isAdmin, breadcrumbs))
 
     companion object
     {
@@ -88,7 +86,6 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
             val zipFile = fileViewModelBuilder
                     .buildZipFileViewModel()
 
-            val isAdmin = context.hasPermission(ReifiedPermission("reports.review", Scope.Global()))
             val isRunner = context.hasPermission(ReifiedPermission("reports.run", Scope.Global()))
             val showPermissionManagement = context.hasPermission(ReifiedPermission("users.manage", Scope.Global()))
                     && appConfig.authorizationEnabled
@@ -104,7 +101,6 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
 
             return ReportVersionPageViewModel(report.copy(displayName = displayName),
                     focalArtefactUrl,
-                    isAdmin,
                     isRunner,
                     showPermissionManagement,
                     artefactViewModels,

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests
 
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import freemarker.ext.beans.StringModel
@@ -79,6 +80,7 @@ class TemplateObjectWrapperTests : TeamcityTests()
     {
         val mockContext = mock<ActionContext> {
             on { it.userProfile } doReturn CommonProfile().apply { id = "user.name" }
+            on { hasPermission(any())} doReturn true
         }
         val model = IndexViewModel(mockContext, listOf(), listOf())
 
@@ -90,6 +92,8 @@ class TemplateObjectWrapperTests : TeamcityTests()
         assertThat(result["user"].toString()).isEqualTo("user.name")
         assertThat((result["loggedIn"] as TemplateBooleanModel).asBoolean).isEqualTo(true)
         assertThat((result["isReviewer"] as TemplateBooleanModel).asBoolean).isEqualTo(true)
+        assertThat((result["isAdmin"] as TemplateBooleanModel).asBoolean).isEqualTo(true)
+        assertThat((result["fineGrainedAuth"] as TemplateBooleanModel).asBoolean).isEqualTo(true)
         assertThat((result["reports"])).isNotNull()
         assertThat((result["pinnedReports"])).isNotNull()
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
@@ -80,7 +80,7 @@ class TemplateObjectWrapperTests : TeamcityTests()
         val mockContext = mock<ActionContext> {
             on { it.userProfile } doReturn CommonProfile().apply { id = "user.name" }
         }
-        val model = IndexViewModel(mockContext, listOf(), listOf(), true)
+        val model = IndexViewModel(mockContext, listOf(), listOf())
 
         val sut = TemplateObjectWrapper()
         val result = sut.wrap(model) as SimpleHash

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests.kt
@@ -298,7 +298,7 @@ class ReportControllerTests : TeamcityTests()
         }
         val sut = ReportController(actionContext, mockOrderly)
         val result = sut.getByNameAndVersion()
-        assertThat(result.isAdmin).isTrue()
+        assertThat(result.isReviewer).isTrue()
     }
 
     @Test
@@ -311,7 +311,7 @@ class ReportControllerTests : TeamcityTests()
         }
         val sut = ReportController(actionContext, mockOrderly)
         val result = sut.getByNameAndVersion()
-        assertThat(result.isAdmin).isFalse()
+        assertThat(result.isReviewer).isFalse()
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests.kt
@@ -289,32 +289,6 @@ class ReportControllerTests : TeamcityTests()
     }
 
     @Test
-    fun `report reviewers are admins`()
-    {
-        val actionContext = mock<ActionContext> {
-            on { this.params(":name") } doReturn "r1"
-            on { this.params(":version") } doReturn versionId
-            on { this.hasPermission(ReifiedPermission("reports.review", Scope.Global())) } doReturn true
-        }
-        val sut = ReportController(actionContext, mockOrderly)
-        val result = sut.getByNameAndVersion()
-        assertThat(result.isReviewer).isTrue()
-    }
-
-    @Test
-    fun `non report reviewers are not admins`()
-    {
-        val actionContext = mock<ActionContext> {
-            on { this.params(":name") } doReturn "r1"
-            on { this.params(":version") } doReturn versionId
-            on { this.hasPermission(ReifiedPermission("reports.review", Scope.Global())) } doReturn false
-        }
-        val sut = ReportController(actionContext, mockOrderly)
-        val result = sut.getByNameAndVersion()
-        assertThat(result.isReviewer).isFalse()
-    }
-
-    @Test
     fun `users with report running permissions are report runners`()
     {
         val actionContext = mock<ActionContext> {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests.kt
@@ -341,54 +341,6 @@ class ReportControllerTests : TeamcityTests()
     }
 
     @Test
-    fun `showPermissionManagement is true if user has users manage permission and fine grained auth is on`()
-    {
-        val actionContext = mock<ActionContext> {
-            on { this.params(":name") } doReturn "r1"
-            on { this.params(":version") } doReturn versionId
-            on { this.hasPermission(ReifiedPermission("users.manage", Scope.Global())) } doReturn true
-        }
-        val mockConfig = mock<Config> {
-            on { authorizationEnabled } doReturn true
-        }
-        val sut = ReportController(actionContext, mockOrderly)
-        val result = sut.getByNameAndVersion(mockConfig)
-        assertThat(result.showPermissionManagement).isTrue()
-    }
-
-    @Test
-    fun `showPermissionManagement is false for users without users manage permission`()
-    {
-        val actionContext = mock<ActionContext> {
-            on { this.params(":name") } doReturn "r1"
-            on { this.params(":version") } doReturn versionId
-            on { this.hasPermission(ReifiedPermission("users.manage", Scope.Global())) } doReturn false
-        }
-        val mockConfig = mock<Config> {
-            on { authorizationEnabled } doReturn true
-        }
-        val sut = ReportController(actionContext, mockOrderly)
-        val result = sut.getByNameAndVersion(mockConfig)
-        assertThat(result.showPermissionManagement).isFalse()
-    }
-
-    @Test
-    fun `showPermissionManagement is false if fine grained auth is off`()
-    {
-        val actionContext = mock<ActionContext> {
-            on { this.params(":name") } doReturn "r1"
-            on { this.params(":version") } doReturn versionId
-            on { this.hasPermission(ReifiedPermission("users.manage", Scope.Global())) } doReturn true
-        }
-        val mockConfig = mock<Config> {
-            on { authorizationEnabled } doReturn false
-        }
-        val sut = ReportController(actionContext, mockOrderly)
-        val result = sut.getByNameAndVersion(mockConfig)
-        assertThat(result.showPermissionManagement).isFalse()
-    }
-
-    @Test
     fun `creates correct breadcrumbs`()
     {
         val sut = ReportController(mockActionContext, mockOrderly)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/DefaultViewModelTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/DefaultViewModelTests.kt
@@ -1,0 +1,85 @@
+package org.vaccineimpact.orderlyweb.tests.unit_tests.templates
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.Test
+import org.pac4j.core.profile.CommonProfile
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.db.Config
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+import org.vaccineimpact.orderlyweb.viewmodels.DefaultViewModel
+import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
+
+class DefaultViewModelTests : TeamcityTests()
+{
+    @Test
+    fun `isAdmin is true if user can manage users`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { userProfile } doReturn CommonProfile().apply {
+                id = "test.user"
+            }
+            on {
+                hasPermission(ReifiedPermission("users.manage", Scope.Global()))
+            } doReturn true
+        }
+
+        val sut = DefaultViewModel(mockContext, IndexViewModel.breadcrumb)
+        assertThat(sut.isAdmin).isTrue()
+    }
+
+    @Test
+    fun `isAdmin is false if user cannot manage users`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { userProfile } doReturn CommonProfile().apply {
+                id = "test.user"
+            }
+            on {
+                hasPermission(ReifiedPermission("users.manage", Scope.Global()))
+            } doReturn false
+        }
+
+        val sut = DefaultViewModel(mockContext, IndexViewModel.breadcrumb)
+        assertThat(sut.isAdmin).isFalse()
+    }
+
+    @Test
+    fun `showPermissionManagement is false if isAdmin is false`()
+    {
+        val mockConfig = mock<Config>()
+        {
+            on { authorizationEnabled } doReturn true
+        }
+
+        val sut = DefaultViewModel(true,
+                "username",
+                isReviewer = true,
+                isAdmin = false,
+                breadcrumbs = listOf(IndexViewModel.breadcrumb),
+                appConfig = mockConfig)
+
+        assertThat(sut.showPermissionManagement).isFalse()
+    }
+
+    @Test
+    fun `showPermissionManagement is false if auth is not enabled`()
+    {
+        val mockConfig = mock<Config>()
+        {
+            on { authorizationEnabled } doReturn false
+        }
+
+        val sut = DefaultViewModel(true,
+                "username",
+                isReviewer = true,
+                isAdmin = true,
+                breadcrumbs = listOf(IndexViewModel.breadcrumb),
+                appConfig = mockConfig)
+
+        assertThat(sut.showPermissionManagement).isFalse()
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/DefaultViewModelTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/DefaultViewModelTests.kt
@@ -48,7 +48,25 @@ class DefaultViewModelTests : TeamcityTests()
     }
 
     @Test
-    fun `showPermissionManagement is false if isAdmin is false`()
+    fun `fineGrainedAuth is false if auth is not enabled`()
+    {
+        val mockConfig = mock<Config>()
+        {
+            on { authorizationEnabled } doReturn false
+        }
+
+        val sut = DefaultViewModel(true,
+                "username",
+                isReviewer = true,
+                isAdmin = false,
+                breadcrumbs = listOf(IndexViewModel.breadcrumb),
+                appConfig = mockConfig)
+
+        assertThat(sut.fineGrainedAuth).isFalse()
+    }
+
+    @Test
+    fun `fineGrainedAuth is true if auth is enabled`()
     {
         val mockConfig = mock<Config>()
         {
@@ -62,25 +80,7 @@ class DefaultViewModelTests : TeamcityTests()
                 breadcrumbs = listOf(IndexViewModel.breadcrumb),
                 appConfig = mockConfig)
 
-        assertThat(sut.showPermissionManagement).isFalse()
-    }
-
-    @Test
-    fun `showPermissionManagement is false if auth is not enabled`()
-    {
-        val mockConfig = mock<Config>()
-        {
-            on { authorizationEnabled } doReturn false
-        }
-
-        val sut = DefaultViewModel(true,
-                "username",
-                isReviewer = true,
-                isAdmin = true,
-                breadcrumbs = listOf(IndexViewModel.breadcrumb),
-                appConfig = mockConfig)
-
-        assertThat(sut.showPermissionManagement).isFalse()
+        assertThat(sut.fineGrainedAuth).isTrue()
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/DefaultViewModelTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/DefaultViewModelTests.kt
@@ -82,4 +82,30 @@ class DefaultViewModelTests : TeamcityTests()
 
         assertThat(sut.showPermissionManagement).isFalse()
     }
+
+    @Test
+    fun `isReviewer is true if user has global review permission`()
+    {
+        val mockContext = mock<ActionContext>()
+        {
+            on { hasPermission(ReifiedPermission("reports.review", Scope.Global())) } doReturn true
+        }
+
+        val sut = DefaultViewModel(mockContext, IndexViewModel.breadcrumb)
+
+        assertThat(sut.isReviewer).isTrue()
+    }
+
+    @Test
+    fun `isReviewer is false if user does not have global review permission`()
+    {
+        val mockContext = mock<ActionContext>()
+        {
+            on { hasPermission(ReifiedPermission("reports.review", Scope.Global())) } doReturn false
+        }
+
+        val sut = DefaultViewModel(mockContext, IndexViewModel.breadcrumb)
+
+        assertThat(sut.isReviewer).isFalse()
+    }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/IndexTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/IndexTests.kt
@@ -22,7 +22,7 @@ class IndexTests : TeamcityTests()
     @Test
     fun `renders correctly`()
     {
-        val testModel = IndexViewModel(mock(), listOf(), listOf(), false)
+        val testModel = IndexViewModel(mock(), listOf(), listOf())
 
         val doc = template.jsoupDocFor(testModel)
         val breadcrumbs = doc.select(".crumb-item")
@@ -42,7 +42,7 @@ class IndexTests : TeamcityTests()
                     DownloadableFileViewModel("zip file 1", "zip file url 1")),
                 PinnedReportViewModel("report2", "version2", "display2", "date2",
                         DownloadableFileViewModel("zip file 2", "zip file url 2"))
-        ), false)
+        ))
 
         val doc = template.jsoupDocFor(testModel)
 
@@ -75,7 +75,7 @@ class IndexTests : TeamcityTests()
     @Test
     fun `renders correctly when no pinned reports`()
     {
-        val testModel = IndexViewModel(mock(), listOf(), listOf(), false)
+        val testModel = IndexViewModel(mock(), listOf(), listOf())
 
         val doc = template.jsoupDocFor(testModel)
 
@@ -89,7 +89,7 @@ class IndexTests : TeamcityTests()
     @Test
     fun `reviewers can see the status column`()
     {
-        val testModel = IndexViewModel(mock(), listOf(), listOf(), true)
+        val testModel = IndexViewModel(mock(), listOf(), listOf())
         val header = template.jsoupDocFor(testModel).selectFirst("thead tr")
 
         assertThat(header.select("th").count()).isEqualTo(5)
@@ -103,7 +103,7 @@ class IndexTests : TeamcityTests()
     @Test
     fun `non-reviewers cannot see the status column`()
     {
-        val testModel = IndexViewModel(mock(), listOf(), listOf(), false)
+        val testModel = IndexViewModel(mock(), listOf(), listOf())
         val header = template.jsoupDocFor(testModel).selectFirst("thead tr")
 
         assertThat(header.select("th").count()).isEqualTo(4)
@@ -117,7 +117,7 @@ class IndexTests : TeamcityTests()
     @Test
     fun `each column has a custom filter`()
     {
-        val testModel = IndexViewModel(mock(), listOf(), listOf(), true)
+        val testModel = IndexViewModel(mock(), listOf(), listOf())
         val filters = template.jsoupDocFor(testModel).select("thead tr")[1]
 
         assertThat(filters.select("th").count()).isEqualTo(5)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/IndexTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/IndexTests.kt
@@ -6,6 +6,7 @@ import org.junit.ClassRule
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
 import org.vaccineimpact.orderlyweb.tests.unit_tests.templates.rules.FreemarkerTestRule
+import org.vaccineimpact.orderlyweb.viewmodels.DefaultViewModel
 import org.vaccineimpact.orderlyweb.viewmodels.DownloadableFileViewModel
 import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 import org.vaccineimpact.orderlyweb.viewmodels.PinnedReportViewModel
@@ -39,7 +40,7 @@ class IndexTests : TeamcityTests()
     {
         val testModel = IndexViewModel(mock(), listOf(), listOf(
                 PinnedReportViewModel("report1", "version1", "display1", "date1",
-                    DownloadableFileViewModel("zip file 1", "zip file url 1")),
+                        DownloadableFileViewModel("zip file 1", "zip file url 1")),
                 PinnedReportViewModel("report2", "version2", "display2", "date2",
                         DownloadableFileViewModel("zip file 2", "zip file url 2"))
         ))
@@ -89,7 +90,8 @@ class IndexTests : TeamcityTests()
     @Test
     fun `reviewers can see the status column`()
     {
-        val testModel = IndexViewModel(mock(), listOf(), listOf())
+        val defaultModel = DefaultViewModel(true, "username", isReviewer = true, isAdmin = false, breadcrumbs = listOf(IndexViewModel.breadcrumb))
+        val testModel = IndexViewModel(listOf(), listOf(), defaultModel)
         val header = template.jsoupDocFor(testModel).selectFirst("thead tr")
 
         assertThat(header.select("th").count()).isEqualTo(5)
@@ -103,7 +105,9 @@ class IndexTests : TeamcityTests()
     @Test
     fun `non-reviewers cannot see the status column`()
     {
-        val testModel = IndexViewModel(mock(), listOf(), listOf())
+        val defaultModel = DefaultViewModel(true, "username", isReviewer = false,
+                isAdmin = false, breadcrumbs = listOf(IndexViewModel.breadcrumb))
+        val testModel = IndexViewModel(listOf(), listOf(), defaultModel)
         val header = template.jsoupDocFor(testModel).selectFirst("thead tr")
 
         assertThat(header.select("th").count()).isEqualTo(4)
@@ -117,7 +121,9 @@ class IndexTests : TeamcityTests()
     @Test
     fun `each column has a custom filter`()
     {
-        val testModel = IndexViewModel(mock(), listOf(), listOf())
+        val defaultModel = DefaultViewModel(true, "username", isReviewer = true,
+                isAdmin = false, breadcrumbs = listOf(IndexViewModel.breadcrumb))
+        val testModel = IndexViewModel(listOf(), listOf(), defaultModel)
         val filters = template.jsoupDocFor(testModel).select("thead tr")[1]
 
         assertThat(filters.select("th").count()).isEqualTo(5)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/LayoutTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/LayoutTests.kt
@@ -62,7 +62,7 @@ class LayoutTests : TeamcityTests()
 
         assertHeaderRenderedCorrectly(doc, xml)
 
-        assertThat(doc.selectFirst(".logout span").text()).isEqualTo("")
+        assertThat(doc.selectFirst(".logout span").text()).isEqualTo("Logged in as test.user | Logout")
         assertThat(doc.selectFirst(".logout span a").attr("href")).isEqualTo("#")
         assertThat(doc.selectFirst(".logout span a").attr("onclick")).isEqualTo("logoutViaMontagu()")
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/LayoutTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/LayoutTests.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.orderlyweb.tests.unit_tests.templates
 
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
@@ -121,10 +122,9 @@ class LayoutTests : TeamcityTests()
             on { userProfile } doReturn CommonProfile().apply {
                 id = "test.user"
             }
-            on {
-                hasPermission(any())
-            } doReturn true
+            on { hasPermission(any()) } doReturn true
         }
+
         val mockConfig = mock<Config> {
             on { authorizationEnabled } doReturn false
             on { get("app.name") } doReturn "appName"

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -71,8 +71,8 @@ class VersionPageTests : TeamcityTests()
     )
 
     private val testDefaultModel = DefaultViewModel(true, "username",
-            isReviewer = true,
-            isAdmin = true,
+            isReviewer = false,
+            isAdmin = false,
             breadcrumbs = listOf(Breadcrumb("name", "url")))
 
     private val testModel = ReportVersionPageViewModel(

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -70,11 +70,14 @@ class VersionPageTests : TeamcityTests()
             DownloadableFileViewModel("resource2.csv", "http://resource2/csv")
     )
 
+    private val testDefaultModel = DefaultViewModel(true, "username",
+            isReviewer = true,
+            isAdmin = true,
+            breadcrumbs = listOf(Breadcrumb("name", "url")))
+
     private val testModel = ReportVersionPageViewModel(
             testReport,
             "/testFocalArtefactUrl",
-            false,
-            false,
             false,
             testArtefactViewModels,
             testDataLinks,
@@ -82,9 +85,7 @@ class VersionPageTests : TeamcityTests()
             DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
             listOf(),
             listOf(),
-            listOf(Breadcrumb("name", "url")),
-            true,
-            "userName")
+            testDefaultModel)
 
     @Test
     fun `renders outline correctly`()
@@ -316,22 +317,7 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `reviewers see publish switch`()
     {
-        val mockModel =  ReportVersionPageViewModel(
-                testReport,
-                "/testFocalArtefactUrl",
-                isReviewer = true,
-                isRunner = false,
-                showPermissionManagement = false,
-                artefacts = testArtefactViewModels,
-                dataLinks = testDataLinks,
-                resources = testResources,
-                zipFile = DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
-                versions = listOf(),
-                changelog = listOf(),
-                breadcrumbs = listOf(Breadcrumb("name", "url")),
-                loggedIn = true,
-                userName = "userName")
-
+        val mockModel = testModel.copy(appViewModel = testDefaultModel.copy(isReviewer = true))
         val htmlResponse = template.htmlPageResponseFor(mockModel)
 
         val publishSwitch = htmlResponse.getElementById("publishSwitchVueApp")
@@ -341,22 +327,7 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `non reviewers do not see publish switch`()
     {
-        val mockModel =  ReportVersionPageViewModel(
-                testReport,
-                "/testFocalArtefactUrl",
-                isReviewer = false,
-                isRunner = false,
-                showPermissionManagement = false,
-                artefacts = testArtefactViewModels,
-                dataLinks = testDataLinks,
-                resources = testResources,
-                zipFile = DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
-                versions = listOf(),
-                changelog = listOf(),
-                breadcrumbs = listOf(Breadcrumb("name", "url")),
-                loggedIn = true,
-                userName = "userName")
-
+        val mockModel = testModel.copy(appViewModel = testDefaultModel.copy(isReviewer = false))
         val htmlResponse = template.htmlPageResponseFor(mockModel)
 
         val publishSwitch = htmlResponse.getElementById("publishSwitchVueApp")
@@ -367,7 +338,6 @@ class VersionPageTests : TeamcityTests()
     fun `runners see run report`()
     {
         val mockModel = testModel.copy(isRunner = true)
-
         val htmlResponse = template.htmlPageResponseFor(mockModel)
 
         val runReport = htmlResponse.getElementById("runReportVueApp")
@@ -388,21 +358,7 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `report readers are shown if showPermissionManagement is true`()
     {
-        val mockModel = ReportVersionPageViewModel(
-            testReport,
-            "/testFocalArtefactUrl",
-            isReviewer = false,
-            isRunner = false,
-            showPermissionManagement = true,
-            artefacts = testArtefactViewModels,
-            dataLinks = testDataLinks,
-            resources = testResources,
-            zipFile = DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
-            versions = listOf(),
-            changelog = listOf(),
-            breadcrumbs = listOf(Breadcrumb("name", "url")),
-            loggedIn = true,
-            userName = "userName")
+        val mockModel = testModel.copy(appViewModel = testDefaultModel.copy(isAdmin = true))
 
         val htmlResponse = template.htmlPageResponseFor(mockModel)
         val doc = template.jsoupDocFor(mockModel)
@@ -418,21 +374,7 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `report readers are not shown if showPermissionManagement is false`()
     {
-        val mockModel =  ReportVersionPageViewModel(
-            testReport,
-            "/testFocalArtefactUrl",
-            isReviewer = false,
-            isRunner = false,
-            showPermissionManagement = false,
-            artefacts = testArtefactViewModels,
-            dataLinks = testDataLinks,
-            resources = testResources,
-            zipFile = DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
-            versions = listOf(),
-            changelog = listOf(),
-            breadcrumbs = listOf(Breadcrumb("name", "url")),
-            loggedIn = true,
-            userName = "userName")
+        val mockModel = testModel.copy(appViewModel = testDefaultModel.copy(isAdmin = false))
 
         val htmlResponse = template.htmlPageResponseFor(mockModel)
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -84,7 +84,7 @@ class VersionPageTests : TeamcityTests()
             listOf(),
             listOf(Breadcrumb("name", "url")),
             true,
-            "appName")
+            "userName")
 
     @Test
     fun `renders outline correctly`()
@@ -316,7 +316,21 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `admins see publish switch`()
     {
-        val mockModel = testModel.copy(isAdmin = true)
+        val mockModel =  ReportVersionPageViewModel(
+                testReport,
+                "/testFocalArtefactUrl",
+                isAdmin = true,
+                isRunner = false,
+                showPermissionManagement = false,
+                artefacts = testArtefactViewModels,
+                dataLinks = testDataLinks,
+                resources = testResources,
+                zipFile = DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
+                versions = listOf(),
+                changelog = listOf(),
+                breadcrumbs = listOf(Breadcrumb("name", "url")),
+                loggedIn = true,
+                userName = "userName")
 
         val htmlResponse = template.htmlPageResponseFor(mockModel)
 
@@ -327,8 +341,21 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `non admins do not see publish switch`()
     {
-        val mockModel = testModel.copy(isAdmin = false)
-
+        val mockModel =  ReportVersionPageViewModel(
+                testReport,
+                "/testFocalArtefactUrl",
+                isAdmin = false,
+                isRunner = false,
+                showPermissionManagement = false,
+                artefacts = testArtefactViewModels,
+                dataLinks = testDataLinks,
+                resources = testResources,
+                zipFile = DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
+                versions = listOf(),
+                changelog = listOf(),
+                breadcrumbs = listOf(Breadcrumb("name", "url")),
+                loggedIn = true,
+                userName = "userName")
 
         val htmlResponse = template.htmlPageResponseFor(mockModel)
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -314,12 +314,12 @@ class VersionPageTests : TeamcityTests()
     }
 
     @Test
-    fun `admins see publish switch`()
+    fun `reviewers see publish switch`()
     {
         val mockModel =  ReportVersionPageViewModel(
                 testReport,
                 "/testFocalArtefactUrl",
-                isAdmin = true,
+                isReviewer = true,
                 isRunner = false,
                 showPermissionManagement = false,
                 artefacts = testArtefactViewModels,
@@ -339,12 +339,12 @@ class VersionPageTests : TeamcityTests()
     }
 
     @Test
-    fun `non admins do not see publish switch`()
+    fun `non reviewers do not see publish switch`()
     {
         val mockModel =  ReportVersionPageViewModel(
                 testReport,
                 "/testFocalArtefactUrl",
-                isAdmin = false,
+                isReviewer = false,
                 isRunner = false,
                 showPermissionManagement = false,
                 artefacts = testArtefactViewModels,
@@ -388,7 +388,21 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `report readers are shown if showPermissionManagement is true`()
     {
-        val mockModel = testModel.copy(showPermissionManagement = true)
+        val mockModel = ReportVersionPageViewModel(
+            testReport,
+            "/testFocalArtefactUrl",
+            isReviewer = false,
+            isRunner = false,
+            showPermissionManagement = true,
+            artefacts = testArtefactViewModels,
+            dataLinks = testDataLinks,
+            resources = testResources,
+            zipFile = DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
+            versions = listOf(),
+            changelog = listOf(),
+            breadcrumbs = listOf(Breadcrumb("name", "url")),
+            loggedIn = true,
+            userName = "userName")
 
         val htmlResponse = template.htmlPageResponseFor(mockModel)
         val doc = template.jsoupDocFor(mockModel)
@@ -404,7 +418,21 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `report readers are not shown if showPermissionManagement is false`()
     {
-        val mockModel = testModel.copy(showPermissionManagement = false)
+        val mockModel =  ReportVersionPageViewModel(
+            testReport,
+            "/testFocalArtefactUrl",
+            isReviewer = false,
+            isRunner = false,
+            showPermissionManagement = false,
+            artefacts = testArtefactViewModels,
+            dataLinks = testDataLinks,
+            resources = testResources,
+            zipFile = DownloadableFileViewModel("zipFileName", "http://zipFileUrl"),
+            versions = listOf(),
+            changelog = listOf(),
+            breadcrumbs = listOf(Breadcrumb("name", "url")),
+            loggedIn = true,
+            userName = "userName")
 
         val htmlResponse = template.htmlPageResponseFor(mockModel)
 

--- a/src/app/templates/partials/header.ftl
+++ b/src/app/templates/partials/header.ftl
@@ -25,7 +25,7 @@
     </div>
     <#if loggedIn>
         <div class="logout">
-            <#if showPermissionManagement>
+            <#if isAdmin && fineGrainedAuth>
                 <span>
                     <a href="/admin">Admin</a> |
                 </span>

--- a/src/app/templates/partials/header.ftl
+++ b/src/app/templates/partials/header.ftl
@@ -25,6 +25,11 @@
     </div>
     <#if loggedIn>
         <div class="logout">
+            <#if showPermissionManagement>
+                <span>
+                    <a href="/admin">Admin</a> |
+                </span>
+            </#if>
             <span>Logged in as ${user} | <a id="logout-link"
               <#if authProvider?lower_case == "montagu">
                 href="#" onclick="logoutViaMontagu()"

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -37,7 +37,7 @@
                                 <div id="reportReadersListVueApp" class="mt-5">
                                     <label class="font-weight-bold">
                                         Global read access
-                                        <a href="#" class="small" data-toggle="tooltip" title="Coming soon!">
+                                        <a href="/admin" class="small">
                                             <edit-icon></edit-icon>
                                             Edit roles</a>
                                     </label>

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -28,7 +28,7 @@
                         <hr/>
                         <div class="pl-3">
                             <#include "partials/version-picker.ftl">
-                            <#if isAdmin>
+                            <#if isReviewer>
                                 <div id="publishSwitchVueApp" class="pt-3">
                                     <publish-switch :report=report @toggle="handleToggle"></publish-switch>
                                 </div>

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -1,6 +1,6 @@
 <#-- @ftlvariable name="report" type="org.vaccineimpact.orderlyweb.models.ReportVersionDetails" -->
 <#-- @ftlvariable name="reportJson" type="String" -->
-<#-- @ftlvariable name="isAdmin" type="Boolean" -->
+<#-- @ftlvariable name="showPermissionManagement" type="Boolean" -->
 <@layoutwide>
     <#macro styles>
         <link rel="stylesheet" href="${appUrl}/css/report-page.min.css"/>

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -30,7 +30,7 @@
                         <hr/>
                         <div class="pl-3">
                             <#include "partials/version-picker.ftl">
-                            <#if isReviewer && fineGrainedAuth>
+                            <#if isReviewer || !fineGrainedAuth>
                                 <div id="publishSwitchVueApp" class="pt-3">
                                     <publish-switch :report=report @toggle="handleToggle"></publish-switch>
                                 </div>
@@ -52,7 +52,7 @@
                                     <report-readers-list :report=report></report-readers-list>
                                 </div>
                             </#if>
-                            <#if isRunner>
+                            <#if isRunner || !fineGrainedAuth>
                                 <div id="runReportVueApp" class="mt-5">
                                     <run-report :report=report></run-report>
                                 </div>

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -1,6 +1,8 @@
 <#-- @ftlvariable name="report" type="org.vaccineimpact.orderlyweb.models.ReportVersionDetails" -->
 <#-- @ftlvariable name="reportJson" type="String" -->
-<#-- @ftlvariable name="showPermissionManagement" type="Boolean" -->
+<#-- @ftlvariable name="isAdmin" type="Boolean" -->
+<#-- @ftlvariable name="isReviewer" type="Boolean" -->
+<#-- @ftlvariable name="fineGrainedAuth" type="Boolean" -->
 <@layoutwide>
     <#macro styles>
         <link rel="stylesheet" href="${appUrl}/css/report-page.min.css"/>
@@ -28,12 +30,12 @@
                         <hr/>
                         <div class="pl-3">
                             <#include "partials/version-picker.ftl">
-                            <#if isReviewer>
+                            <#if isReviewer && fineGrainedAuth>
                                 <div id="publishSwitchVueApp" class="pt-3">
                                     <publish-switch :report=report @toggle="handleToggle"></publish-switch>
                                 </div>
                             </#if>
-                            <#if showPermissionManagement>
+                            <#if isAdmin && fineGrainedAuth>
                                 <div id="reportReadersListVueApp" class="mt-5">
                                     <label class="font-weight-bold">
                                         Global read access

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
@@ -5,11 +5,7 @@ import khttp.post
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.openqa.selenium.By
-import org.openqa.selenium.support.ui.ExpectedConditions
 import org.vaccineimpact.orderlyweb.db.AppConfig
-import org.vaccineimpact.orderlyweb.models.Scope
-import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.test_helpers.TestTokenHeader
 
 class FineGrainedPermissionTests : CustomConfigTests()

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
@@ -5,7 +5,11 @@ import khttp.post
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.openqa.selenium.By
+import org.openqa.selenium.support.ui.ExpectedConditions
 import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.test_helpers.TestTokenHeader
 
 class FineGrainedPermissionTests : CustomConfigTests()


### PR DESCRIPTION
As well as removing the "coming soon" tooltip and wiring up the link from the report page, I've added an admin link to the header. Had to re-jig the VMs a bit to make `isAdmin` a base VM property, and made `isReviewer` a base VM one while I was at it, given it's shared between report and index pages. I also added a separate `fineGrainedAuth` property to the base VM so that it can be used as needed in the templates. This seemed like the simplest approach for readability and testability.