### PR TITLE
mrc-1368 publish reports without hitting orderly server

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/ReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/ReportRouteConfig.kt
@@ -33,6 +33,7 @@ object ReportRouteConfig : RouteConfig
             APIEndpoint("/reports/:key/status/", controller, "status")
                     .json()
                     .secure(runReports),
+
             APIEndpoint("/reports/:name/latest/changelog/", controller, "getLatestChangelogByName")
                     .json()
                     .transform()

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/VersionRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/VersionRouteConfig.kt
@@ -41,6 +41,7 @@ object VersionRouteConfig : RouteConfig
                     .json()
                     .transform()
                     .secure(reviewReports),
+
             APIEndpoint("/reports/:name/versions/:version/changelog/", versionController, "getChangelogByNameAndVersion")
                     .json()
                     .transform()

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/VersionRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/VersionRouteConfig.kt
@@ -39,6 +39,7 @@ object VersionRouteConfig : RouteConfig
             APIEndpoint("/reports/:name/versions/:version/publish/", reportController, "publish",
                     method = HttpMethod.post)
                     .json()
+                    .transform()
                     .secure(reviewReports),
             APIEndpoint("/reports/:name/versions/:version/changelog/", versionController, "getChangelogByNameAndVersion")
                     .json()

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebVersionRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebVersionRouteConfig.kt
@@ -26,6 +26,7 @@ object WebVersionRouteConfig : RouteConfig
             WebEndpoint("/report/:name/version/:version/publish/",
                     org.vaccineimpact.orderlyweb.controllers.api.ReportController::class, "publish",
                     method = HttpMethod.post)
+                    .transform()
                     .json()
                     .secure(reviewReports),
             WebEndpoint("/report/:name/version/:version/data/:data/",

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
@@ -17,14 +17,12 @@ import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
 
 class ReportController(context: ActionContext,
                        private val orderly: OrderlyClient,
-                       private val zip: ZipClient,
                        private val orderlyServerAPI: OrderlyServerAPI,
-                       private val config: Config) : Controller(context, config)
+                       config: Config) : Controller(context, config)
 {
     constructor(context: ActionContext) :
             this(context,
                     Orderly(context),
-                    Zip(),
                     OrderlyServer(AppConfig(), KHttpClient()),
                     AppConfig())
 
@@ -39,10 +37,9 @@ class ReportController(context: ActionContext,
     {
         val name = context.params(":name")
         val version = context.params(":version")
-        val response = orderlyServerAPI.post("/reports/$name/$version/publish/", context)
-        return passThroughResponse(response)
+        orderly.togglePublishStatus(name, version)
+        return okayResponse()
     }
-
 
     fun status(): String
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
@@ -33,12 +33,11 @@ class ReportController(context: ActionContext,
         return passThroughResponse(response)
     }
 
-    fun publish(): String
+    fun publish(): Boolean
     {
         val name = context.params(":name")
         val version = context.params(":version")
-        orderly.togglePublishStatus(name, version)
-        return okayResponse()
+        return orderly.togglePublishStatus(name, version)
     }
 
     fun status(): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -264,14 +264,17 @@ class Orderly(val isReviewer: Boolean,
         }
     }
 
-    override fun togglePublishStatus(name: String, version: String)
+    override fun togglePublishStatus(name: String, version: String): Boolean
     {
         JooqContext().use {
             val existing = getReportVersion(name, version, it)
+            val newStatus = !existing.published
             it.dsl.update(REPORT_VERSION)
-                    .set(REPORT_VERSION.PUBLISHED, !existing.published)
+                    .set(REPORT_VERSION.PUBLISHED, newStatus)
                     .where(REPORT_VERSION.ID.eq(version))
                     .execute()
+
+            return newStatus
         }
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -267,9 +267,9 @@ class Orderly(val isReviewer: Boolean,
     override fun togglePublishStatus(name: String, version: String)
     {
         JooqContext().use {
-            getReportVersion(name, version, it)
+            val existing = getReportVersion(name, version, it)
             it.dsl.update(REPORT_VERSION)
-                    .set(REPORT_VERSION.PUBLISHED, REPORT_VERSION.PUBLISHED.neg())
+                    .set(REPORT_VERSION.PUBLISHED, !existing.published)
                     .where(REPORT_VERSION.ID.eq(version))
                     .execute()
         }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -247,7 +247,6 @@ class Orderly(val isReviewer: Boolean,
             return getDatedChangelogForReport(name, latestVersionDate.value1(), it)
 
         }
-
     }
 
     override fun getChangelogByNameAndVersion(name: String, version: String): List<Changelog>
@@ -279,6 +278,7 @@ class Orderly(val isReviewer: Boolean,
                     .execute()
 
             return newStatus
+        }
     }
       
     private fun getDataInfo(name: String, version: String): List<DataInfo>

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -1,7 +1,6 @@
 package org.vaccineimpact.orderlyweb.db
 
-import org.jooq.impl.DSL.select
-import org.jooq.impl.DSL.trueCondition
+import org.jooq.impl.DSL.*
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.db.Tables.*
@@ -262,6 +261,17 @@ class Orderly(val isReviewer: Boolean,
     {
         JooqContext().use {
             getReportVersion(name, version, it)
+        }
+    }
+
+    override fun togglePublishStatus(name: String, version: String)
+    {
+        JooqContext().use {
+            getReportVersion(name, version, it)
+            it.dsl.update(REPORT_VERSION)
+                    .set(REPORT_VERSION.PUBLISHED, REPORT_VERSION.PUBLISHED.neg())
+                    .where(REPORT_VERSION.ID.eq(version))
+                    .execute()
         }
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
@@ -50,5 +50,5 @@ interface OrderlyClient
 
     fun getReadme(name: String, version: String): Map<String, String>
 
-    fun togglePublishStatus(name: String, version: String)
+    fun togglePublishStatus(name: String, version: String): Boolean
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
@@ -49,4 +49,6 @@ interface OrderlyClient
     fun getLatestChangelogByName(name: String): List<Changelog>
 
     fun getReadme(name: String, version: String): Map<String, String>
+
+    fun togglePublishStatus(name: String, version: String)
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportTests.kt
@@ -216,11 +216,13 @@ class ReportTests : CleanDatabaseTests()
 
         val sut = createSut(isReviewer = true)
 
-        sut.togglePublishStatus("test", "version1")
+        var result = sut.togglePublishStatus("test", "version1")
 
         assertThat(sut.getDetailsByNameAndVersion("test", "version1").published).isFalse()
+        assertThat(result).isFalse()
 
-        sut.togglePublishStatus("test", "version1")
+        result = sut.togglePublishStatus("test", "version1")
+        assertThat(result).isTrue()
 
         assertThat(sut.getDetailsByNameAndVersion("test", "version1").published).isTrue()
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportTests.kt
@@ -209,4 +209,21 @@ class ReportTests : CleanDatabaseTests()
 
     }
 
+    @Test
+    fun `can toggle publish status`()
+    {
+        insertReport("test", "version1", published = true)
+
+        val sut = createSut(isReviewer = true)
+
+        sut.togglePublishStatus("test", "version1")
+
+        assertThat(sut.getDetailsByNameAndVersion("test", "version1").published).isFalse()
+
+        sut.togglePublishStatus("test", "version1")
+
+        assertThat(sut.getDetailsByNameAndVersion("test", "version1").published).isTrue()
+
+    }
+
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportTests.kt
@@ -190,7 +190,6 @@ class ReportTests : CleanDatabaseTests()
         assertThat(results[2].name).isEqualTo("test3")
     }
 
-
     @Test
     fun `reviewer can get all published and unpublished report versions for report`()
     {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/VersionTests.kt
@@ -23,7 +23,7 @@ class VersionTests : IntegrationTest()
     @Test // method name prefixed with A so runs first
     fun `A publishes report`()
     {
-        val unpublishedVersion = JooqContext("git/orderly.sqlite").use {
+        val unpublishedVersion = JooqContext().use {
 
             it.dsl.select(Tables.REPORT_VERSION.ID, REPORT_VERSION.REPORT)
                     .from(Tables.REPORT_VERSION)
@@ -41,7 +41,7 @@ class VersionTests : IntegrationTest()
         val data = JSONValidator.getData(response.text).asBoolean()
         assertThat(data).isEqualTo(true)
 
-        val publishStatus = JooqContext("git/orderly.sqlite").use {
+        val publishStatus = JooqContext().use {
 
             it.dsl.select(Tables.REPORT_VERSION.PUBLISHED)
                     .from(Tables.REPORT_VERSION)
@@ -57,7 +57,7 @@ class VersionTests : IntegrationTest()
     @Test // method name prefixed with B so runs first
     fun `B unpublishes report`()
     {
-        val publishedVersion = JooqContext("git/orderly.sqlite").use {
+        val publishedVersion = JooqContext().use {
 
             it.dsl.select(Tables.REPORT_VERSION.ID, REPORT_VERSION.REPORT)
                     .from(Tables.REPORT_VERSION)
@@ -78,7 +78,7 @@ class VersionTests : IntegrationTest()
         val data = JSONValidator.getData(response.text).asBoolean()
         assertThat(data).isEqualTo(false)
 
-        val publishStatus = JooqContext("git/orderly.sqlite").use {
+        val publishStatus = JooqContext().use {
 
             it.dsl.select(Tables.REPORT_VERSION.PUBLISHED)
                     .from(Tables.REPORT_VERSION)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/VersionTests.kt
@@ -17,7 +17,7 @@ class VersionTests : IntegrationTest()
     @Test
     fun `only report reviewers can publish report version`()
     {
-        val version = JooqContext("git/orderly.sqlite").use {
+        val version = JooqContext().use {
 
             it.dsl.select(REPORT_VERSION.ID, REPORT_VERSION.REPORT)
                     .from(REPORT_VERSION)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/VersionTests.kt
@@ -18,7 +18,6 @@ class VersionTests : IntegrationTest()
     fun `only report reviewers can publish report version`()
     {
         val version = JooqContext().use {
-
             it.dsl.select(REPORT_VERSION.ID, REPORT_VERSION.REPORT)
                     .from(REPORT_VERSION)
                     .fetchAny()
@@ -29,7 +28,8 @@ class VersionTests : IntegrationTest()
 
         val url = "/report/$reportName/version/$versionId/publish/"
 
-        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.review", Scope.Global())), method = HttpMethod.post,
+        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Global()),
+                ReifiedPermission("reports.review", Scope.Global())), method = HttpMethod.post,
                 contentType = ContentTypes.json)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
@@ -158,7 +158,9 @@ class ReportControllerTests : ControllerTest()
     {
         val name = "reportName"
         val version = "v1"
-        val orderly = mock<OrderlyClient>()
+        val orderly = mock<OrderlyClient>() {
+            on {togglePublishStatus(name, version)} doReturn false
+        }
 
         val mockContext = mock<ActionContext> {
             on { this.params(":version") } doReturn version
@@ -171,7 +173,7 @@ class ReportControllerTests : ControllerTest()
 
         val result = sut.publish()
 
-        assertThat(result).isEqualTo("OK")
+        assertThat(result).isEqualTo(false)
 
         verify(orderly).togglePublishStatus(name, version)
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
@@ -29,12 +29,6 @@ class ReportControllerTests : ControllerTest()
 
     private val reportName = "report1"
 
-    private val permissionSetForSingleReport = PermissionSet(
-            setOf(ReifiedPermission("reports.read", Scope.Specific("report", reportName))))
-
-    private val permissionSetGlobal = PermissionSet(
-            setOf(ReifiedPermission("reports.read", Scope.Global())))
-
     private val reports = listOf(Report(reportName, "test full name 1", "v1"),
             Report("testname2", "test full name 2", "v1"))
 
@@ -68,7 +62,7 @@ class ReportControllerTests : ControllerTest()
         }
 
         val sut = ReportController(actionContext, mock<OrderlyClient>(),
-                mock<ZipClient>(), apiClient, mockConfig)
+               apiClient, mockConfig)
 
         val result = sut.run()
 
@@ -82,7 +76,7 @@ class ReportControllerTests : ControllerTest()
             on { it.permissions } doReturn PermissionSet()
         }
 
-        val sut = ReportController(mockContext, mockOrderly, mock(),
+        val sut = ReportController(mockContext, mockOrderly,
                 mock(),
                 mockConfig)
 
@@ -99,7 +93,7 @@ class ReportControllerTests : ControllerTest()
         }
 
         val sut = ReportController(mockContext, mock(), mock(),
-                mock(), mockConfig)
+                mockConfig)
 
         assertThatThrownBy { sut.getAllVersions() }
                 .isInstanceOf(MissingRequiredPermissionError::class.java)
@@ -120,7 +114,7 @@ class ReportControllerTests : ControllerTest()
             on { it.params(":name") } doReturn reportName
         }
 
-        val sut = ReportController(mockContext, orderly, mock<ZipClient>(),
+        val sut = ReportController(mockContext, orderly,
                 mock<OrderlyServerAPI>(),
                 mockConfig)
 
@@ -146,7 +140,7 @@ class ReportControllerTests : ControllerTest()
             on { this.params(":name") } doReturn reportName
         }
 
-        val sut = ReportController(mockContext, orderly, mock<ZipClient>(),
+        val sut = ReportController(mockContext, orderly,
                 mock<OrderlyServerAPI>(),
                 mockConfig)
 


### PR DESCRIPTION
Rather than round tripping publishing via orderly server, just update the db directly.