### PR TITLE
mrc-1335 should be able to use keys to select values from typeahead

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -8439,12 +8439,6 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
     "lodash.clone": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
@@ -8485,12 +8479,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
-      "dev": true
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "lodash.some": {
@@ -9304,7 +9292,8 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
       "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -9591,6 +9580,12 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -11073,12 +11068,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-      "dev": true
-    },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "dev": true
     },
     "resolve": {
@@ -13360,16 +13349,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
       "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==",
       "dev": true
-    },
-    "vue-bootstrap-typeahead": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/vue-bootstrap-typeahead/-/vue-bootstrap-typeahead-0.2.6.tgz",
-      "integrity": "sha512-BcUAnvfN+PS0StL6E3endd37P7HUt9otk+8m7tsa2gkt2I2KY8O2Dma49oR8ie8iletvJAlAqpN+klF6ktPULQ==",
-      "dev": true,
-      "requires": {
-        "resize-observer-polyfill": "^1.5.0",
-        "vue": "^2.5.17"
-      }
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -42,7 +42,6 @@
     "through": "^2.3.8",
     "treetables": "^1.1.3",
     "vue": "^2.6.11",
-    "vue-bootstrap-typeahead": "^0.2.6",
     "vue-jest": "^3.0.5",
     "vue-loader": "^15.8.3",
     "vue-template-compiler": "^2.6.11",

--- a/src/app/static/src/js/components/admin/addUserToRole.vue
+++ b/src/app/static/src/js/components/admin/addUserToRole.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="mb-3 ml-3">
-        <vue-bootstrap-typeahead
+        <typeahead
                 size="sm"
                 v-model="newUser"
                 placeholder="email"
@@ -8,15 +8,15 @@
             <template slot="append">
                 <button v-on:click="add" type="submit" class="btn btn-sm">Add user</button>
             </template>
-        </vue-bootstrap-typeahead>
+        </typeahead>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>
     </div>
 </template>
 
 <script>
     import {api} from "../../utils/api";
-    import VueBootstrapTypeahead from 'vue-bootstrap-typeahead'
     import ErrorInfo from "../errorInfo.vue";
+    import Typeahead from "../typeahead/typeahead.vue";
 
     export default {
         name: 'addUserToRole',
@@ -30,7 +30,7 @@
         },
         components: {
             ErrorInfo,
-            VueBootstrapTypeahead
+            Typeahead
         },
         watch: {
             newUser() {

--- a/src/app/static/src/js/components/permissions/addReportReader.vue
+++ b/src/app/static/src/js/components/permissions/addReportReader.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="mb-3">
-        <vue-bootstrap-typeahead
+        <typeahead
                 size="sm"
                 v-model="newUserGroup"
                 :placeholder="placeholder"
@@ -8,14 +8,14 @@
             <template slot="append">
                 <button v-on:click="add" type="submit" class="btn btn-sm">Add {{type}}</button>
             </template>
-        </vue-bootstrap-typeahead>
+        </typeahead>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>
     </div>
 </template>
 
 <script>
     import {api} from "../../utils/api";
-    import VueBootstrapTypeahead from 'vue-bootstrap-typeahead'
+    import Typeahead from "../typeahead/typeahead.vue";
     import ErrorInfo from "../errorInfo.vue";
 
     export default {
@@ -35,7 +35,7 @@
         },
         components: {
             ErrorInfo,
-            VueBootstrapTypeahead
+            Typeahead
         },
         watch: {
             newUserGroup() {

--- a/src/app/static/src/js/components/reports/reportReadersList.vue
+++ b/src/app/static/src/js/components/reports/reportReadersList.vue
@@ -13,7 +13,6 @@
 
 <script>
     import {api} from "../../utils/api";
-    import VueBootstrapTypeahead from 'vue-bootstrap-typeahead'
     import ErrorInfo from "../errorInfo.vue";
     import UserList from "../permissions/userList.vue";
     import AddReportReader from "../permissions/addReportReader";
@@ -36,8 +35,7 @@
         components: {
             AddReportReader,
             UserList,
-            ErrorInfo,
-            VueBootstrapTypeahead
+            ErrorInfo
         },
         computed: {
             availableUsers: function () {

--- a/src/app/static/src/js/components/typeahead/typeahead.vue
+++ b/src/app/static/src/js/components/typeahead/typeahead.vue
@@ -1,0 +1,168 @@
+<template>
+    <div>
+        <div :class="sizeClasses">
+            <div ref="prependDiv" v-if="$slots.prepend || prepend" class="input-group-prepend">
+                <slot name="prepend">
+                    <span class="input-group-text">{{ prepend }}</span>
+                </slot>
+            </div>
+            <input
+                    ref="input"
+                    type="search"
+                    :class="`form-control ${inputClass}`"
+                    :placeholder="placeholder"
+                    :aria-label="placeholder"
+                    :value="inputValue"
+                    @focus="isFocused = true"
+                    @blur="handleBlur"
+                    @input="handleInput($event.target.value)"
+                    @keyup.down="$emit('keyup.down', $event.target.value)"
+                    @keyup.up="$emit('keyup.up', $event.target.value)"
+                    @keyup.enter="$emit('keyup.enter', $event.target.value)"
+                    autocomplete="off"
+            />
+            <div v-if="$slots.append || append" class="input-group-append">
+                <slot name="append">
+                    <span class="input-group-text">{{ append }}</span>
+                </slot>
+            </div>
+        </div>
+        <vue-bootstrap-typeahead-list
+                class="vbt-autcomplete-list"
+                ref="list"
+                v-show="isFocused && data.length > 0"
+                :query="inputValue"
+                :data="formattedData"
+                :background-variant="backgroundVariant"
+                :text-variant="textVariant"
+                :maxMatches="maxMatches"
+                :minMatchingChars="minMatchingChars"
+                @hit="handleHit"
+        >
+            <!-- pass down all scoped slots -->
+            <template v-for="(slot, slotName) in $scopedSlots" :slot="slotName" slot-scope="{ data, htmlText }">
+                <slot :name="slotName" v-bind="{ data, htmlText }"></slot>
+            </template>
+            <!-- below is the right solution, however if the user does not provide a scoped slot, vue will still set $scopedSlots.suggestion to a blank scope
+            <template v-if="$scopedSlots.suggestion" slot="suggestion" slot-scope="{ data, htmlText }">
+              <slot name="suggestion" v-bind="{ data, htmlText }" />
+            </template>-->
+        </vue-bootstrap-typeahead-list>
+    </div>
+</template>
+
+<script>
+    import VueBootstrapTypeaheadList from './typeaheadList.vue'
+
+    export default {
+        name: 'VueBootstrapTypehead',
+
+        components: {
+            VueBootstrapTypeaheadList
+        },
+
+        props: {
+            size: {
+                type: String,
+                default: null,
+                validator: size => ['lg', 'sm'].indexOf(size) > -1
+            },
+            value: {
+                type: String
+            },
+            data: {
+                type: Array,
+                required: true,
+                validator: d => d instanceof Array
+            },
+            serializer: {
+                type: Function,
+                default: (d) => d,
+                validator: d => d instanceof Function
+            },
+            backgroundVariant: String,
+            textVariant: String,
+            inputClass: {
+                type: String,
+                default: ''
+            },
+            maxMatches: {
+                type: Number,
+                default: 10
+            },
+            minMatchingChars: {
+                type: Number,
+                default: 2
+            },
+            placeholder: String,
+            prepend: String,
+            append: String
+        },
+
+        computed: {
+            sizeClasses() {
+                return this.size ? `input-group input-group-${this.size}` : 'input-group'
+            },
+
+            formattedData() {
+                if (!(this.data instanceof Array)) {
+                    return []
+                }
+                return this.data.map((d, i) => {
+                    return {
+                        id: i,
+                        data: d,
+                        text: this.serializer(d)
+                    }
+                })
+            }
+        },
+
+        methods: {
+            handleHit(evt) {
+                if (typeof this.value !== 'undefined') {
+                    this.$emit('input', evt.text)
+                }
+
+                this.inputValue = evt.text
+                this.$emit('hit', evt.data)
+                this.$refs.input.blur()
+                this.isFocused = false
+            },
+
+            handleBlur(evt) {
+                const tgt = evt.relatedTarget
+                if (tgt && tgt.classList.contains('vbst-item')) {
+                    return
+                }
+                this.isFocused = false
+            },
+
+            handleInput(newValue) {
+                this.inputValue = newValue
+
+                // If v-model is being used, emit an input event
+                if (typeof this.value !== 'undefined') {
+                    this.$emit('input', newValue)
+                }
+            }
+        },
+
+        data() {
+            return {
+                isFocused: false,
+                inputValue: ''
+            }
+        }
+    }
+</script>
+
+<style scoped>
+    .vbt-autcomplete-list {
+        padding-top: 5px;
+        position: absolute;
+        max-height: 350px;
+        overflow-y: auto;
+        z-index: 999;
+    }
+</style>

--- a/src/app/static/src/js/components/typeahead/typeaheadList.vue
+++ b/src/app/static/src/js/components/typeahead/typeaheadList.vue
@@ -1,0 +1,147 @@
+<template>
+    <div class="list-group shadow">
+        <vue-bootstrap-typeahead-list-item
+                v-for="(item, id) in matchedItems" :key="id"
+                :data="item.data"
+                :html-text="highlight(item.text)"
+                :background-variant="backgroundVariant"
+                :text-variant="textVariant"
+                :active="isListItemActive(id)"
+                @click.native="handleHit(item, $event)"
+        >
+            <template v-if="$scopedSlots.suggestion" slot="suggestion" slot-scope="{ data, htmlText }">
+                <slot name="suggestion" v-bind="{ data, htmlText }"/>
+            </template>
+        </vue-bootstrap-typeahead-list-item>
+    </div>
+</template>
+
+<script>
+    import VueBootstrapTypeaheadListItem from './typeaheadListItem.vue'
+
+    function sanitize(text) {
+        return text.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    }
+
+    function escapeRegExp(str) {
+        return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    }
+
+    export default {
+        name: 'VueBootstrapTypeaheadList',
+
+        components: {
+            VueBootstrapTypeaheadListItem
+        },
+
+        props: {
+            data: {
+                type: Array,
+                required: true,
+                validator: d => d instanceof Array
+            },
+            query: {
+                type: String,
+                default: ''
+            },
+            backgroundVariant: {
+                type: String
+            },
+            textVariant: {
+                type: String
+            },
+            maxMatches: {
+                type: Number,
+                default: 10
+            },
+            minMatchingChars: {
+                type: Number,
+                default: 2
+            }
+        },
+        data() {
+            return {
+                activeListItem: -1
+            }
+        },
+        computed: {
+            highlight() {
+                return (text) => {
+                    text = sanitize(text)
+                    if (this.query.length === 0) {
+                        return text
+                    }
+                    const re = new RegExp(this.escapedQuery, 'gi')
+
+                    return text.replace(re, `<strong>$&</strong>`)
+                }
+            },
+
+            escapedQuery() {
+                return escapeRegExp(sanitize(this.query))
+            },
+
+            matchedItems() {
+                if (this.query.length === 0 || this.query.length < this.minMatchingChars) {
+                    return []
+                }
+
+                const re = new RegExp(this.escapedQuery, 'gi')
+
+                // Filter, sort, and concat
+                return this.data
+                    .filter(i => i.text.match(re) !== null)
+                    .sort((a, b) => {
+                        const aIndex = a.text.indexOf(a.text.match(re)[0])
+                        const bIndex = b.text.indexOf(b.text.match(re)[0])
+
+                        if (aIndex < bIndex) {
+                            return -1
+                        }
+                        if (aIndex > bIndex) {
+                            return 1
+                        }
+                        return 0
+                    }).slice(0, this.maxMatches)
+            }
+        },
+
+        methods: {
+            handleHit(item, evt) {
+                this.$emit('hit', item)
+                evt.preventDefault()
+            },
+            isListItemActive(id) {
+                return this.activeListItem === id
+            },
+            resetActiveListItem() {
+                this.activeListItem = -1
+            },
+            selectNextListItem() {
+                if (this.activeListItem < this.matchedItems.length - 1) {
+                    this.activeListItem++
+                } else {
+                    this.resetActiveListItem()
+                }
+            },
+            selectPreviousListItem() {
+                if (this.activeListItem < 0) {
+                    this.activeListItem = this.matchedItems.length - 1
+                } else {
+                    this.activeListItem--
+                }
+            },
+            hitActiveListItem() {
+                if (this.activeListItem >= 0) {
+                    this.$emit('hit', this.matchedItems[this.activeListItem])
+                }
+            }
+        },
+        created() {
+            this.$parent.$on('input', this.resetActiveListItem)
+            this.$parent.$on('keyup.down', this.selectNextListItem)
+            this.$parent.$on('keyup.up', this.selectPreviousListItem)
+            this.$parent.$on('keyup.enter', this.hitActiveListItem)
+        }
+    }
+</script>

--- a/src/app/static/src/js/components/typeahead/typeaheadListItem.vue
+++ b/src/app/static/src/js/components/typeahead/typeaheadListItem.vue
@@ -1,0 +1,42 @@
+<template>
+    <a
+            tabindex="0"
+            href="#"
+            :class="textClasses"
+    >
+        <slot name="suggestion" v-bind="{ data: data, htmlText: htmlText }">
+            <span v-html="htmlText"></span>
+        </slot>
+    </a>
+</template>
+
+<script>
+    export default {
+        name: 'VueBootstrapTypeaheadListItem',
+
+        props: {
+            data: {},
+            htmlText: {
+                type: String
+            },
+            active: {
+                type: Boolean
+            },
+            backgroundVariant: {
+                type: String
+            },
+            textVariant: {
+                type: String
+            }
+        },
+        computed: {
+            textClasses() {
+                const classes = ['vbst-item', 'list-group-item', 'list-group-item-action']
+                if (this.active) classes.push('active')
+                if (this.backgroundVariant) classes.push(`bg-${this.backgroundVariant}`)
+                if (this.textVariant) classes.push(`text-${this.textVariant}`)
+                return classes.join(' ')
+            }
+        }
+    }
+</script>

--- a/src/app/static/src/tests/components/typeahead/typeahead.test.js
+++ b/src/app/static/src/tests/components/typeahead/typeahead.test.js
@@ -1,0 +1,82 @@
+import { mount } from '@vue/test-utils'
+import VueBootstrapTypeahead from '../../../js/components/typeahead/typeahead.vue'
+import VueBootstrapTypeaheadList from '../../../js/components/typeahead/typeaheadList.vue'
+import Vue from "vue";
+
+describe('VueBootstrapTypeahead', () => {
+    let wrapper
+
+    const demoData = [
+        'Canada',
+        'United States',
+        'Mexico',
+        'Japan',
+        'China',
+        'United Kingdom'
+    ]
+
+    beforeEach(() => {
+        wrapper = mount(VueBootstrapTypeahead, {
+            propsData: {
+                data: demoData
+            }
+        })
+    })
+
+    it('Should mount and render a hidden typeahead list', () => {
+        let child = wrapper.find(VueBootstrapTypeaheadList)
+        expect(child).toBeTruthy()
+        expect(child.isVisible()).toBe(false)
+    })
+
+    it('Formats the input data properly', () => {
+        expect(wrapper.vm.formattedData[0].id).toBe(0)
+        expect(wrapper.vm.formattedData[0].data).toBe('Canada')
+        expect(wrapper.vm.formattedData[0].text).toBe('Canada')
+    })
+
+    it('Uses a custom serializer properly', async () => {
+        wrapper.setProps({
+            data: [{
+                name: 'Canada',
+                code: 'CA'
+            }],
+            value: 'Can',
+            serializer: t => t.name
+        })
+        await Vue.nextTick();
+        expect(wrapper.vm.formattedData[0].id).toBe(0)
+        expect(wrapper.vm.formattedData[0].data.code).toBe('CA')
+        expect(wrapper.vm.formattedData[0].text).toBe('Canada')
+    })
+
+    it('Show the list when given a query and focused', async () => {
+        let child = wrapper.find(VueBootstrapTypeaheadList)
+        wrapper.find('input').setValue('Can')
+        await Vue.nextTick();
+        expect(child.isVisible()).toBe(false)
+        wrapper.find('input').trigger('focus')
+        await Vue.nextTick();
+        expect(child.isVisible()).toBe(true)
+    })
+
+    it('Hides the list when blurred', async () => {
+        let child = wrapper.find(VueBootstrapTypeaheadList)
+        wrapper.setData({inputValue: 'Can'})
+        await Vue.nextTick();
+        wrapper.find('input').trigger('focus')
+        await Vue.nextTick();
+        expect(child.isVisible()).toBe(true)
+        wrapper.find('input').trigger('blur')
+        await Vue.nextTick();
+        expect(child.isVisible()).toBe(false)
+    })
+
+    it('Renders the list in different sizes', () => {
+        expect(wrapper.vm.sizeClasses).toBe('input-group')
+        wrapper.setProps({
+            size: 'lg'
+        })
+        expect(wrapper.vm.sizeClasses).toBe('input-group input-group-lg')
+    })
+})

--- a/src/app/static/src/tests/components/typeahead/typeaheadList.test.js
+++ b/src/app/static/src/tests/components/typeahead/typeaheadList.test.js
@@ -1,0 +1,165 @@
+import { mount } from '@vue/test-utils'
+import VueBootstrapTypeaheadList from '../../../js/components/typeahead/typeaheadList.vue'
+import VueBootstrapTypeaheadListItem from '../../../js/components/typeahead/typeaheadListItem.vue'
+import Vue from "vue";
+
+describe('VueBootstrapTypeaheadList', () => {
+    let wrapper
+
+    const demoData = [
+        {
+            id: 0,
+            data: 'Canada',
+            text: 'Canada'
+        },
+        {
+            id: 1,
+            data: 'USA',
+            text: 'USA'
+        },
+        {
+            id: 2,
+            data: 'Mexico',
+            text: 'Mexico'
+        },
+        {
+            id: 3,
+            data: 'Canadiana',
+            text: 'Canadiana'
+        }
+    ]
+
+    beforeEach(() => {
+        wrapper = mount(VueBootstrapTypeaheadList, {
+            propsData: {
+                data: demoData
+            }
+        })
+    })
+
+    it('Mounts and renders a list-group div', () => {
+        expect(wrapper.is('div')).toBe(true)
+        expect(wrapper.classes()).toContain('list-group')
+    })
+
+    it('Matches items when there is a query', async () => {
+        expect(wrapper.vm.matchedItems.length).toBe(0)
+        wrapper.setProps({
+            query: 'Can'
+        })
+        await Vue.nextTick();
+        expect(wrapper.vm.matchedItems.length).toBe(2)
+        expect(wrapper.findAll(VueBootstrapTypeaheadListItem).length).toBe(2)
+        wrapper.setProps({
+            query: 'Canada'
+        })
+        await Vue.nextTick();
+        expect(wrapper.vm.matchedItems.length).toBe(1)
+        expect(wrapper.findAll(VueBootstrapTypeaheadListItem).length).toBe(1)
+    })
+
+    it('Limits the number of matches with maxMatches', async () => {
+        wrapper.setProps({
+            query: 'can'
+        })
+        await Vue.nextTick();
+        expect(wrapper.vm.matchedItems.length).toBe(2)
+        wrapper.setProps({
+            maxMatches: 1
+        })
+        await Vue.nextTick();
+        expect(wrapper.vm.matchedItems.length).toBe(1)
+    })
+
+    it('Uses minMatchingChars to filter the number of matches', async () => {
+        wrapper.setProps({
+            query: 'c',
+            minMatchingChars: 1
+        })
+        await Vue.nextTick();
+        expect(wrapper.findAll(VueBootstrapTypeaheadListItem).length).toBe(3)
+    })
+
+    it('Highlights text matches properly', async () => {
+        wrapper.setProps({
+            query: 'Canada'
+        })
+        await Vue.nextTick();
+        expect(wrapper.find(VueBootstrapTypeaheadListItem).vm.htmlText).toBe('<strong>Canada</strong>')
+    })
+
+    it('Resets the active list item', async () => {
+        wrapper.setProps({
+            query: 'Can'
+        })
+        await Vue.nextTick();
+        wrapper.vm.$parent.$emit('keyup.down')
+        wrapper.vm.resetActiveListItem()
+        expect(wrapper.vm.activeListItem).toBe(-1)
+    })
+
+    it('Selects next list item on keyup.down', async () => {
+        wrapper.setProps({
+            query: 'Can'
+        })
+        await Vue.nextTick();
+        wrapper.vm.$parent.$emit('keyup.down')
+        expect(wrapper.vm.activeListItem).toBe(0)
+    })
+
+    it('Wraps back to input on keyup.down at bottom of list', async () => {
+        wrapper.setProps({
+            query: 'Canada'
+        })
+        await Vue.nextTick();
+        wrapper.vm.$parent.$emit('keyup.down')
+        wrapper.vm.$parent.$emit('keyup.down')
+        expect(wrapper.vm.activeListItem).toBe(-1)
+    })
+
+    it('Selects previous list item on keyup.up', async () => {
+        wrapper.setProps({
+            query: 'Can'
+        })
+        await Vue.nextTick();
+        wrapper.vm.$parent.$emit('keyup.up')
+        expect(wrapper.vm.activeListItem).toBe(wrapper.vm.matchedItems.length - 1)
+    })
+
+    it('Selects input on keyup.up at when at top of the list', async () => {
+        wrapper.setProps({
+            query: 'Can'
+        })
+        await Vue.nextTick();
+        wrapper.vm.$parent.$emit('keyup.down')
+        wrapper.vm.$parent.$emit('keyup.up')
+        expect(wrapper.vm.activeListItem).toBe(-1)
+    })
+
+    it('Hits active item on keyup.enter', async (done) => {
+        wrapper.setProps({
+            query: 'Can'
+        })
+        await Vue.nextTick();
+        wrapper.vm.$parent.$emit('keyup.down') // advance active Item
+        await Vue.nextTick();
+        wrapper.vm.$on('hit', (hitItem) => {
+            expect(hitItem).toBe(wrapper.vm.matchedItems[0])
+            done()
+        })
+
+        wrapper.vm.$parent.$emit('keyup.enter')
+    })
+
+    it('Indicates list item is active or inactive', async () => {
+        wrapper.setProps({
+            query: 'Can'
+        })
+        await Vue.nextTick();
+        wrapper.vm.$parent.$emit('keyup.down')
+        await Vue.nextTick();
+        expect(wrapper.vm.isListItemActive(0)).toBeTruthy()
+        expect(wrapper.vm.isListItemActive(1)).toBeFalsy()
+    })
+
+})

--- a/src/app/static/src/tests/components/typeahead/typeaheadListItem.test.js
+++ b/src/app/static/src/tests/components/typeahead/typeaheadListItem.test.js
@@ -1,0 +1,34 @@
+import { shallowMount } from '@vue/test-utils'
+import VueBootstrapTypeaheadListItem from '../../../js/components/typeahead/typeaheadListItem.vue'
+import Vue from "vue";
+
+describe('VueBootstrapTypeaheadListItem.vue', () => {
+    let wrapper
+    beforeEach(() => {
+        wrapper = shallowMount(VueBootstrapTypeaheadListItem)
+    })
+
+    it('Mounts and renders an <a> tag', () => {
+        expect(wrapper.exists()).toBe(true)
+        expect(wrapper.contains('a')).toBe(true)
+    })
+
+    it('Renders textVariant classes properly', async () => {
+        wrapper.setProps({textVariant: 'dark'})
+        await Vue.nextTick();
+        expect(wrapper.classes()).toEqual(expect.arrayContaining(['text-dark']))
+    })
+
+    it('Renders backgroundVariant classes properly', async () => {
+        wrapper.setProps({backgroundVariant: 'light'})
+        await Vue.nextTick();
+        expect(wrapper.classes()).toEqual(expect.arrayContaining(['bg-light']))
+    })
+
+    it('Renders active class', async () => {
+        wrapper.setProps({active: true})
+        await Vue.nextTick();
+        expect(wrapper.vm.active).toBe(true)
+        expect(wrapper.classes()).toEqual(expect.arrayContaining(['active']))
+    })
+})


### PR DESCRIPTION
The npm typeahead package seems to be dead, so I just pulled in the source code along with the fix for keyboard navigation from this PR on that repo: https://github.com/alexurquhart/vue-bootstrap-typeahead/pull/29