### PR TITLE
mrc-1382 backend for external file links

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Files.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Files.kt
@@ -68,7 +68,7 @@ class Files : FileSystem
         return if (file.extension == "url")
         {
             val url = file.readText().trim('\n').trim().split("URL=").last()
-            DocumentDetails(url, url, url, true, true)
+            DocumentDetails(url, file.absolutePath, file.absolutePath.removePrefix(documentsRoot), true, true)
         }
         else
         {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Files.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Files.kt
@@ -60,12 +60,24 @@ class Files : FileSystem
         val source = File(sourceAbsolutePath)
         val children = source.list() ?: arrayOf()
         return children.map { File(source, it) }
-                .map {
-                    DocumentDetails(it.name,
-                            it.absolutePath,
-                            it.absolutePath.removePrefix(documentsRoot),
-                            it.isFile)
-                }
+                .map { getDocumentDetails(it, documentsRoot) }
+    }
+
+    private fun getDocumentDetails(file: File, documentsRoot: String): DocumentDetails
+    {
+        return if (file.extension == "url")
+        {
+            val url = file.readText().trim('\n').trim().split("URL=").last()
+            DocumentDetails(url, url, url, true, true)
+        }
+        else
+        {
+            DocumentDetails(file.name,
+                    file.absolutePath,
+                    file.absolutePath.removePrefix(documentsRoot),
+                    file.isFile,
+                    false)
+        }
     }
 
     override fun getAbsolutePath(sourcePath: String): String
@@ -92,4 +104,8 @@ class Files : FileSystem
     }
 }
 
-class DocumentDetails(val name: String, val absolutePath: String, val pathFragment: String?, val isFile: Boolean)
+class DocumentDetails(val name: String,
+                      val absolutePath: String,
+                      val pathFragment: String?,
+                      val isFile: Boolean,
+                      val external: Boolean)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/DocumentController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/DocumentController.kt
@@ -27,7 +27,7 @@ class DocumentController(context: ActionContext,
     fun refreshDocuments(): String
     {
         val allDocs = repo.getAllFlat()
-        val root = DocumentDetails("root", documentsRoot, null, false)
+        val root = DocumentDetails("root", documentsRoot, null, false, false)
         val unrefreshedDocs = allDocs.toMutableList()
         refreshDocumentsInDir(root, unrefreshedDocs)
 
@@ -52,7 +52,7 @@ class DocumentController(context: ActionContext,
             }
             else
             {
-                repo.add(child.pathFragment!!, child.name, child.isFile, dir.pathFragment)
+                repo.add(child.pathFragment!!, child.name, child.isFile, child.external, dir.pathFragment)
             }
 
             if (!child.isFile)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/DocumentRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/DocumentRepository.kt
@@ -43,7 +43,7 @@ class OrderlyDocumentRepository : DocumentRepository
                         it[ORDERLYWEB_DOCUMENT.DISPLAY_NAME] ?: it[ORDERLYWEB_DOCUMENT.NAME],
                         it[ORDERLYWEB_DOCUMENT.PATH],
                         it[ORDERLYWEB_DOCUMENT.IS_FILE] == 1,
-                        it[ORDERLYWEB_DOCUMENT.IS_FILE] == 1,
+                        it[ORDERLYWEB_DOCUMENT.EXTERNAL] == 1,
                         listOf()
                 )
             }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/DocumentRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/DocumentRepository.kt
@@ -4,22 +4,24 @@ import org.jooq.Record
 import org.vaccineimpact.orderlyweb.db.Tables.ORDERLYWEB_DOCUMENT
 import org.vaccineimpact.orderlyweb.models.Document
 
-interface DocumentRepository {
+interface DocumentRepository
+{
 
     fun getAllVisibleDocuments(): List<Document>
 
     fun getAllFlat(): List<Document>
 
-    fun add(path: String, name: String, isFile: Boolean, parentPath: String?)
+    fun add(path: String, name: String, isFile: Boolean, external: Boolean, parentPath: String?)
     fun setVisibility(documents: List<Document>, show: Boolean)
 
 }
 
-class OrderlyDocumentRepository : DocumentRepository {
+class OrderlyDocumentRepository : DocumentRepository
+{
 
-    override fun getAllVisibleDocuments(): List<Document> {
-        JooqContext().use {
-            db ->
+    override fun getAllVisibleDocuments(): List<Document>
+    {
+        JooqContext().use { db ->
             val rootNodes = db.dsl.selectFrom(ORDERLYWEB_DOCUMENT)
                     .where(ORDERLYWEB_DOCUMENT.PARENT.isNull)
                     .and(ORDERLYWEB_DOCUMENT.SHOW.eq(1))
@@ -27,29 +29,35 @@ class OrderlyDocumentRepository : DocumentRepository {
             return rootNodes.map {
                 mapDocument(db, it)
             }.sortedBy { it.displayName }
+                    .sortedBy { it.external }
         }
     }
 
-    override fun getAllFlat(): List<Document> {
+    override fun getAllFlat(): List<Document>
+    {
         JooqContext().use { db ->
-            val result =  db.dsl.selectFrom(ORDERLYWEB_DOCUMENT)
+            val result = db.dsl.selectFrom(ORDERLYWEB_DOCUMENT)
                     .fetch()
-            return result.map{ Document(
-                    it[ORDERLYWEB_DOCUMENT.DISPLAY_NAME] ?: it[ORDERLYWEB_DOCUMENT.NAME],
-                    it[ORDERLYWEB_DOCUMENT.PATH],
-                    it[ORDERLYWEB_DOCUMENT.IS_FILE]==1,
-                    listOf()
-            ) }
+            return result.map {
+                Document(
+                        it[ORDERLYWEB_DOCUMENT.DISPLAY_NAME] ?: it[ORDERLYWEB_DOCUMENT.NAME],
+                        it[ORDERLYWEB_DOCUMENT.PATH],
+                        it[ORDERLYWEB_DOCUMENT.IS_FILE] == 1,
+                        it[ORDERLYWEB_DOCUMENT.IS_FILE] == 1,
+                        listOf()
+                )
+            }
         }
     }
 
-    override fun add(path: String, name: String, isFile: Boolean, parentPath: String?)
+    override fun add(path: String, name: String, isFile: Boolean, external: Boolean, parentPath: String?)
     {
         JooqContext().use { db ->
             db.dsl.insertInto(ORDERLYWEB_DOCUMENT)
                     .set(ORDERLYWEB_DOCUMENT.PATH, path)
                     .set(ORDERLYWEB_DOCUMENT.NAME, name)
                     .set(ORDERLYWEB_DOCUMENT.IS_FILE, isFile.toInt())
+                    .set(ORDERLYWEB_DOCUMENT.EXTERNAL, external.toInt())
                     .set(ORDERLYWEB_DOCUMENT.PARENT, parentPath)
                     .set(ORDERLYWEB_DOCUMENT.SHOW, 1)
                     .execute()
@@ -58,7 +66,7 @@ class OrderlyDocumentRepository : DocumentRepository {
 
     override fun setVisibility(documents: List<Document>, show: Boolean)
     {
-        val paths = documents.map{ it.path }
+        val paths = documents.map { it.path }
         JooqContext().use { db ->
             db.dsl.update(ORDERLYWEB_DOCUMENT)
                     .set(ORDERLYWEB_DOCUMENT.SHOW, show.toInt())
@@ -67,7 +75,8 @@ class OrderlyDocumentRepository : DocumentRepository {
         }
     }
 
-    private fun getChildren(db: JooqContext, node: Document): List<Document> {
+    private fun getChildren(db: JooqContext, node: Document): List<Document>
+    {
 
         return db.dsl.selectFrom(ORDERLYWEB_DOCUMENT)
                 .where(ORDERLYWEB_DOCUMENT.PARENT.eq(node.path))
@@ -75,11 +84,14 @@ class OrderlyDocumentRepository : DocumentRepository {
                 .fetch().map {
                     mapDocument(db, it)
                 }.sortedBy { it.displayName }
+                .sortedBy { it.external }
     }
 
-    private fun mapDocument(db: JooqContext, record: Record) : Document {
-        val doc = Document(record[ORDERLYWEB_DOCUMENT.DISPLAY_NAME]?: record[ORDERLYWEB_DOCUMENT.NAME], record[ORDERLYWEB_DOCUMENT.PATH],
-                record[ORDERLYWEB_DOCUMENT.IS_FILE] == 1, listOf())
+    private fun mapDocument(db: JooqContext, record: Record): Document
+    {
+        val doc = Document(record[ORDERLYWEB_DOCUMENT.DISPLAY_NAME]
+                ?: record[ORDERLYWEB_DOCUMENT.NAME], record[ORDERLYWEB_DOCUMENT.PATH],
+                record[ORDERLYWEB_DOCUMENT.IS_FILE] == 1, record[ORDERLYWEB_DOCUMENT.EXTERNAL] == 1, listOf())
         return doc.copy(children = getChildren(db, doc))
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Document.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Document.kt
@@ -3,4 +3,5 @@ package org.vaccineimpact.orderlyweb.models
 data class Document(val displayName: String,
                     val path: String,
                     val file: Boolean,
+                    val external: Boolean,
                     val children: List<Document>)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/DocumentRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/DocumentRepositoryTests.kt
@@ -72,10 +72,10 @@ class DocumentRepositoryTests : CleanDatabaseTests()
         assertThat(result[0]).isEqualTo(Document("root", "/root/", false, false, listOf()))
         assertThat(result[1]).isEqualTo(Document("some", "/some/", false, false, listOf()))
         assertThat(result[2]).isEqualTo(Document("empty", "/some/empty/", false, false, listOf()))
-        assertThat(result[3]).isEqualTo(Document("first.csv", "/some/first.csv", true, false, listOf()))
-        assertThat(result[4]).isEqualTo(Document("path", "/some/path/", false, false, listOf()))
-        assertThat(result[5]).isEqualTo(Document("file.csv", "/some/path/file.csv", true, false, listOf()))
-        assertThat(result[6]).isEqualTo(Document("http://external.com", "/some/external.web.url", true, true, listOf()))
+        assertThat(result[3]).isEqualTo(Document("http://external.com", "/some/external.web.url", true, true, listOf()))
+        assertThat(result[4]).isEqualTo(Document("first.csv", "/some/first.csv", true, false, listOf()))
+        assertThat(result[5]).isEqualTo(Document("path", "/some/path/", false, false, listOf()))
+        assertThat(result[6]).isEqualTo(Document("file.csv", "/some/path/file.csv", true, false, listOf()))
     }
 
     @Test
@@ -84,7 +84,7 @@ class DocumentRepositoryTests : CleanDatabaseTests()
         val sut = OrderlyDocumentRepository()
         sut.add("/root/", "root", false, false, null)
         sut.add("/root/file.csv", "file.csv", true, false, "/root/")
-        sut.add("http://external.com", "http://external.com", true, true, "/root/")
+        sut.add("/root/some.web.url", "http://external.com", true, true, "/root/")
 
         JooqContext().use {
             val result = it.dsl.selectFrom(Tables.ORDERLYWEB_DOCUMENT)
@@ -110,7 +110,7 @@ class DocumentRepositoryTests : CleanDatabaseTests()
             assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.EXTERNAL]).isEqualTo(0)
             assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.PARENT]).isEqualTo("/root/")
 
-            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.PATH]).isEqualTo("/some/external.web.url")
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.PATH]).isEqualTo("/root/some.web.url")
             assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.IS_FILE]).isEqualTo(1)
             assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.DISPLAY_NAME]).isEqualTo(null)
             assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.DESCRIPTION]).isEqualTo(null)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/DocumentRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/DocumentRepositoryTests.kt
@@ -16,12 +16,13 @@ class DocumentRepositoryTests : CleanDatabaseTests()
         insertDocuments()
         val sut = OrderlyDocumentRepository()
         val result = sut.getAllVisibleDocuments()
-        val expectedLeaf1 = Document("first.csv", "/some/first.csv", true, listOf())
-        val expectedLeaf2 = Document("file.csv", "/some/path/file.csv", true, listOf())
-        val expectedLeaf3 = Document("empty", "/some/empty/", false, listOf())
-        val expectedRoot1 = Document("root", "/root/", false, listOf())
-        val expectedRoot2 = Document("some", "/some/", false,
-                listOf(expectedLeaf3, expectedLeaf1, Document("path", "/some/path/", false, listOf(expectedLeaf2))))
+        val expectedLeaf1 = Document("first.csv", "/some/first.csv", true, false, listOf())
+        val expectedLeaf2 = Document("file.csv", "/some/path/file.csv", true, false, listOf())
+        val expectedLeaf3 = Document("empty", "/some/empty/", false, false, listOf())
+        val expectedRoot1 = Document("root", "/root/", false, false, listOf())
+        val expectedRoot2 = Document("some", "/some/", false, false,
+                listOf(expectedLeaf3, expectedLeaf1, Document("path", "/some/path/", false, false, listOf(expectedLeaf2)),
+                Document("http://external.com", "http://external.com", true, true, listOf())))
 
         assertThat(result.count()).isEqualTo(2)
         assertThat(result.first()).isEqualTo(expectedRoot1)
@@ -67,34 +68,37 @@ class DocumentRepositoryTests : CleanDatabaseTests()
         insertDocuments()
         val sut = OrderlyDocumentRepository()
         val result = sut.getAllFlat().sortedBy { it.path }
-        assertThat(result.count()).isEqualTo(6)
-        assertThat(result[0]).isEqualTo(Document("root", "/root/", false, listOf()))
-        assertThat(result[1]).isEqualTo(Document("some", "/some/", false, listOf()))
-        assertThat(result[2]).isEqualTo(Document("empty", "/some/empty/", false, listOf()))
-        assertThat(result[3]).isEqualTo(Document("first.csv", "/some/first.csv", true, listOf()))
-        assertThat(result[4]).isEqualTo(Document("path", "/some/path/", false, listOf()))
-        assertThat(result[5]).isEqualTo(Document("file.csv", "/some/path/file.csv", true, listOf()))
+        assertThat(result.count()).isEqualTo(7)
+        assertThat(result[0]).isEqualTo(Document("root", "/root/", false, false, listOf()))
+        assertThat(result[1]).isEqualTo(Document("some", "/some/", false, false, listOf()))
+        assertThat(result[2]).isEqualTo(Document("empty", "/some/empty/", false, false, listOf()))
+        assertThat(result[3]).isEqualTo(Document("first.csv", "/some/first.csv", true, false, listOf()))
+        assertThat(result[4]).isEqualTo(Document("path", "/some/path/", false, false, listOf()))
+        assertThat(result[5]).isEqualTo(Document("file.csv", "/some/path/file.csv", true, false, listOf()))
+        assertThat(result[6]).isEqualTo(Document("http://external.com", "http://external.com", true, true, listOf()))
     }
 
     @Test
     fun `can add documents`()
     {
         val sut = OrderlyDocumentRepository()
-        sut.add("/root/", "root", false, null)
-        sut.add("/root/file.csv", "file.csv", true, "/root/")
+        sut.add("/root/", "root", false, false, null)
+        sut.add("/root/file.csv", "file.csv", true, false, "/root/")
+        sut.add("http://external.com", "http://external.com", true, true, "/root/")
 
         JooqContext().use {
             val result = it.dsl.selectFrom(Tables.ORDERLYWEB_DOCUMENT)
                     .orderBy(Tables.ORDERLYWEB_DOCUMENT.PATH)
                     .fetch()
 
-            assertThat(result.count()).isEqualTo(2)
+            assertThat(result.count()).isEqualTo(3)
             assertThat(result[0][Tables.ORDERLYWEB_DOCUMENT.PATH]).isEqualTo("/root/")
             assertThat(result[0][Tables.ORDERLYWEB_DOCUMENT.IS_FILE]).isEqualTo(0)
             assertThat(result[0][Tables.ORDERLYWEB_DOCUMENT.DISPLAY_NAME]).isEqualTo(null)
             assertThat(result[0][Tables.ORDERLYWEB_DOCUMENT.DESCRIPTION]).isEqualTo(null)
             assertThat(result[0][Tables.ORDERLYWEB_DOCUMENT.NAME]).isEqualTo("root")
             assertThat(result[0][Tables.ORDERLYWEB_DOCUMENT.SHOW]).isEqualTo(1)
+            assertThat(result[0][Tables.ORDERLYWEB_DOCUMENT.EXTERNAL]).isEqualTo(0)
             assertThat(result[0][Tables.ORDERLYWEB_DOCUMENT.PARENT]).isEqualTo(null)
 
             assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.PATH]).isEqualTo("/root/file.csv")
@@ -103,7 +107,17 @@ class DocumentRepositoryTests : CleanDatabaseTests()
             assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.DESCRIPTION]).isEqualTo(null)
             assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.NAME]).isEqualTo("file.csv")
             assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.SHOW]).isEqualTo(1)
+            assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.EXTERNAL]).isEqualTo(0)
             assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.PARENT]).isEqualTo("/root/")
+
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.PATH]).isEqualTo("http://external.com")
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.IS_FILE]).isEqualTo(1)
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.DISPLAY_NAME]).isEqualTo(null)
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.DESCRIPTION]).isEqualTo(null)
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.NAME]).isEqualTo("http://external.com")
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.SHOW]).isEqualTo(1)
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.EXTERNAL]).isEqualTo(1)
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.PARENT]).isEqualTo("/root/")
         }
 
     }
@@ -114,27 +128,27 @@ class DocumentRepositoryTests : CleanDatabaseTests()
         insertDocuments()
         val sut = OrderlyDocumentRepository()
 
-        val document1 = sut.getAllFlat().filter{it.path == "/some/"}[0]
-        val document2 = sut.getAllFlat().filter{it.path == "/some/path/"}[0]
+        val document1 = sut.getAllFlat().filter { it.path == "/some/" }[0]
+        val document2 = sut.getAllFlat().filter { it.path == "/some/path/" }[0]
 
         JooqContext().use {
             val query = it.dsl.select(Tables.ORDERLYWEB_DOCUMENT.SHOW)
                     .from(Tables.ORDERLYWEB_DOCUMENT)
                     .where(Tables.ORDERLYWEB_DOCUMENT.PATH.`in`(document1.path, document2.path))
 
-            var show = query.fetch().map{ it[Tables.ORDERLYWEB_DOCUMENT.SHOW] }
+            var show = query.fetch().map { it[Tables.ORDERLYWEB_DOCUMENT.SHOW] }
             assertThat(show[0]).isEqualTo(1)
             assertThat(show[1]).isEqualTo(1)
 
             sut.setVisibility(listOf(document1, document2), false)
 
-            show = query.fetch().map{ it[Tables.ORDERLYWEB_DOCUMENT.SHOW] }
+            show = query.fetch().map { it[Tables.ORDERLYWEB_DOCUMENT.SHOW] }
             assertThat(show[0]).isEqualTo(0)
             assertThat(show[1]).isEqualTo(0)
 
             sut.setVisibility(listOf(document1, document2), true)
 
-            show = query.fetch().map{ it[Tables.ORDERLYWEB_DOCUMENT.SHOW] }
+            show = query.fetch().map { it[Tables.ORDERLYWEB_DOCUMENT.SHOW] }
             assertThat(show[0]).isEqualTo(1)
             assertThat(show[1]).isEqualTo(1)
         }
@@ -189,6 +203,16 @@ class DocumentRepositoryTests : CleanDatabaseTests()
                         this.path = "/some/empty/"
                         this.parent = "/some/"
                         this.isFile = 0
+                        this.show = 1
+                    }.insert()
+
+            it.dsl.newRecord(Tables.ORDERLYWEB_DOCUMENT)
+                    .apply {
+                        this.name = "http://external.com"
+                        this.path = "http://external.com"
+                        this.parent = "/some/"
+                        this.isFile = 1
+                        this.external = 1
                         this.show = 1
                     }.insert()
         }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/DocumentRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/DocumentRepositoryTests.kt
@@ -22,7 +22,7 @@ class DocumentRepositoryTests : CleanDatabaseTests()
         val expectedRoot1 = Document("root", "/root/", false, false, listOf())
         val expectedRoot2 = Document("some", "/some/", false, false,
                 listOf(expectedLeaf3, expectedLeaf1, Document("path", "/some/path/", false, false, listOf(expectedLeaf2)),
-                Document("http://external.com", "http://external.com", true, true, listOf())))
+                Document("http://external.com", "/some/external.web.url", true, true, listOf())))
 
         assertThat(result.count()).isEqualTo(2)
         assertThat(result.first()).isEqualTo(expectedRoot1)
@@ -75,7 +75,7 @@ class DocumentRepositoryTests : CleanDatabaseTests()
         assertThat(result[3]).isEqualTo(Document("first.csv", "/some/first.csv", true, false, listOf()))
         assertThat(result[4]).isEqualTo(Document("path", "/some/path/", false, false, listOf()))
         assertThat(result[5]).isEqualTo(Document("file.csv", "/some/path/file.csv", true, false, listOf()))
-        assertThat(result[6]).isEqualTo(Document("http://external.com", "http://external.com", true, true, listOf()))
+        assertThat(result[6]).isEqualTo(Document("http://external.com", "/some/external.web.url", true, true, listOf()))
     }
 
     @Test
@@ -110,7 +110,7 @@ class DocumentRepositoryTests : CleanDatabaseTests()
             assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.EXTERNAL]).isEqualTo(0)
             assertThat(result[1][Tables.ORDERLYWEB_DOCUMENT.PARENT]).isEqualTo("/root/")
 
-            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.PATH]).isEqualTo("http://external.com")
+            assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.PATH]).isEqualTo("/some/external.web.url")
             assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.IS_FILE]).isEqualTo(1)
             assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.DISPLAY_NAME]).isEqualTo(null)
             assertThat(result[2][Tables.ORDERLYWEB_DOCUMENT.DESCRIPTION]).isEqualTo(null)
@@ -209,7 +209,7 @@ class DocumentRepositoryTests : CleanDatabaseTests()
             it.dsl.newRecord(Tables.ORDERLYWEB_DOCUMENT)
                     .apply {
                         this.name = "http://external.com"
-                        this.path = "http://external.com"
+                        this.path = "/some/external.web.url"
                         this.parent = "/some/"
                         this.isFile = 1
                         this.external = 1

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
@@ -109,7 +109,7 @@ class TemplateObjectWrapperTests : TeamcityTests()
             on { it.userProfile } doReturn CommonProfile().apply { id = "user.name" }
             on { hasPermission(any()) } doReturn true
         }
-        val model = DocumentsViewModel.build(mockContext, listOf(Document("name", "path", true, listOf())))
+        val model = DocumentsViewModel.build(mockContext, listOf(Document("name", "path", true, false, listOf())))
 
         val sut = TemplateObjectWrapper()
         val result = sut.wrap(model) as SimpleHash

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/FileTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/FileTests.kt
@@ -31,14 +31,20 @@ class FileTests
     {
         File("documents/child/grandchild").mkdirs()
         File("documents/childFile.csv").createNewFile()
+        File("documents/link.web.url").createNewFile()
+        File("documents/link.web.url").writeText("[InternetShortcut]\n" +
+                "URL=https://external.com\n")
 
         val root = File("documents").absolutePath
         val children = Files().getAllChildren(root, root).sortedBy { it.name }
-        assertThat(children.count()).isEqualTo(2)
-        assertThat(children[0]).isEqualToComparingFieldByField(DocumentDetails("child", "$root/child", "/child", false))
+        assertThat(children.count()).isEqualTo(3)
+        assertThat(children[0]).isEqualToComparingFieldByField(DocumentDetails("child", "$root/child", "/child", false, false))
         assertThat(children[1])
                 .isEqualToComparingFieldByField(
-                        DocumentDetails("childFile.csv", "$root/childFile.csv", "/childFile.csv", true))
+                        DocumentDetails("childFile.csv", "$root/childFile.csv", "/childFile.csv", true, false))
+        assertThat(children[2])
+                .isEqualToComparingFieldByField(
+                        DocumentDetails("https://external.com", "https://external.com", "https://external.com", true, true))
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/FileTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/FileTests.kt
@@ -44,7 +44,7 @@ class FileTests
                         DocumentDetails("childFile.csv", "$root/childFile.csv", "/childFile.csv", true, false))
         assertThat(children[2])
                 .isEqualToComparingFieldByField(
-                        DocumentDetails("https://external.com", "https://external.com", "https://external.com", true, true))
+                        DocumentDetails("https://external.com", "$root/link.web.url", "/link.web.url", true, true))
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
@@ -86,7 +86,7 @@ class DocumentControllerTests : ControllerTest()
     fun `creates correct breadcrumbs`()
     {
         val mockRepo = mock<DocumentRepository> {
-            on { getAllVisibleDocuments() } doReturn listOf(Document("name", "path", true, listOf()))
+            on { getAllVisibleDocuments() } doReturn listOf(Document("name", "path", true, false, listOf()))
         }
         val sut = DocumentController(mock(), AppConfig(), Files(), mockRepo)
         val result = sut.getAll()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/DocumentControllerTests.kt
@@ -99,8 +99,8 @@ class DocumentControllerTests : ControllerTest()
     {
         val mockRepo = mock<DocumentRepository> {
             on { getAllVisibleDocuments() } doReturn
-                    listOf(Document("name", "/path", false, listOf(
-                            Document("child", "/childpath", true, listOf())
+                    listOf(Document("name", "/path", false, false, listOf(
+                            Document("child", "/childpath", true, false, listOf())
                     )))
         }
         val sut = DocumentController(mock(), AppConfig(), Files(), mockRepo)
@@ -124,16 +124,16 @@ class DocumentControllerTests : ControllerTest()
     {
         val mockRepo = mock<DocumentRepository> {
             on { getAllVisibleDocuments() } doReturn
-                    listOf(Document("toplevelwithonenonemptychild", "toplevelwithonenonemptychild", false, listOf(
-                            Document("emptychild", "emptychild", false, listOf()),
-                            Document("file", "file", true, listOf())
+                    listOf(Document("toplevelwithonenonemptychild", "toplevelwithonenonemptychild", false, false, listOf(
+                            Document("emptychild", "emptychild", false, false, listOf()),
+                            Document("file", "file", true, false, listOf())
                     )),
-                            Document("toplevelempty", "toplevelempty", false, listOf()),
-                            Document("toplevelwithemptychild", "toplevelwithemptychild", false,
-                                    listOf(Document("emptychild", "emptychild   ", false, listOf()))),
-                            Document("toplevelwithemptygrandchild", "toplevelwithemptygrandchild", false,
-                                    listOf(Document("childwithemptygrandchild", "childwithemptygrandchild", false, listOf(
-                                            Document("grandchildempty", "grandchildempty", false, listOf())
+                            Document("toplevelempty", "toplevelempty", false, false, listOf()),
+                            Document("toplevelwithemptychild", "toplevelwithemptychild", false, false,
+                                    listOf(Document("emptychild", "emptychild   ", false, false, listOf()))),
+                            Document("toplevelwithemptygrandchild", "toplevelwithemptygrandchild", false, false,
+                                    listOf(Document("childwithemptygrandchild", "childwithemptygrandchild", false, false, listOf(
+                                            Document("grandchildempty", "grandchildempty", false, false, listOf())
                                     )))))
         }
         val sut = DocumentController(mock(), AppConfig(), Files(), mockRepo)
@@ -150,10 +150,10 @@ class DocumentControllerTests : ControllerTest()
     {
         val mockRepo = mock<DocumentRepository> {
             on { getAllVisibleDocuments() } doReturn
-                    listOf(Document("folder", "path", false, listOf(Document("file", "path", true, listOf()))),
-                            Document("file", "path", true, listOf()),
-                            Document("anotherfolder", "path", false, listOf(Document("file", "path", true, listOf()))),
-                            Document("anotherfile", "path", true, listOf()))
+                    listOf(Document("folder", "path", false, false, listOf(Document("file", "path", true, false, listOf()))),
+                            Document("file", "path", true, false, listOf()),
+                            Document("anotherfolder", "path", false, false, listOf(Document("file", "path", true, false, listOf()))),
+                            Document("anotherfile", "path", true, false, listOf()))
         }
         val sut = DocumentController(mock(), AppConfig(), Files(), mockRepo)
         val result = sut.getAll()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/DocumentsPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/DocumentsPageTests.kt
@@ -28,12 +28,12 @@ class DocumentsPageTests : TeamcityTests()
     @Test
     fun `renders list of docs`()
     {
-        val leaf1 = Document("file.csv", "some/file.csv", true, listOf())
-        val leaf2 = Document("empty", "some/empty/", false, listOf())
-        val leaf3 = Document("file.doc", "some/path/file.doc", true, listOf())
-        val root1 = Document("root", "root/", false, listOf())
-        val root2 = Document("some", "some/", false,
-                listOf(leaf1, leaf2, Document("path", "some/path/", false, listOf(leaf3))))
+        val leaf1 = Document("file.csv", "some/file.csv", true, false, listOf())
+        val leaf2 = Document("empty", "some/empty/", false, false, listOf())
+        val leaf3 = Document("file.doc", "some/path/file.doc", true, false, listOf())
+        val root1 = Document("root", "root/", false, false, listOf())
+        val root2 = Document("some", "some/", false, false,
+                listOf(leaf1, leaf2, Document("path", "some/path/", false, false, listOf(leaf3))))
 
         val viewModel = DocumentsViewModel(listOf(root1, root2), testDefaultModel)
         val doc = template.jsoupDocFor(viewModel)
@@ -54,7 +54,8 @@ class DocumentsPageTests : TeamcityTests()
         assertLinkListItem(thirdLevelMenu.selectFirst("li"), "file.doc", "some/path/file.doc")
     }
 
-    private fun assertLinkListItem(listItem: Element, name: String, href: String) {
+    private fun assertLinkListItem(listItem: Element, name: String, href: String)
+    {
         assertThat(listItem.selectFirst("span").text()).isEqualTo("$name:")
         assertThat(listItem.selectFirst("a").text()).isEqualTo("open")
         assertThat(listItem.selectFirst("a").attr("href"))


### PR DESCRIPTION
Contains commits from https://github.com/vimc/orderly-web/pull/174

What I haven't done here is update the index page itself, so any external links will currently link to the .url text file on disk, rather than the external link. But those changes will be made on a separate branch, and should be done after https://github.com/vimc/orderly-web/pull/173 is merged as well.