### PR TITLE
Mrc 1370 Show report version parameter values

### DIFF
--- a/docs/spec/VersionDetails.schema.json
+++ b/docs/spec/VersionDetails.schema.json
@@ -10,8 +10,9 @@
         "published":  {"type" :"boolean"},
         "artefacts": { "type": "array", "items": { "$ref": "Artefact.schema.json"}},
         "resources": {"type": "array", "items": {"type": "string"}},
-        "data_info": {"type":  "array", "items":  {"$ref": "DataInfo.schema.json"}}
+        "data_info": {"type":  "array", "items":  {"$ref": "DataInfo.schema.json"}},
+		"parameter_values": {"type":  "object"}
 	},
 	"additionalProperties": false,
-	"required": ["name", "id", "display_name", "description", "date", "published"]
+	"required": ["name", "id", "display_name", "description", "date", "published", "parameter_values"]
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -144,7 +144,8 @@ class Orderly(val isReviewer: Boolean,
         JooqContext().use {
 
             val reportVersionResult = getReportVersion(name, version, it)
-            val aretefacts = getArtefacts(name, version)
+            val artefacts = getArtefacts(name, version)
+            val parameterValues = getParametersForVersions(listOf(version))[version] ?: mapOf()
 
             return ReportVersionDetails(id = reportVersionResult.id,
                     name = reportVersionResult.report,
@@ -152,9 +153,10 @@ class Orderly(val isReviewer: Boolean,
                     date = reportVersionResult.date.toInstant(),
                     description = reportVersionResult.description,
                     published = reportVersionResult.published,
-                    artefacts = aretefacts,
+                    artefacts = artefacts,
                     resources = getResourceFiles(name, version),
-                    dataInfo = getDataInfo(name, version))
+                    dataInfo = getDataInfo(name, version),
+                    parameterValues = parameterValues)
         }
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -68,7 +68,7 @@ class Orderly(val isReviewer: Boolean,
                             .orderBy(REPORT_VERSION.REPORT, REPORT_VERSION.ID)
                             .fetch()
 
-            return mapToReportVersionsWithCustomFields(it, versions)
+            return mapToReportVersions(it, versions)
         }
     }
 
@@ -95,7 +95,7 @@ class Orderly(val isReviewer: Boolean,
                     .orderBy(ORDERLYWEB_PINNED_REPORT_GLOBAL.ORDERING)
                     .fetch()
 
-            return mapToReportVersionsWithCustomFields(it, versions)
+            return mapToReportVersions(it, versions)
         }
     }
 
@@ -268,8 +268,8 @@ class Orderly(val isReviewer: Boolean,
         }
     }
 
-    private fun mapToReportVersionsWithCustomFields(ctx: JooqContext,
-                                                    versions: Result<GenericReportVersionRecord>): List<ReportVersion>
+    private fun mapToReportVersions(ctx: JooqContext,
+                                    versions: Result<GenericReportVersionRecord>): List<ReportVersion>
     {
         val allCustomFields = ctx.dsl.select(
                 CUSTOM_FIELDS.ID)
@@ -287,6 +287,8 @@ class Orderly(val isReviewer: Boolean,
                 .fetch()
                 .groupBy{ it[REPORT_VERSION_CUSTOM_FIELDS.REPORT_VERSION] }
 
+        val parametersForVersions = getParametersForVersions(versionIds)
+
         return versions.map{
             val versionId = it[REPORT_VERSION.ID]
 
@@ -299,13 +301,23 @@ class Orderly(val isReviewer: Boolean,
                         .associate { f -> f[REPORT_VERSION_CUSTOM_FIELDS.KEY] to f[REPORT_VERSION_CUSTOM_FIELDS.VALUE] })
             }
 
+            val versionParameters = if (parametersForVersions.containsKey(versionId))
+            {
+                parametersForVersions[versionId]
+            }
+            else
+            {
+                null
+            }
+
             ReportVersion(it[REPORT_VERSION.REPORT],
                     it[REPORT_VERSION.DISPLAYNAME],
                     it[REPORT_VERSION.ID],
                     it["latestVersion"] as String,
                     it[REPORT_VERSION.PUBLISHED],
                     it[REPORT_VERSION.DATE].toInstant(),
-                    versionCustomFields)
+                    versionCustomFields,
+                    versionParameters)
         }
     }
 
@@ -320,6 +332,22 @@ class Orderly(val isReviewer: Boolean,
                     .execute()
 
             return newStatus
+        }
+    }
+
+    private fun getParametersForVersions(versionIds: List<String>): Map<String, String>
+    {
+        JooqContext().use { ctx ->
+            return ctx.dsl.select(
+                    PARAMETERS.REPORT_VERSION,
+                    PARAMETERS.NAME,
+                    PARAMETERS.VALUE)
+                    .from(PARAMETERS)
+                    .where(PARAMETERS.REPORT_VERSION.`in`(versionIds))
+                    .fetch()
+                    .groupBy{it[PARAMETERS.REPORT_VERSION]}
+                    .mapValues{ it.value.map{ r -> "${r[PARAMETERS.NAME]}=${r[PARAMETERS.VALUE]}"}.joinToString(", ")}
+
         }
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -303,11 +303,11 @@ class Orderly(val isReviewer: Boolean,
 
             val versionParameters = if (parametersForVersions.containsKey(versionId))
             {
-                parametersForVersions[versionId]
+                parametersForVersions[versionId]!!
             }
             else
             {
-                null
+                mapOf()
             }
 
             ReportVersion(it[REPORT_VERSION.REPORT],
@@ -335,7 +335,7 @@ class Orderly(val isReviewer: Boolean,
         }
     }
 
-    private fun getParametersForVersions(versionIds: List<String>): Map<String, String>
+    private fun getParametersForVersions(versionIds: List<String>): Map<String, Map<String, String>>
     {
         JooqContext().use { ctx ->
             return ctx.dsl.select(
@@ -346,8 +346,7 @@ class Orderly(val isReviewer: Boolean,
                     .where(PARAMETERS.REPORT_VERSION.`in`(versionIds))
                     .fetch()
                     .groupBy{it[PARAMETERS.REPORT_VERSION]}
-                    .mapValues{ it.value.map{ r -> "${r[PARAMETERS.NAME]}=${r[PARAMETERS.VALUE]}"}.joinToString(", ")}
-
+                    .mapValues{it.value.associate{r -> r[PARAMETERS.NAME] to r[PARAMETERS.VALUE]}}
         }
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
@@ -17,4 +17,5 @@ constructor(val name: String,
             val latestVersion: String,
             val published: Boolean,
             val date: Instant,
-            val customFields: Map<String, String?>)
+            val customFields: Map<String, String?>,
+            val parameterValues: String?)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
@@ -18,4 +18,4 @@ constructor(val name: String,
             val published: Boolean,
             val date: Instant,
             val customFields: Map<String, String?>,
-            val parameterValues: String?)
+            val parameterValues: Map<String, String>)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
@@ -10,5 +10,6 @@ data class ReportVersionDetails(val name: String,
                                 val description: String?,
                                 val artefacts: List<Artefact>,
                                 val resources: List<FileInfo>,
-                                val dataInfo: List<DataInfo>)
+                                val dataInfo: List<DataInfo>,
+                                val parameterValues: Map<String, String>)
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
@@ -76,7 +76,8 @@ data class ReportRowViewModel(val ttKey: Int,
                               val date: String?,
                               val numVersions: Int,
                               val published: Boolean?,
-                              val customFields: Map<String, String?>)
+                              val customFields: Map<String, String?>,
+                              val parameterValues: String?)
 {
     companion object
     {
@@ -87,7 +88,7 @@ data class ReportRowViewModel(val ttKey: Int,
             val displayName = latestVersion.displayName?: latestVersion.name
 
             return ReportRowViewModel(key, 0, latestVersion.name, displayName,
-                    latestVersion.id, latestVersion.id, null, numVersions, null, customFields)
+                    latestVersion.id, latestVersion.id, null, numVersions, null, customFields, null)
         }
 
         fun buildVersion(version: ReportVersion, key: Int, parent: ReportRowViewModel): ReportRowViewModel
@@ -103,7 +104,8 @@ data class ReportRowViewModel(val ttKey: Int,
                     dateString,
                     parent.numVersions,
                     version.published,
-                    version.customFields)
+                    version.customFields,
+                    version.parameterValues)
 
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
@@ -94,6 +94,14 @@ data class ReportRowViewModel(val ttKey: Int,
         fun buildVersion(version: ReportVersion, key: Int, parent: ReportRowViewModel): ReportRowViewModel
         {
             val dateString = IndexViewDateFormatter.format(version.date)
+            val parameterValues = if (version.parameterValues.keys.count() > 0)
+            {
+                version.parameterValues.keys.joinToString(", ") { "$it=${version.parameterValues[it]}" }
+            }
+            else
+            {
+                null
+            }
 
             return ReportRowViewModel(key,
                     parent.ttKey,
@@ -105,7 +113,7 @@ data class ReportRowViewModel(val ttKey: Int,
                     parent.numVersions,
                     version.published,
                     version.customFields,
-                    version.parameterValues)
+                    parameterValues)
 
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -21,6 +21,7 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                                       val zipFile: DownloadableFileViewModel,
                                       val versions: List<VersionPickerViewModel>,
                                       val changelog: List<ChangelogViewModel>,
+                                      val parameterValues: String?,
                                       val appViewModel: AppViewModel) :
         AppViewModel by appViewModel
 {
@@ -65,6 +66,15 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                         ChangelogViewModel.build(it.key, it.value)
                     }
 
+            val parameterValues = if (report.parameterValues.keys.count() > 0)
+            {
+                report.parameterValues.keys.joinToString(", ") { "$it=${report.parameterValues[it]}" }
+            }
+            else
+            {
+                null
+            }
+
             return ReportVersionPageViewModel(report.copy(displayName = displayName),
                     focalArtefactUrl,
                     isRunner,
@@ -74,6 +84,7 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                     zipFile,
                     versions.sortedByDescending { it }.map { buildVersionPickerViewModel(report.name, report.id, it) },
                     changelogViewModel,
+                    parameterValues,
                     DefaultViewModel(context, IndexViewModel.breadcrumb, breadcrumb))
         }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
@@ -14,6 +14,7 @@ import org.vaccineimpact.orderlyweb.tests.insertData
 import org.vaccineimpact.orderlyweb.tests.insertFileInput
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.test_helpers.insertReportWithCustomFields
+import org.vaccineimpact.orderlyweb.test_helpers.insertVersionParameterValues
 import java.sql.Timestamp
 
 class VersionTests : CleanDatabaseTests()
@@ -103,7 +104,10 @@ class VersionTests : CleanDatabaseTests()
     fun `reader can get all published report versions`()
     {
         insertReport("test", "va")
+
         insertReport("test", "vz")
+        insertVersionParameterValues("vz", mapOf("p1" to "v1", "p2" to "v2"))
+
         insertReport("test2", "vc")
         insertReport("test2", "vb")
         insertReportWithCustomFields("test2", "vd", mapOf("author" to "test2 author"))
@@ -124,10 +128,14 @@ class VersionTests : CleanDatabaseTests()
         Assertions.assertThat(results[0].customFields.keys.count()).isEqualTo(2)
         Assertions.assertThat(results[0].customFields["author"]).isEqualTo("author authorson")
         Assertions.assertThat(results[0].customFields["requester"]).isEqualTo("requester mcfunder")
+        Assertions.assertThat(results[0].parameterValues.keys.count()).isEqualTo(0)
 
         Assertions.assertThat(results[1].name).isEqualTo("test")
         Assertions.assertThat(results[1].id).isEqualTo("vz")
         Assertions.assertThat(results[1].latestVersion).isEqualTo("vz")
+        Assertions.assertThat(results[1].parameterValues.keys.count()).isEqualTo(2)
+        Assertions.assertThat(results[1].parameterValues["p1"]).isEqualTo("v1")
+        Assertions.assertThat(results[1].parameterValues["p2"]).isEqualTo("v2")
 
         Assertions.assertThat(results[2].name).isEqualTo("test2")
         Assertions.assertThat(results[2].id).isEqualTo("vb")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
@@ -39,6 +39,8 @@ class VersionTests : CleanDatabaseTests()
         insertArtefact("version1", "some artefact",
                 ArtefactFormat.DATA, files = listOf(FileInfo("artefactfile.csv", 1234)))
 
+        insertVersionParameterValues("version1", mapOf("p1" to "v1", "p2" to "v2"))
+
         val sut = createSut()
         val result = sut.getDetailsByNameAndVersion("test", "version1")
 
@@ -51,6 +53,9 @@ class VersionTests : CleanDatabaseTests()
         assertThat(result.artefacts).containsExactly(Artefact(ArtefactFormat.DATA,
                 "some artefact", listOf(FileInfo("artefactfile.csv", 1234))))
         assertThat(result.dataInfo).hasSameElementsAs(listOf(DataInfo("dat", 9876, 7654)))
+        assertThat(result.parameterValues.keys.count()).isEqualTo(2)
+        assertThat(result.parameterValues["p1"]).isEqualTo("v1")
+        assertThat(result.parameterValues["p2"]).isEqualTo("v2")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
@@ -38,7 +38,8 @@ class TemplateObjectWrapperTests : TeamcityTests()
                 "a fake report",
                 listOf(Artefact(ArtefactFormat.DATA, "a graph", artFiles)),
                 listOf(),
-                listOf(DataInfo("hash", 1234, 2345)))
+                listOf(DataInfo("hash", 1234, 2345)),
+                mapOf("param" to "value"))
 
         val sut = TemplateObjectWrapper()
         val result = sut.wrap(report) as SimpleHash

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
@@ -36,9 +36,9 @@ class ReportControllerTests : ControllerTest()
 
     private val reportVersions = listOf(
             ReportVersion(reportName, "display1", "v1", "v1", true, Instant.now(),
-                    mapOf("author" to "auth", "requester" to "req")),
+                    mapOf("author" to "auth", "requester" to "req"), mapOf("p1" to "v1")),
             ReportVersion("r2", "display2", "v2", "v2", true, Instant.now(),
-                    mapOf("author" to "auth", "requester" to "req"))
+                    mapOf("author" to "auth", "requester" to "req"), mapOf("p1" to "v1", "p2" to "v2"))
     )
 
     private val mockOrderly = mock<OrderlyClient> {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
@@ -35,7 +35,7 @@ class VersionControllerTests : ControllerTest()
         val report = ReportVersionDetails(displayName = "displayName", id = "id", date = Instant.now(),
                 name = "name", published = true, description = "description",
                 artefacts = listOf(),
-                resources = listOf(), dataInfo = listOf())
+                resources = listOf(), dataInfo = listOf(), parameterValues = mapOf())
 
         val orderly = mock<OrderlyClient> {
             on { this.getDetailsByNameAndVersion(reportName, reportVersion) } doReturn report

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/IndexControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/IndexControllerTests.kt
@@ -39,7 +39,7 @@ class IndexControllerTests : TeamcityTests()
         val someDate = Instant.parse("2019-05-23T12:31:00.613Z")
 
         val r1v1 = ReportVersion("r1", null, "v1", "v2", true, someDate,
-                mapOf("author" to "author1", "requester" to "requester1"))
+                mapOf("author" to "author1", "requester" to "requester1"), mapOf("p1" to "v1", "p2" to "v2"))
         val r1v2 = r1v1.copy(
                 id = "v2",
                 displayName = "r1 display name",
@@ -47,7 +47,7 @@ class IndexControllerTests : TeamcityTests()
                 date = someDate.plus(Duration.ofDays(1)))
 
         val r2v1 = ReportVersion("r2", null, "r2v1", "r2v1", true, someDate.minus(Duration.ofDays(2)),
-                mapOf("author" to "another author", "requester" to "another requester"))
+                mapOf("author" to "another author", "requester" to "another requester"), mapOf())
 
         val fakeReports = listOf(r1v1, r1v2, r2v1)
 
@@ -68,14 +68,16 @@ class IndexControllerTests : TeamcityTests()
                 id = "v2",
                 published = null,
                 numVersions = 2,
-                customFields = mapOf("author" to null, "requester" to null))
+                customFields = mapOf("author" to null, "requester" to null),
+                parameterValues = null)
 
         val r1v1Expected = r1Expected.copy(
                 ttKey = 2,
                 ttParent = 1,
                 published = false,
                 date = "Fri May 24 2019",
-                customFields = mapOf("author" to "author1", "requester" to "requester1")
+                customFields = mapOf("author" to "author1", "requester" to "requester1"),
+                parameterValues =  "p1=v1, p2=v2"
         )
 
         val r1v2Expected = r1v1Expected.copy(
@@ -95,7 +97,8 @@ class IndexControllerTests : TeamcityTests()
                         id = "r2v1",
                         published = null,
                         numVersions = 1,
-                        customFields = mapOf("author" to null, "requester" to null))
+                        customFields = mapOf("author" to null, "requester" to null),
+                        parameterValues = null)
 
         val r2v1Expected =
                 r2Expected.copy(
@@ -103,7 +106,8 @@ class IndexControllerTests : TeamcityTests()
                         ttParent = 4,
                         date = "Tue May 21 2019",
                         published = true,
-                        customFields = mapOf("author" to "another author", "requester" to "another requester"))
+                        customFields = mapOf("author" to "another author", "requester" to "another requester"),
+                        parameterValues = null)
 
         val expected = listOf(r1Expected, r1v1Expected, r1v2Expected, r2Expected, r2v1Expected)
         assertThat(result.count()).isEqualTo(5)
@@ -118,7 +122,7 @@ class IndexControllerTests : TeamcityTests()
         val someDate = Instant.parse("2019-06-07T12:31:00.613Z")
 
         val r1v1 = ReportVersion("r1", null, "v1", "v2", true, someDate,
-                mapOf("author" to "author1", "requester" to "requester1"))
+                mapOf("author" to "author1", "requester" to "requester1"), mapOf("p" to "v"))
         val r1v2 = r1v1.copy(
                 name = "r2",
                 id = "v2",

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests.kt
@@ -26,7 +26,8 @@ class ReportControllerTests : TeamcityTests()
             "a fake report",
             listOf(),
             listOf(),
-            listOf())
+            listOf(),
+            mapOf("p1" to "v1", "p2" to "v2"))
 
     private val mockChangelog = listOf(Changelog("20160103-143015-1234abcd", "internal", "something internal", true),
             Changelog("20160103-143015-1234abcd", "public", "something public", true),
@@ -67,6 +68,27 @@ class ReportControllerTests : TeamcityTests()
         val result = sut.getByNameAndVersion()
 
         assertThat(result.report.displayName).isEqualTo("r1")
+    }
+
+    @Test
+    fun `builds parameter values`()
+    {
+        val sut = ReportController(mockActionContext, mockOrderly)
+        val result = sut.getByNameAndVersion()
+        assertThat(result.parameterValues).isEqualTo("p1=v1, p2=v2")
+    }
+
+    @Test
+    fun `builds empty parameter values`()
+    {
+        val orderly = mock<OrderlyClient> {
+            on { this.getDetailsByNameAndVersion("r1", versionId) } doReturn
+                    mockReportDetails.copy(parameterValues = mapOf())
+        }
+
+        val sut = ReportController(mockActionContext, orderly)
+        val result = sut.getByNameAndVersion()
+        assertThat(result.parameterValues).isEqualTo(null)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/IndexTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/IndexTests.kt
@@ -94,12 +94,13 @@ class IndexTests : TeamcityTests()
         val testModel = IndexViewModel(listOf(), listOf(), listOf("author", "requester"), defaultModel)
         val header = template.jsoupDocFor(testModel).selectFirst("thead tr")
 
-        assertThat(header.select("th").count()).isEqualTo(5)
+        assertThat(header.select("th").count()).isEqualTo(6)
         assertThat(header.select("th")[0].selectFirst("label").text()).isEqualTo("Name")
         assertThat(header.select("th")[1].selectFirst("label").text()).isEqualTo("Version")
         assertThat(header.select("th")[2].selectFirst("label").text()).isEqualTo("Status")
-        assertThat(header.select("th")[3].selectFirst("label").text()).isEqualTo("Author")
-        assertThat(header.select("th")[4].selectFirst("label").text()).isEqualTo("Requester")
+        assertThat(header.select("th")[3].selectFirst("label").text()).isEqualTo("Parameter Values")
+        assertThat(header.select("th")[4].selectFirst("label").text()).isEqualTo("Author")
+        assertThat(header.select("th")[5].selectFirst("label").text()).isEqualTo("Requester")
     }
 
     @Test
@@ -110,11 +111,12 @@ class IndexTests : TeamcityTests()
         val testModel = IndexViewModel(listOf(), listOf(), listOf("author", "requester"), defaultModel)
         val header = template.jsoupDocFor(testModel).selectFirst("thead tr")
 
-        assertThat(header.select("th").count()).isEqualTo(4)
+        assertThat(header.select("th").count()).isEqualTo(5)
         assertThat(header.select("th")[0].selectFirst("label").text()).isEqualTo("Name")
         assertThat(header.select("th")[1].selectFirst("label").text()).isEqualTo("Version")
-        assertThat(header.select("th")[2].selectFirst("label").text()).isEqualTo("Author")
-        assertThat(header.select("th")[3].selectFirst("label").text()).isEqualTo("Requester")
+        assertThat(header.select("th")[2].selectFirst("label").text()).isEqualTo("Parameter Values")
+        assertThat(header.select("th")[3].selectFirst("label").text()).isEqualTo("Author")
+        assertThat(header.select("th")[4].selectFirst("label").text()).isEqualTo("Requester")
 
     }
 
@@ -126,11 +128,12 @@ class IndexTests : TeamcityTests()
         val testModel = IndexViewModel(listOf(), listOf(), listOf("author", "requester"), defaultModel)
         val filters = template.jsoupDocFor(testModel).select("thead tr")[1]
 
-        assertThat(filters.select("th").count()).isEqualTo(5)
+        assertThat(filters.select("th").count()).isEqualTo(6)
         assertThat(filters.select("th")[0].selectFirst("input").id()).isEqualTo("name-filter")
         assertThat(filters.select("th")[1].selectFirst("input").id()).isEqualTo("version-filter")
         assertThat(filters.select("th")[2].selectFirst("select").id()).isEqualTo("status-filter")
-        assertThat(filters.select("th")[3].selectFirst("input").id()).isEqualTo("author-filter")
-        assertThat(filters.select("th")[4].selectFirst("input").id()).isEqualTo("requester-filter")
+        assertThat(filters.select("th")[3].selectFirst("input").id()).isEqualTo("parameter-values-filter")
+        assertThat(filters.select("th")[4].selectFirst("input").id()).isEqualTo("author-filter")
+        assertThat(filters.select("th")[5].selectFirst("input").id()).isEqualTo("requester-filter")
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -40,7 +40,8 @@ class VersionPageTests : TeamcityTests()
             description = "description",
             artefacts = listOf(),
             resources = listOf(),
-            dataInfo = listOf())
+            dataInfo = listOf(),
+            parameterValues = mapOf("p1" to "v1", "p2" to "v2"))
 
     private val testArtefactViewModels = listOf(
             ArtefactViewModel(
@@ -89,6 +90,7 @@ class VersionPageTests : TeamcityTests()
             DownloadableFileViewModel("zipFileName", "http://zipFileUrl", null),
             listOf(),
             listOf(),
+            "p1=v1, p2=v2",
             testDefaultModel)
 
     @Test
@@ -141,6 +143,8 @@ class VersionPageTests : TeamcityTests()
                 equalToCompressingWhiteSpace("r1 display")))
         assertThat(xmlResponse, hasXPath("$xPathRoot/p[1]/text()",
                 equalToCompressingWhiteSpace("r1-v1")))
+
+        assertThat(xmlResponse, hasXPath("$xPathRoot/p[id='param-values']", equalTo("Parameter values: p1=v1, p2=v2")))
 
         assertThat(xmlResponse, hasXPath("$xPathRoot/iframe/@src", equalTo("/testFocalArtefactUrl")))
         assertThat(xmlResponse, hasXPath("$xPathRoot/div[@class='text-right']/a/text()",

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -144,7 +144,7 @@ class VersionPageTests : TeamcityTests()
         assertThat(xmlResponse, hasXPath("$xPathRoot/p[1]/text()",
                 equalToCompressingWhiteSpace("r1-v1")))
 
-        assertThat(xmlResponse, hasXPath("$xPathRoot/p[id='param-values']", equalTo("Parameter values: p1=v1, p2=v2")))
+        assertThat(xmlResponse, hasXPath("$xPathRoot/p[@id='param-values']", equalToCompressingWhiteSpace("Parameter values: p1=v1, p2=v2")))
 
         assertThat(xmlResponse, hasXPath("$xPathRoot/iframe/@src", equalTo("/testFocalArtefactUrl")))
         assertThat(xmlResponse, hasXPath("$xPathRoot/div[@class='text-right']/a/text()",

--- a/src/app/static/src/js/index.js
+++ b/src/app/static/src/js/index.js
@@ -25,7 +25,7 @@ export const initReportTable = (isReviewer, reports, customFields) => {
     }
 
     $.fn.dataTable.ext.search.push((settings, data) => {
-        const displayNameReviewerIdx = customFields.length + 4;
+        const displayNameReviewerIdx = customFields.length + 5;
         const displayName = isReviewer ? displayNameReviewerIdx : displayNameReviewerIdx-1;
         const value = $('#name-filter').val();
         return nameFilter(displayName, value, data);

--- a/src/app/static/src/js/utils/reportsTable.js
+++ b/src/app/static/src/js/utils/reportsTable.js
@@ -73,6 +73,12 @@ export const options = (isReviewer, reports, customFields) => {
         })
     }
 
+    cols.push({
+        "data": "parameter_values",
+        "render": buildBasicCell,
+        "orderable": false
+    });
+
     for (const customField of customFields) {
         cols.push({
             "data": customField,

--- a/src/app/static/src/tests/indexReader.test.js
+++ b/src/app/static/src/tests/indexReader.test.js
@@ -15,6 +15,9 @@ describe("index page as report reader", () => {
         '            </th>\n' +
         '            <th><label for="status-filter">Status</label>\n' +
         '            </th>\n' +
+        '            <th>' +
+        '               <label for="parameter-values-filter">Parameter Values</label>\n' +
+        '            </th>\n' +
         '            <th>\n' +
         '                <label for="author-filter">Author</label>\n' +
         '            </th>\n' +
@@ -32,14 +35,19 @@ describe("index page as report reader", () => {
         '                       data-col="2"/>\n' +
         '            </th>\n' +
         '            <th>\n' +
-        '                <input class="form-control" type="text" id="author-filter"\n' +
+        '                <input class="form-control" type="text" id="parameter-values-filter"\n' +
         '                       data-role="standard-filter"\n' +
         '                       data-col="3"/>\n' +
         '            </th>\n' +
         '            <th>\n' +
-        '                <input class="form-control" type="text" id="requester-filter"\n' +
+        '                <input class="form-control" type="text" id="author-filter"\n' +
         '                       data-role="standard-filter"\n' +
         '                       data-col="4"/>\n' +
+        '            </th>\n' +
+        '            <th>\n' +
+        '                <input class="form-control" type="text" id="requester-filter"\n' +
+        '                       data-role="standard-filter"\n' +
+        '                       data-col="5"/>\n' +
         '            </th>\n' +
         '        </tr>\n' +
         '        </thead>\n' +
@@ -55,7 +63,8 @@ describe("index page as report reader", () => {
         latest_version: "20181112-152443-4de0c811",
         author: "author",
         requester: "requester",
-        published: true
+        published: true,
+        parameter_values: "p1=v1"
     }];
 
     initReportTable(false, reports, ["author", "requester"]);
@@ -99,6 +108,23 @@ describe("index page as report reader", () => {
 
         expect($($table.find("tbody tr td")[1]).find("span")[0].innerHTML).toBe("r1 display");
 
+    });
+
+    it("wires up parameter values filter", () => {
+
+        const $table = $('#reports-table');
+        const $filter = $('#parameter-values-filter');
+        expect($($table.find("tbody tr td")[1]).find("span")[0].innerHTML).toBe("r1 display");
+
+        $filter.val("r1");
+        $filter.keyup();
+
+        expect($table.find("tbody tr td")[0].innerHTML).toBe("No matching records found");
+
+        $filter.val("p1");
+        $filter.keyup();
+
+        expect($($table.find("tbody tr td")[1]).find("span")[0].innerHTML).toBe("r1 display");
     });
 
     it("wires up author filter", () => {

--- a/src/app/static/src/tests/indexReviewer.test.js
+++ b/src/app/static/src/tests/indexReviewer.test.js
@@ -16,6 +16,9 @@ describe("index page as report reviewer", () => {
         '            <th><label for="status-filter">Status</label>\n' +
         '            </th>\n' +
         '            <th>\n' +
+        '            <th>' +
+        '               <label for="parameter-values-filter">Parameter Values</label>\n' +
+        '            </th>\n' +
         '                <label for="author-filter">Author</label>\n' +
         '            </th>\n' +
         '            <th>\n' +
@@ -45,14 +48,19 @@ describe("index page as report reviewer", () => {
         '                 </select>\n' +
         '            </th>\n' +
         '            <th>\n' +
-        '                <input class="form-control" type="text" id="author-filter"\n' +
+        '            <th>\n' +
+        '                <input class="form-control" type="text" id="parameter-values-filter"\n' +
         '                       data-role="standard-filter"\n' +
         '                       data-col="4"/>\n' +
+        '            </th>\n' +
+        '                <input class="form-control" type="text" id="author-filter"\n' +
+        '                       data-role="standard-filter"\n' +
+        '                       data-col="5"/>\n' +
         '            </th>\n' +
         '            <th>\n' +
         '                <input class="form-control" type="text" id="requester-filter"\n' +
         '                       data-role="standard-filter"\n' +
-        '                       data-col="5"/>\n' +
+        '                       data-col="6"/>\n' +
         '            </th>\n' +
         '        </tr>\n' +
         '        </thead>\n' +
@@ -68,7 +76,8 @@ describe("index page as report reviewer", () => {
         latest_version: "20181112-152443-4de0c811",
         author: "author",
         requester: "requester",
-        published: true
+        published: true,
+        parameter_values: "p1=v1"
     }];
 
     initReportTable(true, reports, ["author", "requester"]);
@@ -112,6 +121,24 @@ describe("index page as report reviewer", () => {
         expect($($table.find("tbody tr td")[1]).find("span")[0].innerHTML).toBe("r1 display");
 
     });
+
+    it("wires up parameter values filter", () => {
+
+        const $table = $('#reports-table');
+        const $filter = $('#parameter-values-filter');
+        expect($($table.find("tbody tr td")[1]).find("span")[0].innerHTML).toBe("r1 display");
+
+        $filter.val("r1");
+        $filter.keyup();
+
+        expect($table.find("tbody tr td")[0].innerHTML).toBe("No matching records found");
+
+        $filter.val("p1");
+        $filter.keyup();
+
+        expect($($table.find("tbody tr td")[1]).find("span")[0].innerHTML).toBe("r1 display");
+    });
+
 
     it("wires up author filter", () => {
 

--- a/src/app/static/src/tests/reportTable.test.js
+++ b/src/app/static/src/tests/reportTable.test.js
@@ -8,19 +8,19 @@ describe("reportsTable", () => {
 
     it("has expected columns when user is reviewer", () => {
         const cols = options(true, [], customFields).columns;
-        expect(cols.length).toBe(6);
-        expect(cols.map(c => c.data)).toStrictEqual(["name", "id", "published", "author", "requester", "display_name"])
+        expect(cols.length).toBe(7);
+        expect(cols.map(c => c.data)).toStrictEqual(["name", "id", "published", "parameter_values", "author", "requester", "display_name"])
     });
 
     it("has expected columns when user is not a reviewer", () => {
         const cols = options(false, [], customFields).columns;
-        expect(cols.length).toBe(5);
-        expect(cols.map(c => c.data)).toStrictEqual(["name", "id", "author", "requester", "display_name"])
+        expect(cols.length).toBe(6);
+        expect(cols.map(c => c.data)).toStrictEqual(["name", "id", "parameter_values", "author", "requester", "display_name"])
     });
 
     it("has invisible display name col", () => {
         const cols = options(false, [], customFields).columns;
-        expect(cols[4].visible).toBe(false);
+        expect(cols[5].visible).toBe(false);
     });
 
     it("is ordered by version desc", () => {
@@ -152,15 +152,39 @@ describe("reportsTable", () => {
 
     });
 
+    describe("parameter values cell", () => {
+
+        it("is not orderable", () => {
+            const paramValsCol = options(false, [], customFields).columns[2];
+            expect(paramValsCol.orderable).toBe(false);
+        });
+
+        it("is empty for parent rows", () => {
+            const paramValsCol = options(false, [], customFields).columns[2];
+            expect(paramValsCol.data).toBe("parameter_values");
+
+            const result = paramValsCol.render("parameter_values", null, {tt_parent: 0});
+            expect(result).toBe("");
+        });
+
+        it("shows parameter values for child row", () => {
+            const paramValsCol = options(false, [], customFields).columns[2];
+            expect(paramValsCol.data).toBe("parameter_values");
+
+            const result = paramValsCol.render("parameter_values", null, {tt_parent: 1});
+            expect(result).toBe("parameter_values");
+        });
+    });
+
     describe("author cell", () => {
 
         it("is not orderable", () => {
-            const requesterCol = options(false, [], customFields).columns[2];
+            const requesterCol = options(false, [], customFields).columns[3];
             expect(requesterCol.orderable).toBe(false);
         });
 
         it("is empty for parent rows", () => {
-            const authorCol = options(false, [], customFields).columns[2];
+            const authorCol = options(false, [], customFields).columns[3];
             expect(authorCol.data).toBe("author");
 
             const result = authorCol.render("author", null, {tt_parent: 0});
@@ -168,7 +192,7 @@ describe("reportsTable", () => {
         });
 
         it("shows author for child row", () => {
-            const authorCol = options(false, [], customFields).columns[2];
+            const authorCol = options(false, [], customFields).columns[3];
             expect(authorCol.data).toBe("author");
 
             const result = authorCol.render("author", null, {tt_parent: 1});
@@ -179,12 +203,12 @@ describe("reportsTable", () => {
     describe("requester cell", () => {
 
         it("is not orderable", () => {
-            const requesterCol = options(false, [], customFields).columns[3];
+            const requesterCol = options(false, [], customFields).columns[4];
             expect(requesterCol.orderable).toBe(false);
         });
 
         it("is empty for parent rows", () => {
-            const requesterCol = options(false, [], customFields).columns[3];
+            const requesterCol = options(false, [], customFields).columns[4];
             expect(requesterCol.data).toBe("requester");
 
             const result = requesterCol.render("requester", null, {tt_parent: 0});
@@ -192,7 +216,7 @@ describe("reportsTable", () => {
         });
 
         it("shows author for child row", () => {
-            const requesterCol = options(false, [], customFields).columns[3];
+            const requesterCol = options(false, [], customFields).columns[4];
             expect(requesterCol.data).toBe("requester");
 
             const result = requesterCol.render("requester", null, {tt_parent: 1});
@@ -202,11 +226,11 @@ describe("reportsTable", () => {
 
     describe("filtering", () => {
 
-        const internal = [null, "r1", "v1", false, "author", "requester", "displaya"];
-        const published = [null, "r2", "v1", true, "author", "requester", "displayb"];
-        const parentBoth = [null, "r2,r1", "v1,v1", "true,false", "author", "requester", "displaya,displayb"];
-        const parentInternalOnly = [null, "", "", "false,false", "", "", ""];
-        const parentPublishedOnly = [null, "", "", "true,true", "", "", ""];
+        const internal = [null, "r1", "v1", false, "p1=v1", "author", "requester", "displaya"];
+        const published = [null, "r2", "v1", true, "p1=v2", "author", "requester", "displayb"];
+        const parentBoth = [null, "r2,r1", "v1,v1", "true,false", null,  "author", "requester", "displaya,displayb"];
+        const parentInternalOnly = [null, "", "", "false,false", null, "", "", ""];
+        const parentPublishedOnly = [null, "", "", "true,true", null, "", "", ""];
 
         it("can return reports with any status", () => {
             expect(statusFilter("all", internal)).toBe(true);
@@ -233,15 +257,15 @@ describe("reportsTable", () => {
         });
 
         it("can filter by name", () => {
-            expect(nameFilter(6, "2", internal)).toBe(false);
-            expect(nameFilter(6, "2", published)).toBe(true);
-            expect(nameFilter(6, "2", parentBoth)).toBe(true);
+            expect(nameFilter(7, "2", internal)).toBe(false);
+            expect(nameFilter(7, "2", published)).toBe(true);
+            expect(nameFilter(7, "2", parentBoth)).toBe(true);
         });
 
         it("can filter by display name", () => {
-            expect(nameFilter(6, "aya", internal)).toBe(true);
-            expect(nameFilter(6, "aya", published)).toBe(false);
-            expect(nameFilter(6, "aya", parentBoth)).toBe(true);
+            expect(nameFilter(7, "aya", internal)).toBe(true);
+            expect(nameFilter(7, "aya", published)).toBe(false);
+            expect(nameFilter(7, "aya", parentBoth)).toBe(true);
         });
     });
 

--- a/src/app/templates/index.ftl
+++ b/src/app/templates/index.ftl
@@ -29,6 +29,11 @@
                 </th>
             </#if>
 
+            <th>
+                <label for="parameter-values-filter">Parameter Values</label>
+
+            </th>
+
             <#list customFieldKeys as customField>
                 <th>
                     <label for="${customField}-filter">${customField?cap_first}</label>
@@ -61,15 +66,25 @@
                     </select>
                 </th>
             </#if>
+            <th>
+                <input class="form-control" type="text" id="parameter-values-filter"
+                       placeholder="Type to filter..."
+                       data-role="standard-filter"
+                        <#if isReviewer>
+                            data-col="4"
+                        <#else>
+                            data-col="3"
+                        </#if>
+                />
             <#list customFieldKeys as customField>
                 <th>
                     <input class="form-control" type="text" id="${customField}-filter"
                            placeholder="Type to filter..."
                            data-role="standard-filter"
                            <#if isReviewer>
-                               data-col="${customField?index + 4}"
+                               data-col="${customField?index + 5}"
                            <#else>
-                               data-col="${customField?index + 3}"
+                               data-col="${customField?index + 4}"
                            </#if>
                     />
                 </th>

--- a/src/app/templates/partials/report-tab.ftl
+++ b/src/app/templates/partials/report-tab.ftl
@@ -2,7 +2,9 @@
 <#-- @ftlvariable name="focalArtefactUrl" type="String" -->
 
 <#include "report-title.ftl">
-
+<#if parameterValues??>
+    <p><span class="text-muted">Parameter values:</span> ${parameterValues}</p>
+</#if>
 <#if focalArtefactUrl?has_content>
     <iframe src="${focalArtefactUrl}"
             width="100%" height="600px" class="border border-dark p-3"></iframe>

--- a/src/app/templates/partials/report-tab.ftl
+++ b/src/app/templates/partials/report-tab.ftl
@@ -3,7 +3,7 @@
 
 <#include "report-title.ftl">
 <#if parameterValues??>
-    <p><span class="text-muted">Parameter values:</span> ${parameterValues}</p>
+    <p id="param-values"><span class="text-muted">Parameter values:</span> ${parameterValues}</p>
 </#if>
 <#if focalArtefactUrl?has_content>
     <iframe src="${focalArtefactUrl}"


### PR DESCRIPTION
This shows parameter values in both the Index page and the Report details page. 

I've made the parameter values a string map in the backend models, which then get turned into strings to render in both the Index and Report view models - that seemed more flexible if we want to change the view in future, though it means there's a bit of duplicated code when the view models are built.
