### PR TITLE
throw custom exception if token is expired

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/ExpiredToken.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/ExpiredToken.kt
@@ -1,0 +1,7 @@
+package org.vaccineimpact.orderlyweb.errors
+
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
+
+class ExpiredToken : OrderlyWebError(401, listOf(
+        ErrorInfo("bearer-token-invalid", "Token has expired. Please request a new one.")
+))

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/OrderlyWebBearerTokenAuthenticator.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/OrderlyWebBearerTokenAuthenticator.kt
@@ -4,13 +4,21 @@ import com.nimbusds.jwt.JWT
 import org.pac4j.core.credentials.TokenCredentials
 import org.pac4j.core.exception.CredentialsException
 import org.pac4j.jwt.config.signature.SignatureConfiguration
+import java.text.ParseException
 
 open class OrderlyWebBearerTokenAuthenticator(signatureConfiguration: SignatureConfiguration, expectedIssuer: String)
     : OrderlyWebTokenAuthenticator(signatureConfiguration, expectedIssuer)
 {
     override fun createJwtProfile(credentials: TokenCredentials, jwt: JWT)
     {
-        super.createJwtProfile(credentials, jwt)
+        try
+        {
+            super.createJwtProfile(credentials, jwt)
+        }
+        catch (e: ParseException)
+        {
+            throw CredentialsException("Token is invalid.")
+        }
         if (credentials.userProfile == null)
         {
             throw CredentialsException("Token has expired. Please request a new one.")

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/OrderlyWebBearerTokenAuthenticator.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/OrderlyWebBearerTokenAuthenticator.kt
@@ -11,6 +11,10 @@ open class OrderlyWebBearerTokenAuthenticator(signatureConfiguration: SignatureC
     override fun createJwtProfile(credentials: TokenCredentials, jwt: JWT)
     {
         super.createJwtProfile(credentials, jwt)
+        if (credentials.userProfile == null)
+        {
+            throw CredentialsException("Token has expired. Please request a new one.")
+        }
         val claims = jwt.jwtClaimsSet
         val issuer = claims.issuer
         if (issuer != expectedIssuer)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/OrderlyWebBearerTokenAuthenticator.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/authentication/OrderlyWebBearerTokenAuthenticator.kt
@@ -4,24 +4,18 @@ import com.nimbusds.jwt.JWT
 import org.pac4j.core.credentials.TokenCredentials
 import org.pac4j.core.exception.CredentialsException
 import org.pac4j.jwt.config.signature.SignatureConfiguration
-import java.text.ParseException
+import org.vaccineimpact.orderlyweb.errors.ExpiredToken
 
 open class OrderlyWebBearerTokenAuthenticator(signatureConfiguration: SignatureConfiguration, expectedIssuer: String)
     : OrderlyWebTokenAuthenticator(signatureConfiguration, expectedIssuer)
 {
     override fun createJwtProfile(credentials: TokenCredentials, jwt: JWT)
     {
-        try
-        {
-            super.createJwtProfile(credentials, jwt)
-        }
-        catch (e: ParseException)
-        {
-            throw CredentialsException("Token is invalid.")
-        }
+        super.createJwtProfile(credentials, jwt)
+
         if (credentials.userProfile == null)
         {
-            throw CredentialsException("Token has expired. Please request a new one.")
+            throw ExpiredToken()
         }
         val claims = jwt.jwtClaimsSet
         val issuer = claims.issuer

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/clients/JWTHeaderClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/clients/JWTHeaderClient.kt
@@ -1,5 +1,8 @@
 package org.vaccineimpact.orderlyweb.security.clients
 
+import org.pac4j.core.context.WebContext
+import org.pac4j.core.credentials.TokenCredentials
+import org.pac4j.core.exception.CredentialsException
 import org.pac4j.http.client.direct.HeaderClient
 import org.vaccineimpact.orderlyweb.models.ErrorInfo
 import org.vaccineimpact.orderlyweb.security.authentication.OrderlyWebBearerTokenAuthenticator
@@ -11,7 +14,6 @@ class JWTHeaderClient(helper: RSATokenVerifier) : OrderlyWebTokenCredentialClien
         "Authorization",
         "Bearer ",
         OrderlyWebBearerTokenAuthenticator(helper.signatureConfiguration, helper.expectedIssuer))
-
 {
     override val errorInfo = ErrorInfo("bearer-token-invalid",
             "Bearer token not supplied in Authorization header, or bearer token was invalid")
@@ -20,5 +22,34 @@ class JWTHeaderClient(helper: RSATokenVerifier) : OrderlyWebTokenCredentialClien
     {
         setAuthorizationGenerator(OrderlyAuthorizationGenerator())
         super.clientInit()
+    }
+
+    override fun retrieveCredentials(context: WebContext): TokenCredentials?
+    {
+        return try
+        {
+            val credentials = credentialsExtractor.extract(context) ?: return null
+            val t0 = System.currentTimeMillis()
+            try
+            {
+                authenticator.validate(credentials, context)
+            } finally
+            {
+                val t1 = System.currentTimeMillis()
+                logger.debug("Credentials validation took: {} ms", t1 - t0)
+            }
+            credentials
+        }
+        catch (e: CredentialsException)
+        {
+            logger.info("Failed to retrieve or validate credentials: {}", e.message)
+            logger.debug("Failed to retrieve or validate credentials", e)
+            if (e.message != null)
+            {
+                val errorInfo = ErrorInfo("bearer-token-invalid", e.message!!)
+                context.sessionStore.set(context, "credentials_exception", errorInfo)
+            }
+            null
+        }
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/clients/JWTHeaderClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/security/clients/JWTHeaderClient.kt
@@ -26,6 +26,9 @@ class JWTHeaderClient(helper: RSATokenVerifier) : OrderlyWebTokenCredentialClien
 
     override fun retrieveCredentials(context: WebContext): TokenCredentials?
     {
+        // this method is the same as the base class except that it adds the
+        // credentials exception to the session store for later retrieval and
+        // return to the client
         return try
         {
             val credentials = credentialsExtractor.extract(context) ?: return null

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/APIRequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/APIRequestHelper.kt
@@ -52,6 +52,12 @@ class APIRequestHelper: RequestHelper()
         return get(baseUrl + url, headers)
     }
 
+    fun getWithToken(url: String, bearerToken: String): Response
+    {
+        val headers = standardHeaders(ContentTypes.json).withAuthorizationHeader(bearerToken)
+        return get(baseUrl + url, headers)
+    }
+
     fun getWrongPermissions(url: String, contentType: String = ContentTypes.json): Response
     {
         val token = generateToken("bademail@gmail.com")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/SecurityTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/SecurityTests.kt
@@ -39,7 +39,7 @@ class SecurityTests : IntegrationTest()
         assertJsonContentType(response)
         Assertions.assertThat(response.statusCode).isEqualTo(401)
         JSONValidator.validateError(response.text, "bearer-token-invalid",
-                "Token is invalid.")
+                "Bearer token not supplied in Authorization header, or bearer token was invalid")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/SecurityTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/SecurityTests.kt
@@ -11,6 +11,7 @@ import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeReportRe
 import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
 import sun.security.jca.GetInstance
 import java.time.Instant
+import java.util.*
 
 class SecurityTests : IntegrationTest()
 {
@@ -55,9 +56,9 @@ class SecurityTests : IntegrationTest()
     }
 
     @Test
-    fun `returns 401 if token is expired`()
+    fun `returns 401 if bearer token is expired`()
     {
-        val alreadyExpired = Instant.now()
+        val alreadyExpired = Date.from(Instant.now())
         val claims = WebTokenHelper.instance.issuer.bearerTokenClaims(fakeGlobalReportReviewer())
         val expiredClaims = claims.filter { it.component1() != "exp" } + mapOf("exp" to alreadyExpired)
         val expiredToken = WebTokenHelper.instance.issuer.generator.generate(expiredClaims)
@@ -67,7 +68,7 @@ class SecurityTests : IntegrationTest()
         assertJsonContentType(response)
         Assertions.assertThat(response.statusCode).isEqualTo(401)
         JSONValidator.validateError(response.text, "bearer-token-invalid",
-                "Bearer token not supplied in Authorization header, or bearer token was invalid")
+                "Token has expired. Please request a new one.")
     }
 
     /**  Access token tests */

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/SecurityTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/SecurityTests.kt
@@ -39,8 +39,7 @@ class SecurityTests : IntegrationTest()
         assertJsonContentType(response)
         Assertions.assertThat(response.statusCode).isEqualTo(401)
         JSONValidator.validateError(response.text, "bearer-token-invalid",
-                "Bearer token not supplied in Authorization header, or bearer token was invalid")
-
+                "Token is invalid.")
     }
 
     @Test


### PR DESCRIPTION
So that a 401 with a clear message is returned rather an unexpected error from a null reference exception.