### PR TITLE
mrc-1386 disambiguate git endpoints

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -276,7 +276,7 @@ Schema: [`Publish.schema.json`](Publish.schema.json)
 true
 ```
 
-## GET /reports/git/status/
+## GET /git/status/
 
 Get git status.  This does not quite map onto `git status` but includes output from `git status --porcelain=v1` along with branch and hash information.  When running on a server, ideally the `output` section will be an empty array (otherwise branch changing is disabled)
 
@@ -295,7 +295,7 @@ Schema: [`GitStatus.schema.json`](GitStatus.schema.json)
 }
 ```
 
-## POST /reports/git/fetch/
+## POST /git/fetch/
 
 Fetch from remote git.  This is required before accessing an updated reference (e.g. a remote branch) or a hash not present in the local git tree.  It's always safe because it does not change the working tree
 
@@ -312,7 +312,7 @@ Schema: [`GitFetch.schema.json`](GitFetch.schema.json)
 ]
 ```
 
-## POST /reports/git/pull/
+## POST /git/pull/
 
 Pull from remote git.  This updates the working tree.
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/GitRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/GitRouteConfig.kt
@@ -22,6 +22,19 @@ object GitRouteConfig : RouteConfig {
 
             APIEndpoint("/git/fetch/", controller, "fetch", method = HttpMethod.post)
                     .json()
+                    .secure(runReports),
+
+            // deprecated
+            APIEndpoint("/reports/git/status/", controller, "status")
+                    .json()
+                    .secure(runReports),
+            // deprecated
+            APIEndpoint("/reports/git/pull/", controller, "pull", method = HttpMethod.post)
+                    .json()
+                    .secure(runReports),
+            // deprecated
+            APIEndpoint("/reports/git/fetch/", controller, "fetch", method = HttpMethod.post)
+                    .json()
                     .secure(runReports)
     )
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/GitRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/GitRouteConfig.kt
@@ -12,15 +12,15 @@ object GitRouteConfig : RouteConfig {
     private val controller = GitController::class
 
     override val endpoints: List<EndpointDefinition> = listOf(
-            APIEndpoint("/reports/git/status/", controller, "status")
+            APIEndpoint("/git/status/", controller, "status")
                     .json()
                     .secure(runReports),
 
-            APIEndpoint("/reports/git/pull/", controller, "pull", method = HttpMethod.post)
+            APIEndpoint("/git/pull/", controller, "pull", method = HttpMethod.post)
                     .json()
                     .secure(runReports),
 
-            APIEndpoint("/reports/git/fetch/", controller, "fetch", method = HttpMethod.post)
+            APIEndpoint("/git/fetch/", controller, "fetch", method = HttpMethod.post)
                     .json()
                     .secure(runReports)
     )

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/GitTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/GitTests.kt
@@ -9,7 +9,7 @@ class GitTests : IntegrationTest()
     @Test
     fun `gets git status`()
     {
-        val response = apiRequestHelper.get("/reports/git/status/", userEmail = fakeGlobalReportReviewer())
+        val response = apiRequestHelper.get("/git/status/", userEmail = fakeGlobalReportReviewer())
 
         assertSuccessfulWithResponseText(response)
         assertJsonContentType(response)
@@ -17,9 +17,9 @@ class GitTests : IntegrationTest()
     }
 
     @Test
-    fun `pulls`()
+    fun pulls()
     {
-        val response = apiRequestHelper.post("/reports/git/pull/", mapOf(), userEmail = fakeGlobalReportReviewer())
+        val response = apiRequestHelper.post("/git/pull/", mapOf(), userEmail = fakeGlobalReportReviewer())
 
         assertSuccessfulWithResponseText(response)
         assertJsonContentType(response)
@@ -27,9 +27,9 @@ class GitTests : IntegrationTest()
     }
 
     @Test
-    fun `fetches`()
+    fun fetches()
     {
-        val response = apiRequestHelper.post("/reports/git/fetch/", mapOf(),  userEmail = fakeGlobalReportReviewer())
+        val response = apiRequestHelper.post("/git/fetch/", mapOf(),  userEmail = fakeGlobalReportReviewer())
 
         assertSuccessfulWithResponseText(response)
         assertJsonContentType(response)


### PR DESCRIPTION
Removes the /reports/ modifier from git endpoints. Leaves the deprecated endpoints in place as this is a breaking change. Once references to the endpoints are updated in orderly these can be deleted.
