### PR TITLE
bring API endpoint testing up to spec with web endpoint testing

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/PermissionChecker.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/PermissionChecker.kt
@@ -1,0 +1,83 @@
+package org.vaccineimpact.orderlyweb.tests
+
+
+import khttp.responses.Response
+import org.assertj.core.api.Assertions
+import org.vaccineimpact.orderlyweb.ContentTypes
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.test_helpers.insertReport
+import org.vaccineimpact.orderlyweb.test_helpers.removePermission
+import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.RequestHelper
+import spark.route.HttpMethod
+
+abstract class PermissionChecker(protected val url: String,
+                                 protected val allRequiredPermissions: Set<ReifiedPermission>,
+                                 protected val contentType: String = ContentTypes.html,
+                                 protected val method: HttpMethod = HttpMethod.get,
+                                 protected val postData: Map<String, String>? = null)
+{
+
+    abstract val requestHelper: RequestHelper
+    abstract val unsecuredResponseCode: Int
+
+    fun checkPermissionsAreSufficient()
+    {
+        checkThesePermissionsAreSufficient(allRequiredPermissions,
+                "Expected successful request to $url with the given permissions")
+    }
+
+    fun checkPermissionIsRequired(
+            permission: ReifiedPermission
+    )
+    {
+        val assertionText = "Expected permission '$permission' to be required for $url"
+        val limitedPermissions = allRequiredPermissions - permission
+        removePermission(requestHelper.MontaguTestUser, permission.name, permission.scope.databaseScopePrefix ?: "")
+
+        // also remove the global permission which should always be stronger than the scoped one
+        removePermission(requestHelper.MontaguTestUser, permission.name, "")
+
+        println("Checking that permission '$permission' is required for $url")
+        checkThesePermissionsAreInsufficient(limitedPermissions, assertionText)
+
+        if (permission.scope is Scope.Specific)
+        {
+            val scope = permission.scope as Scope.Specific
+
+            println("Checking that same permission with different scope will not satisfy the requirement")
+            val badPermission = ReifiedPermission(permission.name, Scope.Specific(scope.databaseScopePrefix, "bad-id"))
+            insertReport("bad-id", "v1")
+            checkThesePermissionsAreInsufficient(limitedPermissions + badPermission, assertionText)
+
+            println("Checking that same permission with the global scope WILL satisfy the requirement")
+            val betterPermission = ReifiedPermission(permission.name, Scope.Global())
+            checkThesePermissionsAreSufficient(limitedPermissions + betterPermission,
+                    "Expected to be able to substitute '$betterPermission' in place of '$permission' for $url")
+        }
+    }
+
+    abstract fun requestWithPermissions(permissions: Set<ReifiedPermission>): Response
+
+    private fun checkThesePermissionsAreInsufficient(
+            permissions: Set<ReifiedPermission>,
+            assertionText: String
+    )
+    {
+        val response = requestWithPermissions(permissions)
+
+        Assertions.assertThat(response.statusCode)
+                .withFailMessage(assertionText)
+                .isEqualTo(unsecuredResponseCode) // we return 404s for unauthorized users
+    }
+
+    private fun checkThesePermissionsAreSufficient(permissions: Set<ReifiedPermission>,
+                                                   assertionText: String)
+    {
+        val response = requestWithPermissions(permissions)
+        Assertions.assertThat(response.statusCode)
+                .withFailMessage(assertionText)
+                .isEqualTo(200)
+    }
+
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/APIPermissionChecker.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/APIPermissionChecker.kt
@@ -1,0 +1,39 @@
+package org.vaccineimpact.orderlyweb.tests.integration_tests
+
+import khttp.responses.Response
+import org.vaccineimpact.orderlyweb.ContentTypes
+import org.vaccineimpact.orderlyweb.errors.InvalidOperationError
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.tests.PermissionChecker
+import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.APIRequestHelper
+import spark.route.HttpMethod
+
+class APIPermissionChecker(url: String,
+                           allRequiredPermissions: Set<ReifiedPermission>,
+                           contentType: String = ContentTypes.html,
+                           method: HttpMethod = HttpMethod.get,
+                           postData: Map<String, String>? = null)
+    : PermissionChecker(url, allRequiredPermissions, contentType, method, postData)
+{
+
+    override val unsecuredResponseCode = 403
+    override val requestHelper = APIRequestHelper()
+    override fun requestWithPermissions(permissions: Set<ReifiedPermission>): Response
+    {
+        return when (this.method)
+        {
+            HttpMethod.get ->
+            {
+                requestHelper.getWithPermissions(this.url, this.contentType, permissions)
+            }
+            HttpMethod.post ->
+            {
+                requestHelper.postWithPermissions(this.url, this.postData, this.contentType, permissions)
+            }
+            else ->
+            {
+                throw InvalidOperationError("Only GET and POST supported")
+            }
+        }
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/IntegrationTest.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/IntegrationTest.kt
@@ -96,7 +96,8 @@ abstract class IntegrationTest : TeamcityTests()
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("text/html")
     }
 
-    protected fun assertWebUrlSecured(url: String, requiredPermissions: Set<ReifiedPermission>,
+    protected fun assertWebUrlSecured(url: String,
+                                      requiredPermissions: Set<ReifiedPermission>,
                                       contentType: String = ContentTypes.html,
                                       method: HttpMethod = HttpMethod.get,
                                       postData: Map<String, String>? = null)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/IntegrationTest.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/IntegrationTest.kt
@@ -11,6 +11,7 @@ import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.test_helpers.JSONValidator
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+import org.vaccineimpact.orderlyweb.tests.integration_tests.APIPermissionChecker
 import org.vaccineimpact.orderlyweb.tests.integration_tests.WebPermissionChecker
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.APIRequestHelper
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.WebRequestHelper
@@ -101,6 +102,21 @@ abstract class IntegrationTest : TeamcityTests()
                                       postData: Map<String, String>? = null)
     {
         val checker = WebPermissionChecker(url, requiredPermissions, contentType, method, postData)
+        checker.checkPermissionsAreSufficient()
+
+        for (permission in requiredPermissions)
+        {
+            checker.checkPermissionIsRequired(permission)
+        }
+    }
+
+    protected fun assertAPIUrlSecured(url: String,
+                                      requiredPermissions: Set<ReifiedPermission>,
+                                      contentType: String = ContentTypes.binarydata,
+                                      method: HttpMethod = HttpMethod.get,
+                                      postData: Map<String, String>? = null)
+    {
+        val checker = APIPermissionChecker(url, requiredPermissions, contentType, method, postData)
         checker.checkPermissionsAreSufficient()
 
         for (permission in requiredPermissions)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/RoutingTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/RoutingTests.kt
@@ -3,7 +3,6 @@ package org.vaccineimpact.orderlyweb.tests.integration_tests.tests
 import org.assertj.core.api.Assertions
 import org.junit.Test
 
-
 class RoutingTests: IntegrationTest() {
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/GitTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/GitTests.kt
@@ -1,6 +1,8 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.api
 
 import org.junit.Test
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReviewer
 import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
 
@@ -17,6 +19,13 @@ class GitTests : IntegrationTest()
     }
 
     @Test
+    fun `only report runners can get git status`()
+    {
+        val url ="/reports/git/status/"
+        assertAPIUrlSecured(url, setOf(ReifiedPermission("reports.run", Scope.Global())))
+    }
+
+    @Test
     fun `pulls`()
     {
         val response = apiRequestHelper.post("/reports/git/pull/", mapOf(), userEmail = fakeGlobalReportReviewer())
@@ -27,6 +36,13 @@ class GitTests : IntegrationTest()
     }
 
     @Test
+    fun `only report runners can pull`()
+    {
+        val url ="/reports/git/pull/"
+        assertAPIUrlSecured(url, setOf(ReifiedPermission("reports.run", Scope.Global())))
+    }
+
+    @Test
     fun `fetches`()
     {
         val response = apiRequestHelper.post("/reports/git/fetch/", mapOf(),  userEmail = fakeGlobalReportReviewer())
@@ -34,5 +50,12 @@ class GitTests : IntegrationTest()
         assertSuccessfulWithResponseText(response)
         assertJsonContentType(response)
         JSONValidator.validateAgainstSchema(response.text, "GitFetch")
+    }
+
+    @Test
+    fun `only report runners can fetch`()
+    {
+        val url ="/reports/git/fetch/"
+        assertAPIUrlSecured(url, setOf(ReifiedPermission("reports.run", Scope.Global())))
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ReportTests.kt
@@ -1,8 +1,11 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.api
 
-import org.assertj.core.api.Assertions.assertThat
 import com.fasterxml.jackson.databind.node.ArrayNode
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.vaccineimpact.orderlyweb.ContentTypes
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReviewer
 import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
@@ -32,6 +35,13 @@ class ReportTests : IntegrationTest()
     }
 
     @Test
+    fun `only report runners can run report`()
+    {
+        val url = "/reports/minimal/run/"
+        assertAPIUrlSecured(url, setOf(ReifiedPermission("reports.run", Scope.Global())), ContentTypes.json)
+    }
+
+    @Test
     fun `gets report status`()
     {
         val response = apiRequestHelper.get("/reports/agronomic_seahorse/status",
@@ -39,6 +49,13 @@ class ReportTests : IntegrationTest()
         assertSuccessfulWithResponseText(response)
         assertJsonContentType(response)
         JSONValidator.validateAgainstSchema(response.text, "Status")
+    }
+
+    @Test
+    fun `only report runners can see status`()
+    {
+        val url = "/reports/agronomic_seahorse/status"
+        assertAPIUrlSecured(url, setOf(ReifiedPermission("reports.run", Scope.Global())), ContentTypes.json)
     }
 
     @Test
@@ -80,8 +97,8 @@ class ReportTests : IntegrationTest()
     fun `can get latest changelog if reader permissions only`()
     {
         //This report has been published so we should be able to see it, though it has no log items
-       val response = apiRequestHelper.get("/reports/other/latest/changelog",
-               userEmail = fakeGlobalReportReviewer())
+        val response = apiRequestHelper.get("/reports/other/latest/changelog",
+                userEmail = fakeGlobalReportReviewer())
 
         assertSuccessful(response)
         assertJsonContentType(response)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ResourceTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ResourceTests.kt
@@ -5,6 +5,8 @@ import org.junit.Test
 import org.vaccineimpact.orderlyweb.models.FilePurpose
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.tests.insertFileInput
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReviewer
@@ -25,17 +27,16 @@ class ResourceTests : IntegrationTest()
     }
 
     @Test
-    fun `can't get dict of resource names to hashes if report not in scoped permissions`()
+    fun `only report readers can get dict of resource names to hashes`()
     {
         insertReport("testname", "testversion")
-        val response = apiRequestHelper.get("/reports/testname/versions/testversion/resources",
-                userEmail = fakeReportReader("testname"))
-
-        assertJsonContentType(response)
+        assertAPIUrlSecured("/user/add/",
+                setOf(ReifiedPermission("reports.read", Scope.Specific("report", "testname"))),
+                contentType = ContentTypes.json)
     }
 
     @Test
-    fun `gets resource file`()
+    fun `gets resource file with access token`()
     {
         val version = File("${AppConfig()["orderly.root"]}/archive/use_resource/").list()[0]
 
@@ -47,7 +48,6 @@ class ResourceTests : IntegrationTest()
         assertSuccessful(response)
         Assertions.assertThat(response.headers["content-type"]).isEqualTo("application/octet-stream")
         Assertions.assertThat(response.headers["content-disposition"]).isEqualTo("attachment; filename=\"use_resource/$version/meta/data.csv\"")
-
     }
 
     @Test
@@ -67,16 +67,14 @@ class ResourceTests : IntegrationTest()
     }
 
     @Test
-    fun `can't get resource file if report not in scoped permissions`()
+    fun `only report readers can get resource file`()
     {
         val version = File("${AppConfig()["orderly.root"]}/archive/use_resource/").list()[0]
-
         val resourceEncoded = "meta:data.csv"
         val url = "/reports/use_resource/versions/$version/resources/$resourceEncoded/"
-        val token = apiRequestHelper.generateOnetimeToken(url, fakeReportReader("badereportname"))
-        val response = apiRequestHelper.getNoAuth("$url?access_token=$token", ContentTypes.binarydata)
 
-        assertUnauthorized(response, "use_resource")
+        assertAPIUrlSecured(url,
+                setOf(ReifiedPermission("reports.read", Scope.Specific("report", "use_resource"))))
     }
 
     @Test
@@ -91,18 +89,6 @@ class ResourceTests : IntegrationTest()
         assertJsonContentType(response)
         Assertions.assertThat(response.statusCode).isEqualTo(404)
         JSONValidator.validateError(response.text, "unknown-resource", "Unknown resource : '$fakeresource'")
-    }
-
-    @Test
-    fun `gets 401 if missing access token`()
-    {
-        insertReport("testname", "testversion")
-        val fakeresource = "hf647rhj"
-        val response = apiRequestHelper.getNoAuth("/reports/testname/versions/testversion/resources/$fakeresource/", ContentTypes.binarydata)
-
-        Assertions.assertThat(response.statusCode).isEqualTo(401)
-        JSONValidator.validateMultipleAuthErrors(response.text)
-
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/VersionTests.kt
@@ -6,16 +6,20 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runners.MethodSorters
+import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.db.JooqContext
 import org.vaccineimpact.orderlyweb.db.Tables
 import org.vaccineimpact.orderlyweb.db.Tables.REPORT_VERSION
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.InsertableChangelog
 import org.vaccineimpact.orderlyweb.tests.insertChangelog
-import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReader
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReviewer
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeReportReader
 import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
+import spark.route.HttpMethod
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class VersionTests : IntegrationTest()
@@ -43,10 +47,10 @@ class VersionTests : IntegrationTest()
 
         val publishStatus = JooqContext().use {
 
-            it.dsl.select(Tables.REPORT_VERSION.PUBLISHED)
-                    .from(Tables.REPORT_VERSION)
-                    .where(Tables.REPORT_VERSION.REPORT.eq(reportName))
-                    .and(Tables.REPORT_VERSION.ID.eq(versionId))
+            it.dsl.select(REPORT_VERSION.PUBLISHED)
+                    .from(REPORT_VERSION)
+                    .where(REPORT_VERSION.REPORT.eq(reportName))
+                    .and(REPORT_VERSION.ID.eq(versionId))
                     .fetchInto(Boolean::class.java)
                     .first()
         }
@@ -54,14 +58,14 @@ class VersionTests : IntegrationTest()
         assertThat(publishStatus).isTrue()
     }
 
-    @Test // method name prefixed with B so runs first
+    @Test // method name prefixed with B so runs second
     fun `B unpublishes report`()
     {
         val publishedVersion = JooqContext().use {
 
-            it.dsl.select(Tables.REPORT_VERSION.ID, REPORT_VERSION.REPORT)
-                    .from(Tables.REPORT_VERSION)
-                    .where(Tables.REPORT_VERSION.PUBLISHED.eq(true))
+            it.dsl.select(REPORT_VERSION.ID, REPORT_VERSION.REPORT)
+                    .from(REPORT_VERSION)
+                    .where(REPORT_VERSION.PUBLISHED.eq(true))
                     .fetchAny()
         }
 
@@ -80,15 +84,36 @@ class VersionTests : IntegrationTest()
 
         val publishStatus = JooqContext().use {
 
-            it.dsl.select(Tables.REPORT_VERSION.PUBLISHED)
-                    .from(Tables.REPORT_VERSION)
-                    .where(Tables.REPORT_VERSION.REPORT.eq(reportName))
-                    .and(Tables.REPORT_VERSION.ID.eq(versionId))
+            it.dsl.select(REPORT_VERSION.PUBLISHED)
+                    .from(REPORT_VERSION)
+                    .where(REPORT_VERSION.REPORT.eq(reportName))
+                    .and(REPORT_VERSION.ID.eq(versionId))
                     .fetchInto(Boolean::class.java)
                     .first()
         }
 
         assertThat(publishStatus).isFalse()
+    }
+
+    @Test // method name prefixed with C so runs third
+    fun `C only report reviewers can publish reports`()
+    {
+        val version = JooqContext().use {
+
+            it.dsl.select(REPORT_VERSION.ID, REPORT_VERSION.REPORT)
+                    .from(REPORT_VERSION)
+                    .fetchAny()
+        }
+
+        val versionId = version[REPORT_VERSION.ID]
+        val reportName = version[REPORT_VERSION.REPORT]
+
+        val url = "/reports/$reportName/versions/$versionId/publish/?value=false"
+
+        assertAPIUrlSecured(url,
+                setOf(ReifiedPermission("reports.review", Scope.Global())),
+                method = HttpMethod.post,
+                contentType = ContentTypes.json)
     }
 
     @Test
@@ -135,43 +160,25 @@ class VersionTests : IntegrationTest()
         assertThat(data[0].get("name").asText()).isEqualTo("html")
     }
 
-
     @Test
-    fun `can get report versions by name with global report reading permissions`()
+    fun `can get report version ids`()
     {
-        insertReport("testname", "testversion")
-        val response = apiRequestHelper.get("/reports/testname",
-                userEmail = fakeGlobalReportReader())
+        val response = apiRequestHelper.get("/reports/minimal")
 
-        assertSuccessful(response)
         assertJsonContentType(response)
+        assertThat(response.statusCode).isEqualTo(200)
         JSONValidator.validateAgainstSchema(response.text, "VersionIds")
     }
 
     @Test
-    fun `can get report versions by name with specific report reading permissions`()
+    fun `only report readers can get report version ids`()
     {
-        insertReport("testname", "testversion")
-        val response = apiRequestHelper.get("/reports/testname",
-                userEmail = fakeReportReader("testname"))
-
-        assertSuccessful(response)
-        assertJsonContentType(response)
-        JSONValidator.validateAgainstSchema(response.text, "VersionIds")
+        val url = "/reports/minimal"
+        assertAPIUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Global())), ContentTypes.json)
     }
 
     @Test
-    fun `get report versions throws 403 if user not authorized to read report`()
-    {
-        insertReport("testname", "testversion")
-        val response = apiRequestHelper.get("/reports/testname",
-                userEmail = fakeReportReader("badreportname"))
-
-        assertUnauthorized(response, "testname")
-    }
-
-    @Test
-    fun `can get report by name and version with global permissions`()
+    fun `can get report by name and version`()
     {
         insertReport("testname", "testversion")
         val response = apiRequestHelper.get("/reports/testname/versions/testversion",
@@ -182,23 +189,11 @@ class VersionTests : IntegrationTest()
     }
 
     @Test
-    fun `can get report by name and version with scoped permission`()
+    fun `only report readers can get report by name and version`()
     {
         insertReport("testname", "testversion")
-        val response = apiRequestHelper.get("/reports/testname/versions/testversion",
-                userEmail = fakeReportReader("testname"))
-        assertSuccessful(response)
-        assertJsonContentType(response)
-        JSONValidator.validateAgainstSchema(response.text, "VersionDetails")
-    }
-
-    @Test
-    fun `get by name and version returns 403 if report not in scoped permissions`()
-    {
-        insertReport("testname", "testversion")
-        val response = apiRequestHelper.get("/reports/testname/versions/testversion",
-                userEmail = fakeReportReader("badreportname"))
-        assertUnauthorized(response, "testname")
+        val url = "/reports/testname/versions/testversion"
+        assertAPIUrlSecured(url, setOf(ReifiedPermission("report.read", Scope.Specific("report", "testname"))))
     }
 
     @Test
@@ -211,6 +206,14 @@ class VersionTests : IntegrationTest()
         assertSuccessful(response)
         assertJsonContentType(response)
         JSONValidator.validateAgainstSchema(response.text, "VersionDetails")
+    }
+
+    @Test
+    fun `only report reviewers can get unpublished report by name and version`()
+    {
+        insertReport("testname", "testversion", published = false)
+        val url = "/reports/testname/versions/testversion"
+        assertAPIUrlSecured(url, setOf(ReifiedPermission("report.review", Scope.Global())))
     }
 
     @Test
@@ -267,31 +270,11 @@ class VersionTests : IntegrationTest()
     }
 
     @Test
-    fun `can get version changelog by name and version if global reader permissions only`()
+    fun `only report readers can get version changelog by name and version`()
     {
-        //reader now has permission to get public changelog items for published reports which they have perms to read
         insertReport("testname", "testversion")
-        insertChangelog(listOf(
-                InsertableChangelog(
-                        "id1",
-                        "testversion",
-                        "internal",
-                        "did something awful",
-                        false,
-                        1),
-                InsertableChangelog(
-                        "id2",
-                        "testversion",
-                        "public",
-                        "did something great",
-                        true,
-                        2)))
-
-        val response = apiRequestHelper.get("/reports/testname/versions/testversion/changelog/",
-                userEmail = fakeGlobalReportReader())
-        assertSuccessful(response)
-        assertJsonContentType(response)
-        JSONValidator.validateAgainstSchema(response.text, "Changelog")
+        val url = "/reports/testname/versions/testversion/changelog/"
+        assertAPIUrlSecured(url, setOf(ReifiedPermission("report.read", Scope.Specific("report", "testname"))))
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/VersionTests.kt
@@ -28,7 +28,7 @@ class VersionTests : IntegrationTest()
 
         val url = "/report/$reportName/version/$versionId/publish/"
 
-        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Global()),
+        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Specific("report", reportName)),
                 ReifiedPermission("reports.review", Scope.Global())), method = HttpMethod.post,
                 contentType = ContentTypes.json)
     }
@@ -36,15 +36,15 @@ class VersionTests : IntegrationTest()
     @Test
     fun `only report readers can get resource`()
     {
-        val url = getAnyResourceUrl()
-        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Global())), ContentTypes.binarydata)
+        val (report, url) = getAnyArtefactUrl()
+        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Specific("report", report))), ContentTypes.binarydata)
     }
 
     @Test
     fun `only report readers can get artefact`()
     {
-        val url = getAnyArtefactUrl()
-        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Global())), ContentTypes.binarydata)
+        val (report, url) = getAnyArtefactUrl()
+        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Specific("report", report))), ContentTypes.binarydata)
     }
 
     @Test
@@ -63,26 +63,28 @@ class VersionTests : IntegrationTest()
 
         val url = "/report/$reportName/version/$versionId/all/"
 
-        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Global())), ContentTypes.binarydata)
+        assertWebUrlSecured(url,
+                setOf(ReifiedPermission("reports.read", Scope.Specific("report", reportName))),
+                ContentTypes.binarydata)
     }
 
     @Test
     fun `only report readers can get csv data`()
     {
-        val url = getAnyDataUrl() + "?type=csv"
-        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Global())),
+        val (report, url) = getAnyDataUrl()
+        assertWebUrlSecured("$url?type=csv", setOf(ReifiedPermission("reports.read", Scope.Specific("report", report))),
                 contentType = ContentTypes.binarydata)
     }
 
     @Test
     fun `only report readers can get rds data`()
     {
-        val url = getAnyDataUrl() + "?type=rds"
-        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.read", Scope.Global())),
+        val (report, url) = getAnyDataUrl()
+        assertWebUrlSecured("$url?type=rds", setOf(ReifiedPermission("reports.read", Scope.Specific("report", report))),
                 contentType = ContentTypes.binarydata)
     }
 
-    private fun getAnyDataUrl(): String
+    private fun getAnyDataUrl(): Pair<String, String>
     {
         val data = JooqContext().use {
 
@@ -98,10 +100,10 @@ class VersionTests : IntegrationTest()
         val version = data[REPORT_VERSION_DATA.REPORT_VERSION]
         val name = URLEncoder.encode(data[REPORT_VERSION_DATA.NAME], "UTF-8")
 
-        return "/report/$report/version/$version/data/$name/"
+        return Pair(report, "/report/$report/version/$version/data/$name/")
     }
 
-    private fun getAnyResourceUrl(): String
+    private fun getAnyResourceUrl(): Pair<String, String>
     {
         val resource = JooqContext().use {
 
@@ -119,10 +121,10 @@ class VersionTests : IntegrationTest()
         val fileName = resource[FILE_INPUT.FILENAME]
         val encodedFileName = URLEncoder.encode(fileName, "UTF-8")
 
-        return "/report/$report/version/$version/resources/$encodedFileName/"
+        return Pair(report, "/report/$report/version/$version/resources/$encodedFileName/")
     }
 
-    private fun getAnyArtefactUrl(): String
+    private fun getAnyArtefactUrl(): Pair<String, String>
     {
         val resource = JooqContext().use {
 
@@ -139,6 +141,6 @@ class VersionTests : IntegrationTest()
         val fileName = resource[FILE_ARTEFACT.FILENAME]
         val encodedFileName = URLEncoder.encode(fileName, "UTF-8")
 
-        return "/report/$report/version/$version/artefacts/$encodedFileName/"
+        return Pair(report, "/report/$report/version/$version/artefacts/$encodedFileName/")
     }
 }

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/insertHelpers.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/insertHelpers.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.orderlyweb.test_helpers
 
 import org.vaccineimpact.orderlyweb.db.JooqContext
 import org.vaccineimpact.orderlyweb.db.Tables
+import org.vaccineimpact.orderlyweb.db.Tables.ORDERLYWEB_USER_GROUP_PERMISSION_ALL
 import java.sql.Timestamp
 import java.time.Instant
 
@@ -13,8 +14,6 @@ fun removePermission(email: String, permissionName: String, scopePrefix: String)
                 .from(Tables.ORDERLYWEB_USER_GROUP_PERMISSION)
                 .join(Tables.ORDERLYWEB_PERMISSION)
                 .on(Tables.ORDERLYWEB_USER_GROUP_PERMISSION.PERMISSION.eq(Tables.ORDERLYWEB_PERMISSION.ID))
-                .join(Tables.ORDERLYWEB_USER_GROUP_GLOBAL_PERMISSION)
-                .on(Tables.ORDERLYWEB_USER_GROUP_GLOBAL_PERMISSION.ID.eq(Tables.ORDERLYWEB_USER_GROUP_PERMISSION.ID))
                 .where(Tables.ORDERLYWEB_USER_GROUP_PERMISSION.USER_GROUP.eq(email))
                 .and(Tables.ORDERLYWEB_PERMISSION.ID.eq(permissionName))
                 .fetchAny(Tables.ORDERLYWEB_USER_GROUP_PERMISSION.ID)
@@ -34,11 +33,22 @@ fun removePermission(email: String, permissionName: String, scopePrefix: String)
                         .where(Tables.ORDERLYWEB_USER_GROUP_GLOBAL_PERMISSION.ID.eq(permissionID))
                         .execute()
             }
+        }
 
+        val allPermissions = it.dsl.select(ORDERLYWEB_USER_GROUP_PERMISSION_ALL.ID,
+                        ORDERLYWEB_USER_GROUP_PERMISSION_ALL.PERMISSION,
+                        ORDERLYWEB_USER_GROUP_PERMISSION_ALL.SCOPE_PREFIX,
+                        ORDERLYWEB_USER_GROUP_PERMISSION_ALL.SCOPE_ID)
+                .from(ORDERLYWEB_USER_GROUP_PERMISSION_ALL)
+                .where(ORDERLYWEB_USER_GROUP_PERMISSION_ALL.USER_GROUP.eq(email))
+                .and(ORDERLYWEB_USER_GROUP_PERMISSION_ALL.PERMISSION.eq(permissionName))
+                .fetch()
+
+        if (allPermissions.count() == 0)
+        {
             it.dsl.deleteFrom(Tables.ORDERLYWEB_USER_GROUP_PERMISSION)
                     .where(Tables.ORDERLYWEB_USER_GROUP_PERMISSION.ID.eq(permissionID))
                     .execute()
-
         }
     }
 }
@@ -140,13 +150,13 @@ fun insertVersionParameterValues(version: String,
         if (!typeExists)
         {
             val typeRecord = it.dsl.newRecord(Tables.PARAMETERS_TYPE)
-                    .apply{
+                    .apply {
                         this.name = "text"
                     }
             typeRecord.store()
         }
 
-        for ((k,v) in parameterValues)
+        for ((k, v) in parameterValues)
         {
             val parameterRecord = it.dsl.newRecord(Tables.PARAMETERS)
                     .apply {
@@ -163,11 +173,11 @@ fun insertVersionParameterValues(version: String,
 
 fun insertVersionTags(version: String, tags: List<String>)
 {
-    JooqContext().use{
-        for(tag in tags)
+    JooqContext().use {
+        for (tag in tags)
         {
             val tagRecord = it.dsl.newRecord(Tables.ORDERLYWEB_REPORT_VERSION_TAG)
-                    .apply{
+                    .apply {
                         this.reportVersion = version
                         this.tag = tag
                     }
@@ -178,11 +188,11 @@ fun insertVersionTags(version: String, tags: List<String>)
 
 fun insertReportTags(report: String, tags: List<String>)
 {
-    JooqContext().use{
-        for(tag in tags)
+    JooqContext().use {
+        for (tag in tags)
         {
             val tagRecord = it.dsl.newRecord(Tables.ORDERLYWEB_REPORT_TAG)
-                    .apply{
+                    .apply {
                         this.report = report
                         this.tag = tag
                     }


### PR DESCRIPTION
We introduced a permission checking utility for web endpoints but didn't do the same for api endpoints. As a result api tests are more laborious to write and less consistent (and in some places, tests that endpoints were secure were missing). This PR adds a permission checker for api endpoints and uses it where relevant.

In the course of adding this I found that we were not correctly testing endpoints that were secured with scoped report reading permissions and indeed the logic for doing so had a bug in it. So this has also been fixed and the web tests updated.