### PR TITLE
mrc-1478 bug fix - styling not applied for public changelog items

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -425,8 +425,9 @@ class Orderly(val isReviewer: Boolean,
                 .select(changelogReportVersionColumnForUser.`as`("REPORT_VERSION"),
                         CHANGELOG.LABEL,
                         CHANGELOG.VALUE,
-                        CHANGELOG.FROM_FILE)
-                .from(CHANGELOG)
+                        CHANGELOG.FROM_FILE,
+                        CHANGELOG_LABEL.PUBLIC)
+                .fromJoinPath(CHANGELOG, CHANGELOG_LABEL)
                 .join(REPORT_VERSION)
                 .on(changelogReportVersionColumnForUser.eq(REPORT_VERSION.ID))
                 .where(REPORT_VERSION.REPORT.eq(report))
@@ -445,11 +446,7 @@ class Orderly(val isReviewer: Boolean,
             if (isReviewer)
                 trueCondition()
             else
-                CHANGELOG.LABEL.`in`(
-                        select(CHANGELOG_LABEL.ID)
-                                .from(CHANGELOG_LABEL)
-                                .where(CHANGELOG_LABEL.PUBLIC)
-                ).and(CHANGELOG.REPORT_VERSION_PUBLIC.isNotNull)
+                CHANGELOG_LABEL.PUBLIC.isTrue.and(CHANGELOG.REPORT_VERSION_PUBLIC.isNotNull)
 
     private val changelogReportVersionColumnForUser =
             if (isReviewer)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Changelog.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Changelog.kt
@@ -1,8 +1,11 @@
 package org.vaccineimpact.orderlyweb.models
+
 import java.beans.ConstructorProperties
+
 data class Changelog
 @ConstructorProperties("reportVersion", "label", "value", "fromFile")
 constructor(val reportVersion: String,
             val label: String,
             val value: String,
-            val fromFile: Boolean)
+            val fromFile: Boolean,
+            val public: Boolean)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Changelog.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Changelog.kt
@@ -3,7 +3,7 @@ package org.vaccineimpact.orderlyweb.models
 import java.beans.ConstructorProperties
 
 data class Changelog
-@ConstructorProperties("reportVersion", "label", "value", "fromFile")
+@ConstructorProperties("reportVersion", "label", "value", "fromFile", "public")
 constructor(val reportVersion: String,
             val label: String,
             val value: String,

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -1,15 +1,15 @@
 package org.vaccineimpact.orderlyweb.viewmodels
 
 import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.byteCountToDisplaySize
 import org.vaccineimpact.orderlyweb.canRenderInBrowser
 import org.vaccineimpact.orderlyweb.controllers.web.Serialise
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.isImage
+import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import org.vaccineimpact.orderlyweb.models.*
-import org.vaccineimpact.orderlyweb.byteCountToDisplaySize
 
 
 data class ReportVersionPageViewModel(@Serialise("reportJson") val report: ReportVersionDetails,
@@ -182,14 +182,14 @@ data class InputDataViewModel(val key: String,
 data class DownloadableFileViewModel(val name: String, val url: String, val size: Long?)
 {
     val formattedSize =
-        if (size != null)
-        {
-            byteCountToDisplaySize(size)
-        }
-        else
-        {
-            null
-        }
+            if (size != null)
+            {
+                byteCountToDisplaySize(size)
+            }
+            else
+            {
+                null
+            }
 }
 
 data class ChangelogViewModel(val date: String, val version: String, val entries: List<ChangelogItemViewModel>)
@@ -199,10 +199,21 @@ data class ChangelogViewModel(val date: String, val version: String, val entries
         fun build(id: String, changelog: List<Changelog>): ChangelogViewModel
         {
             val date = ReportVersionPageViewModel.getDateStringFromVersionId(id)
-            val entries = changelog.map { ChangelogItemViewModel(it.label, it.value) }
+
+            val entries = changelog.map {
+                val cssClass = if (it.public)
+                {
+                    "public"
+                }
+                else
+                {
+                    "internal"
+                }
+                ChangelogItemViewModel(it.label, it.value, cssClass)
+            }
             return ChangelogViewModel(date, id, entries)
         }
     }
 }
 
-data class ChangelogItemViewModel(val label: String, val value: String)
+data class ChangelogItemViewModel(val label: String, val value: String, val cssClass: String)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/OrderlyChangelogTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/OrderlyChangelogTests.kt
@@ -44,8 +44,8 @@ class OrderlychangelogTests : CleanDatabaseTests()
         Assertions.assertThat(results.count()).isEqualTo(2)
 
         //changelog items are returned in desc order
-        assertChangelogValuesMatch(results[0], "version1", "internal", "did something awful", false)
-        assertChangelogValuesMatch(results[1], "version1", "public", "did something great", true)
+        assertChangelogValuesMatch(results[0], "version1", "internal", "did something awful", false, false)
+        assertChangelogValuesMatch(results[1], "version1", "public", "did something great", true, true)
     }
 
     @Test
@@ -76,7 +76,7 @@ class OrderlychangelogTests : CleanDatabaseTests()
 
         Assertions.assertThat(results.count()).isEqualTo(1)
 
-        assertChangelogValuesMatch(results[0], "version1", "public", "did something great", true)
+        assertChangelogValuesMatch(results[0], "version1", "public", "did something great", true, true)
     }
 
     @Test
@@ -415,9 +415,9 @@ class OrderlychangelogTests : CleanDatabaseTests()
 
         Assertions.assertThat(results.count()).isEqualTo(3)
 
-        assertChangelogValuesMatch(results[0], "v3", "public", "did something great v3", true)
-        assertChangelogValuesMatch(results[1], "v2", "public", "did something great v2", true)
-        assertChangelogValuesMatch(results[2], "v2", "public", "did something great v1", true)
+        assertChangelogValuesMatch(results[0], "v3", "public", "did something great v3", true, true)
+        assertChangelogValuesMatch(results[1], "v2", "public", "did something great v2", true, true)
+        assertChangelogValuesMatch(results[2], "v2", "public", "did something great v1", true, true)
     }
 
     private fun insertTestReportChangelogs()
@@ -488,24 +488,24 @@ class OrderlychangelogTests : CleanDatabaseTests()
 
         if (latestVersion == "version3")
         {
-            assertChangelogValuesMatch(results[0], "version3", "internal", "everything is broken", false)
-            assertChangelogValuesMatch(results[1], "version3", "internal", "did something awful v3", false)
-            assertChangelogValuesMatch(results[2], "version3", "public", "did something great v3", true)
+            assertChangelogValuesMatch(results[0], "version3", "internal", "everything is broken", false, false)
+            assertChangelogValuesMatch(results[1], "version3", "internal", "did something awful v3", false, false)
+            assertChangelogValuesMatch(results[2], "version3", "public", "did something great v3", true, true)
 
             index += 3
         }
 
         if (latestVersion == "version2" || index > 0)
         {
-            assertChangelogValuesMatch(results[index], "version2", "public", "did something great v2", true)
+            assertChangelogValuesMatch(results[index], "version2", "public", "did something great v2", true, true)
 
             index++
         }
 
         if (latestVersion == "version1" || index > 0)
         {
-            assertChangelogValuesMatch(results[index], "version1", "internal", "did something awful v1", false)
-            assertChangelogValuesMatch(results[index + 1], "version1", "public", "did something great v1", true)
+            assertChangelogValuesMatch(results[index], "version1", "internal", "did something awful v1", false, false)
+            assertChangelogValuesMatch(results[index + 1], "version1", "public", "did something great v1", true, true)
 
             index += 2
         }
@@ -524,7 +524,7 @@ class OrderlychangelogTests : CleanDatabaseTests()
 
         if (latestVersion == "version3")
         {
-            assertChangelogValuesMatch(results[0], "version3", "public", "did something great v3", true)
+            assertChangelogValuesMatch(results[0], "version3", "public", "did something great v3", true, true)
 
             index++
         }
@@ -532,7 +532,7 @@ class OrderlychangelogTests : CleanDatabaseTests()
         if (latestVersion == "version2" || index > 0)
         {
             //The public version of this changelog item is version3, while the 'real' version is version2
-            assertChangelogValuesMatch(results[index], "version3", "public", "did something great v2", true)
+            assertChangelogValuesMatch(results[index], "version3", "public", "did something great v2", true, true)
 
             index++
         }
@@ -545,12 +545,17 @@ class OrderlychangelogTests : CleanDatabaseTests()
         }
     }
 
-    private fun assertChangelogValuesMatch(changelog: Changelog, report_version: String, label: String,
-                                           value: String, fromFile: Boolean)
+    private fun assertChangelogValuesMatch(changelog: Changelog,
+                                           report_version: String,
+                                           label: String,
+                                           value: String,
+                                           fromFile: Boolean,
+                                           public: Boolean)
     {
         Assertions.assertThat(changelog.reportVersion).isEqualTo(report_version)
         Assertions.assertThat(changelog.fromFile).isEqualTo(fromFile)
         Assertions.assertThat(changelog.label).isEqualTo(label)
         Assertions.assertThat(changelog.value).isEqualTo(value)
+        Assertions.assertThat(changelog.public).isEqualTo(public)
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
@@ -129,8 +129,8 @@ class ReportControllerTests : ControllerTest()
         val reportName = "reportName"
 
         val latestVersion = "latestVersion"
-        val changelogs = listOf(Changelog(latestVersion, "public", "did a thing", true),
-                Changelog(latestVersion, "public", "did another thing", true))
+        val changelogs = listOf(Changelog(latestVersion, "public", "did a thing", true, true),
+                Changelog(latestVersion, "public", "did another thing", true, true))
 
         val orderly = mock<OrderlyClient> {
             on { this.getLatestChangelogByName(reportName) } doReturn changelogs

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
@@ -132,8 +132,8 @@ class VersionControllerTests : ControllerTest()
     @Test
     fun `getChangelogByNameAndVersion returns changelog`()
     {
-        val changelogs = listOf(Changelog(reportVersion, "public", "did a thing", true),
-                Changelog(reportVersion, "public", "did another thing", true))
+        val changelogs = listOf(Changelog(reportVersion, "public", "did a thing", true, true),
+                Changelog(reportVersion, "public", "did another thing", true, true))
 
         val orderly = mock<OrderlyClient> {
             on { this.getChangelogByNameAndVersion(reportName, reportVersion) } doReturn changelogs

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
@@ -28,10 +28,10 @@ class GetByNameAndVersionTests : TeamcityTests()
             listOf(),
             mapOf("p1" to "v1", "p2" to "v2"))
 
-    private val mockChangelog = listOf(Changelog("20160103-143015-1234abcd", "internal", "something internal", true),
-            Changelog("20160103-143015-1234abcd", "public", "something public", true),
-            Changelog("20170106-143015-1234abcd", "internal", "something internal in 2017", true),
-            Changelog("20180103-143015-1234abcd", "public", "something public in 2018", true))
+    private val mockChangelog = listOf(Changelog("20160103-143015-1234abcd", "internal", "something internal", true, false),
+            Changelog("20160103-143015-1234abcd", "public", "something public", true, true),
+            Changelog("20170106-143015-1234abcd", "internal", "something internal in 2017", true, false),
+            Changelog("20180103-143015-1234abcd", "public", "something public in 2018", true, true))
 
     private val mockActionContext = mock<ActionContext> {
         on { this.params(":name") } doReturn "r1"
@@ -135,18 +135,18 @@ class GetByNameAndVersionTests : TeamcityTests()
         assertThat(result.changelog.count()).isEqualTo(3)
         assertThat(result.changelog[0].date).isEqualTo("Wed Jan 03 2018, 14:30")
         assertThat(result.changelog[0].version).isEqualTo("20180103-143015-1234abcd")
-        var expectedEntries = listOf(ChangelogItemViewModel("public", "something public in 2018"))
+        var expectedEntries = listOf(ChangelogItemViewModel("public", "something public in 2018", "public"))
         assertThat(result.changelog[0].entries).hasSameElementsAs(expectedEntries)
 
         assertThat(result.changelog[1].date).isEqualTo("Fri Jan 06 2017, 14:30")
         assertThat(result.changelog[1].version).isEqualTo("20170106-143015-1234abcd")
-        expectedEntries = listOf(ChangelogItemViewModel("internal", "something internal in 2017"))
+        expectedEntries = listOf(ChangelogItemViewModel("internal", "something internal in 2017", "internal"))
         assertThat(result.changelog[1].entries).hasSameElementsAs(expectedEntries)
 
         assertThat(result.changelog[2].date).isEqualTo("Sun Jan 03 2016, 14:30")
         assertThat(result.changelog[2].version).isEqualTo("20160103-143015-1234abcd")
-        expectedEntries = listOf(ChangelogItemViewModel("internal", "something internal"),
-                ChangelogItemViewModel("public", "something public"))
+        expectedEntries = listOf(ChangelogItemViewModel("internal", "something internal", "internal"),
+                ChangelogItemViewModel("public", "something public", "public"))
         assertThat(result.changelog[2].entries).hasSameElementsAs(expectedEntries)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -324,8 +324,8 @@ class VersionPageTests : TeamcityTests()
     @Test
     fun `renders changelog rows`()
     {
-        val entries =  listOf(ChangelogItemViewModel("public", "something public"),
-                ChangelogItemViewModel("internal", "something internal"))
+        val entries =  listOf(ChangelogItemViewModel("custom-public-label", "something public", "public"),
+                ChangelogItemViewModel("custom-internal-label", "something internal", "internal"))
 
         val changelog = listOf(ChangelogViewModel("14 Jun 2018", "v1", entries))
 

--- a/src/app/templates/partials/changelog.ftl
+++ b/src/app/templates/partials/changelog.ftl
@@ -15,8 +15,8 @@
         </td>
         <td>
             <#list item.entries as entry>
-                <div class="badge changelog-label badge-${entry.label}">${entry.label}</div>
-                <div class="changelog-item ${entry.label}">
+                <div class="badge changelog-label badge-${entry.cssClass}">${entry.label}</div>
+                <div class="changelog-item ${entry.cssClass}">
                     ${entry.value}
                 </div>
             </#list>


### PR DESCRIPTION
Bug - see screenshot in ticket https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-1478

This is because the css style rules are for classes `public` and `internal` but the labels in the Montagu instance are "external" and "internal". In fact these labels are totally customizable, so we shouldn't be relying on them anyway, rather we can construct the css class from the "changelog_label.public" field in the db,