### PR TITLE
Specify local path where orderly demo might already be located

### DIFF
--- a/dev/migrate-local-test.sh
+++ b/dev/migrate-local-test.sh
@@ -7,7 +7,7 @@ set -ex
 HERE=$(dirname $0)
 . $HERE/../scripts/migrate-common.sh
 
-if [[ -d demo ]]
+if [[ -d ${HERE}/../src/app/demo ]]
 then
   echo "Orderly demo folder already exists, not re-creating it"
 else

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/AdminPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/AdminPageTests.kt
@@ -40,13 +40,13 @@ class AdminPageTests : SeleniumTest()
     {
         val roleList = driver.findElement(By.cssSelector("#manage-roles"))
         val listItems = roleList.findElements(By.cssSelector("li.role"))
-        assertThat(listItems.size).isEqualTo(1)
-        assertThat(listItems[0].getAttribute("id")).isEqualTo("Funders")
+        assertThat(listItems.size).isEqualTo(2)
+        assertThat(listItems[1].getAttribute("id")).isEqualTo("Funders")
 
         //expand the role
-        listItems[0].findElement(By.tagName("span")).click()
+        listItems[1].findElement(By.tagName("span")).click()
         wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("#manage-roles li ul li")))
-        val memberItems = listItems[0].findElements(By.cssSelector("li"))
+        val memberItems = listItems[1].findElements(By.cssSelector("li"))
         assertThat(memberItems.size).isEqualTo(1)
         assertThat(memberItems[0].getAttribute("id")).isEqualTo("test.user@example.com")
     }


### PR DESCRIPTION
I found that ./dev/run-dependencies.sh wasn't working after that last merge because it was trying to create the orderly demo twice. I've modified migrate-local-test.sh to specify the expected demo path from $HERE. Does that make sense?