### PR TITLE
mrc-1345 endpoint to get single document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ src/.idea/vcs.xml
 src/.idea/workspace.xml
 src/app/demo
 src/app/git
+src/app/documents
 src/build/*
 src/classes/
 src/config/users/current_user

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/ActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/ActionContext.kt
@@ -18,6 +18,7 @@ interface ActionContext
     fun queryParams(key: String): String?
     fun params(): Map<String, String>
     fun params(key: String): String
+    fun splat() : Array<String>?
     fun addResponseHeader(key: String, value: String)
     fun addDefaultResponseHeaders(contentType: String)
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
@@ -34,6 +34,7 @@ open class DirectActionContext(private val context: SparkWebContext,
     override fun queryString(): String? = request.queryString()
     override fun params(): Map<String, String> = request.params()
     override fun params(key: String): String = request.params(key)
+    override fun splat(): Array<String>? = request.splat()
     override fun addResponseHeader(key: String, value: String)
     {
         response.header(key, value)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Helpers.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Helpers.kt
@@ -3,6 +3,7 @@ package org.vaccineimpact.orderlyweb
 import spark.Filter
 import spark.Request
 import spark.Response
+import java.io.File
 import java.net.URLDecoder
 import java.net.URLEncoder
 import javax.servlet.http.HttpServletResponse
@@ -50,6 +51,21 @@ fun extensionIsOneOf(fileName: String, extensions: Array<String>): Boolean
 {
     val ext = fileName.toLowerCase().split(".").last()
     return extensions.contains(ext)
+}
+
+fun guessFileType(filename: String): String
+{
+    val ext = File(filename).extension
+    return when (ext)
+    {
+        "csv" -> "text/csv"
+        "png" -> "image/png"
+        "svg" -> "image/svg+xml"
+        "pdf" -> "application/pdf"
+        "html" -> "text/html"
+        "css" -> "text/css"
+        else -> ContentTypes.binarydata
+    }
 }
 
 fun canRenderInBrowser(fileName: String): Boolean

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/RouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/RouteConfig.kt
@@ -31,6 +31,7 @@ object WebRouteConfig : RouteConfig
 
     override val endpoints: List<EndpointDefinition> =
             WebAuthRouteConfig.endpoints +
+                    WebDocumentRouteConfig.endpoints +
                     WebReportRouteConfig.endpoints +
                     WebVersionRouteConfig.endpoints +
                     WebUserRouteConfig.endpoints +

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebDocumentRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebDocumentRouteConfig.kt
@@ -6,9 +6,10 @@ import org.vaccineimpact.orderlyweb.controllers.web.DocumentController
 
 object WebDocumentRouteConfig : RouteConfig
 {
+    private val readDocuments = setOf("*/documents.read")
     override val endpoints: List<EndpointDefinition> = listOf(
             WebEndpoint("/documents/*",
                     DocumentController::class, "getDocument", contentType = ContentTypes.binarydata)
-                    .secure())
+                    .secure(readDocuments))
 
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebDocumentRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebDocumentRouteConfig.kt
@@ -1,0 +1,14 @@
+package org.vaccineimpact.orderlyweb.app_start.routing.web
+
+import org.vaccineimpact.orderlyweb.*
+import org.vaccineimpact.orderlyweb.app_start.RouteConfig
+import org.vaccineimpact.orderlyweb.controllers.web.DocumentController
+
+object WebDocumentRouteConfig : RouteConfig
+{
+    override val endpoints: List<EndpointDefinition> = listOf(
+            WebEndpoint("/documents/*",
+                    DocumentController::class, "getDocument", contentType = ContentTypes.binarydata)
+                    .secure())
+
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/Controller.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/Controller.kt
@@ -5,8 +5,10 @@ import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.encompass
 import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config
+import java.io.File
 
 
 abstract class Controller(val context: ActionContext, val appConfig: Config = AppConfig())

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ArtefactController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ArtefactController.kt
@@ -58,20 +58,4 @@ class ArtefactController(context: ActionContext,
         return true
     }
 
-    // TODO: Just return the mime type of the artefact file, once we have that metadata
-    private fun guessFileType(filename: String): String
-    {
-        val ext = File(filename).extension
-        return when (ext)
-        {
-            "csv" -> "text/csv"
-            "png" -> "image/png"
-            "svg" -> "image/svg+xml"
-            "pdf" -> "application/pdf"
-            "html" -> "text/html"
-            "css" -> "text/css"
-            else -> ContentTypes.binarydata
-        }
-    }
-
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/DocumentController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/DocumentController.kt
@@ -1,0 +1,46 @@
+package org.vaccineimpact.orderlyweb.controllers.web
+
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.FileSystem
+import org.vaccineimpact.orderlyweb.Files
+import org.vaccineimpact.orderlyweb.controllers.Controller
+import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.db.Config
+import org.vaccineimpact.orderlyweb.errors.MissingParameterError
+import org.vaccineimpact.orderlyweb.errors.OrderlyFileNotFoundError
+import org.vaccineimpact.orderlyweb.guessFileType
+
+class DocumentController(context: ActionContext,
+                         private val config: Config,
+                         private val files: FileSystem) : Controller(context)
+{
+    constructor(context: ActionContext) : this(context, AppConfig(), Files())
+    fun getDocument(): Boolean
+    {
+        val path = context.splat()?.joinToString("/")
+                ?: throw MissingParameterError("Path to document not provided")
+
+        val fileName = context.splat()!!.last()
+
+        val inline = context.queryParams("inline")?.toBoolean() ?: false
+
+        val absoluteFilePath = "${this.config["documents.root"]}/$path"
+
+        if (!files.fileExists(absoluteFilePath))
+        {
+            throw OrderlyFileNotFoundError(fileName)
+        }
+
+        val response = context.getSparkResponse().raw()
+
+        context.addDefaultResponseHeaders(guessFileType(fileName))
+        if (!inline)
+        {
+            context.addResponseHeader("Content-Disposition", "attachment; filename=\"$path\"")
+        }
+
+        files.writeFileToOutputStream(absoluteFilePath, response.outputStream)
+
+        return true
+    }
+}

--- a/src/app/src/main/resources/config.properties
+++ b/src/app/src/main/resources/config.properties
@@ -1,4 +1,5 @@
 orderly.root=${orderly_root}
+documents.root=${documents_root}
 db.location=${orderly_root}orderly.sqlite
 orderly.server=${orderly_server}
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/DocumentTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/DocumentTests.kt
@@ -1,0 +1,35 @@
+package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
+
+import org.assertj.core.api.Assertions
+import org.junit.After
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.ContentTypes
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
+import java.io.File
+
+class DocumentTests : IntegrationTest()
+{
+    //private val readDocuments = setOf(ReifiedPermission("documents.read", Scope.Global()))
+
+    @After
+    fun cleanup() {
+        File("documents").deleteRecursively()
+    }
+
+    @Test
+    fun `documents can be downloaded`()
+    {
+        File("documents/some/path").mkdirs()
+        File("documents/some/path/file.csv").createNewFile()
+        File("documents/some/path/file.csv").writeText("TEST")
+        val sessionCookie = webRequestHelper.webLoginWithMontagu()
+        val response = webRequestHelper.requestWithSessionCookie("/documents/some/path/file.csv", sessionCookie,
+                ContentTypes.binarydata)
+        assertSuccessful(response)
+        Assertions.assertThat(response.headers["content-type"]).isEqualTo("text/csv")
+        Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"some/path/file.csv\"")
+        Assertions.assertThat(response.text).isEqualTo("TEST")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/DocumentTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/DocumentTests.kt
@@ -11,11 +11,19 @@ import java.io.File
 
 class DocumentTests : IntegrationTest()
 {
-    //private val readDocuments = setOf(ReifiedPermission("documents.read", Scope.Global()))
+    private val readDocuments = setOf(ReifiedPermission("documents.read", Scope.Global()))
 
     @After
-    fun cleanup() {
+    fun cleanup()
+    {
         File("documents").deleteRecursively()
+    }
+
+    @Test
+    fun `only document readers can download documents`()
+    {
+        val url = "/documents/some/file.csv"
+        assertWebUrlSecured(url, readDocuments, contentType = ContentTypes.binarydata)
     }
 
     @Test
@@ -24,7 +32,7 @@ class DocumentTests : IntegrationTest()
         File("documents/some/path").mkdirs()
         File("documents/some/path/file.csv").createNewFile()
         File("documents/some/path/file.csv").writeText("TEST")
-        val sessionCookie = webRequestHelper.webLoginWithMontagu()
+        val sessionCookie = webRequestHelper.webLoginWithMontagu(readDocuments)
         val response = webRequestHelper.requestWithSessionCookie("/documents/some/path/file.csv", sessionCookie,
                 ContentTypes.binarydata)
         assertSuccessful(response)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/DocumentTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/DocumentTests.kt
@@ -29,7 +29,7 @@ class DocumentTests : IntegrationTest()
     @Test
     fun `only document readers can download documents`()
     {
-        val url = "/documents/some/file.csv"
+        val url = "/documents/some/path/file.csv"
         assertWebUrlSecured(url, readDocuments, contentType = ContentTypes.binarydata)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/DocumentTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/DocumentTests.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
 
 import org.assertj.core.api.Assertions
 import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.models.Scope
@@ -19,6 +20,12 @@ class DocumentTests : IntegrationTest()
         File("documents").deleteRecursively()
     }
 
+    @Before
+    fun setup() {
+        File("documents/some/path").mkdirs()
+        File("documents/some/path/file.csv").createNewFile()
+    }
+
     @Test
     fun `only document readers can download documents`()
     {
@@ -29,8 +36,6 @@ class DocumentTests : IntegrationTest()
     @Test
     fun `documents can be downloaded`()
     {
-        File("documents/some/path").mkdirs()
-        File("documents/some/path/file.csv").createNewFile()
         File("documents/some/path/file.csv").writeText("TEST")
         val sessionCookie = webRequestHelper.webLoginWithMontagu(readDocuments)
         val response = webRequestHelper.requestWithSessionCookie("/documents/some/path/file.csv", sessionCookie,

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
@@ -1,11 +1,10 @@
 package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Test
+import org.mockito.internal.verification.Times
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.Files
 import org.vaccineimpact.orderlyweb.controllers.web.DocumentController
@@ -39,6 +38,24 @@ class DocumentControllerTests : ControllerTest()
         verify(mockContext)
                 .addResponseHeader("Content-Disposition", "attachment; filename=\"some/path/file.csv\"")
         verify(mockContext).addDefaultResponseHeaders("text/csv")
+    }
+
+    @Test
+    fun `attachment header is not added for inline documents`()
+    {
+        File("documents/some/path").mkdirs()
+        File("documents/some/path/file.csv").createNewFile()
+
+        val mockContext = mock<ActionContext>() {
+            on { splat() } doReturn arrayOf("some", "path", "file.csv")
+            on { queryParams("inline") } doReturn "true"
+            on { this.getSparkResponse() } doReturn mockSparkResponse
+        }
+
+        val sut = DocumentController(mockContext, AppConfig(), Files())
+        sut.getDocument()
+        verify(mockContext, Times(0))
+                .addResponseHeader(eq("Content-Disposition"), any())
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
@@ -1,0 +1,40 @@
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.junit.After
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.Files
+import org.vaccineimpact.orderlyweb.controllers.web.DocumentController
+import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+import org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.api.ControllerTest
+import java.io.File
+
+class DocumentControllerTests : ControllerTest()
+{
+    @After
+    fun cleanup() {
+        File("documents").deleteRecursively()
+    }
+
+    @Test
+    fun `can get document`()
+    {
+        File("documents/some/path").mkdirs()
+        File("documents/some/path/file.csv").createNewFile()
+
+        val mockContext = mock<ActionContext>() {
+            on { splat() } doReturn arrayOf("some", "path", "file.csv")
+            on { this.getSparkResponse() } doReturn mockSparkResponse
+        }
+
+        val sut = DocumentController(mockContext, AppConfig(), Files())
+        sut.getDocument()
+        verify(mockContext)
+                .addResponseHeader("Content-Disposition", "attachment; filename=\"some/path/file.csv\"")
+        verify(mockContext).addDefaultResponseHeaders("text/csv")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
@@ -3,20 +3,23 @@ package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.After
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.Files
 import org.vaccineimpact.orderlyweb.controllers.web.DocumentController
 import org.vaccineimpact.orderlyweb.db.AppConfig
-import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+import org.vaccineimpact.orderlyweb.errors.MissingParameterError
+import org.vaccineimpact.orderlyweb.errors.OrderlyFileNotFoundError
 import org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.api.ControllerTest
 import java.io.File
 
 class DocumentControllerTests : ControllerTest()
 {
     @After
-    fun cleanup() {
+    fun cleanup()
+    {
         File("documents").deleteRecursively()
     }
 
@@ -36,5 +39,24 @@ class DocumentControllerTests : ControllerTest()
         verify(mockContext)
                 .addResponseHeader("Content-Disposition", "attachment; filename=\"some/path/file.csv\"")
         verify(mockContext).addDefaultResponseHeaders("text/csv")
+    }
+
+    @Test
+    fun `error is thrown if the path is missing`()
+    {
+        val sut = DocumentController(mock(), AppConfig(), Files())
+        assertThatThrownBy { sut.getDocument() }.isInstanceOf(MissingParameterError::class.java)
+    }
+
+    @Test
+    fun `error is thrown if the file does not exist`()
+    {
+        val mockContext = mock<ActionContext>() {
+            on { splat() } doReturn arrayOf("some", "path", "file.csv")
+            on { this.getSparkResponse() } doReturn mockSparkResponse
+        }
+
+        val sut = DocumentController(mockContext, AppConfig(), Files())
+        assertThatThrownBy { sut.getDocument() }.isInstanceOf(OrderlyFileNotFoundError::class.java)
     }
 }

--- a/src/app/src/test/resources/config.properties
+++ b/src/app/src/test/resources/config.properties
@@ -1,4 +1,5 @@
 orderly.root=${orderly_test_root}
+documents.root=${documents_root}
 db.template=${orderly_test_root}orderly.sqlite
 db.location=${orderly_test_root}testorderly.sqlite
 orderly.server=${orderly_test_server}

--- a/src/config/default.properties
+++ b/src/config/default.properties
@@ -6,6 +6,8 @@ orderly_test_server=http://localhost:8321
 orderly_test_port=8321
 orderly_test_container=orderly-test-server
 
+documents_root=documents/
+
 docker_host=tcp://localhost:2375
 
 app_url=http://localhost:8888


### PR DESCRIPTION
Endpoint to get a single document, locked down to the global `documents.read` permission. Supports inline browser viewing as well as download functionality.

Contains commits from https://github.com/vimc/orderly-web/pull/153