### PR TITLE
mrc-1457 pull out datatables files from bundle

### DIFF
--- a/src/app/static/externals.config.js
+++ b/src/app/static/externals.config.js
@@ -3,5 +3,8 @@ module.exports = [
     "./node_modules/bootstrap/dist/js/bootstrap.min.js",
     "./node_modules/bootstrap/dist/js/bootstrap.min.js.map",
     "./node_modules/popper.js/dist/umd/popper.min.js",
-    "./node_modules/popper.js/dist/umd/popper.min.js.map"
+    "./node_modules/popper.js/dist/umd/popper.min.js.map",
+    "./node_modules/datatables.net/js/jquery.dataTables.min.js",
+    "./node_modules/datatables.net-bs4/js/dataTables.bootstrap4.js",
+    "./node_modules/datatables.net-dt/js/dataTables.dataTables.js",
 ];

--- a/src/app/static/src/js/index.js
+++ b/src/app/static/src/js/index.js
@@ -1,9 +1,6 @@
 import {nameFilter, options, statusFilter} from "./utils/reportsTable";
 import $ from 'jquery';
 
-require("datatables.net")(window, $);
-require("datatables.net-dt")(window, $);
-require('datatables.net-bs4')(window, $);
 require("treetables")(window, $);
 
 export const initReportTable = (isReviewer, reports, customFields) => {

--- a/src/app/templates/index.ftl
+++ b/src/app/templates/index.ftl
@@ -131,6 +131,9 @@
             var canReview = true;
             </#if>
         </script>
+        <script type="text/javascript" src="${appUrl}/js/lib/jquery.dataTables.min.js"></script>
+        <script type="text/javascript" src="${appUrl}/js/lib/dataTables.bootstrap4.js"></script>
+        <script type="text/javascript" src="${appUrl}/js/lib/dataTables.dataTables.js"></script>
         <script type="text/javascript" src="${appUrl}/js/index.bundle.js"></script>
     </#macro>
 </@layout>


### PR DESCRIPTION
the index bundle is over the recommended bundle size and we get a webpack warning about it. this just pulls out the datatables related files from the bundle to keep the size down