### PR TITLE
mrc-1339 Make roles with no permissions expandable

### DIFF
--- a/src/app/static/src/js/components/admin/rolePermissionsList.vue
+++ b/src/app/static/src/js/components/admin/rolePermissionsList.vue
@@ -2,11 +2,10 @@
     <ul class="list-unstyled roles" v-if="roles.length > 0">
         <li v-for="(role, index) in roles"
             v-bind:id="role.name"
-            v-bind:class="['role', {'open':expanded[index]}, {'has-children': role.permissions.length > 0}]">
+            v-bind:class="['role', 'has-children', {'open':expanded[index]}]">
             <div class="expander" v-on:click="toggle(index)"></div>
             <span v-text="role.name" v-on:click="toggle(index)" class="role-name"></span>
-            <permission-list v-if="role.permissions.length > 0"
-                             v-show="expanded[index]"
+            <permission-list v-show="expanded[index]"
                              cssClass="children"
                              :permissions="role.permissions"
                              :user-group="role.name"

--- a/src/app/static/src/tests/components/admin/rolePermissionsList.test.js
+++ b/src/app/static/src/tests/components/admin/rolePermissionsList.test.js
@@ -43,7 +43,8 @@ describe("rolePermissionsList", () => {
         expect(listItems.at(0).find(PermissionList).props().userGroup).toBe("Funders");
 
         expect(listItems.at(1).find('span').text()).toBe("Science");
-        expect(listItems.at(1).findAll(PermissionList).length).toBe(0);
+        expect(listItems.at(1).findAll(PermissionList).length).toBe(1);
+        expect(listItems.at(1).find(PermissionList).props().permissions.length).toBe(0);
 
     });
 


### PR DESCRIPTION
Roles in the role permission list should be shown as expandable, and should be clickable, to show the add permission  component. This was not the case - permission list was not included if no child permissions.,