### PR TITLE
mrc-1476 refactor report related models

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Helpers.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Helpers.kt
@@ -10,6 +10,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.net.URLDecoder
 import java.net.URLEncoder
+import java.time.LocalDateTime
 import javax.servlet.http.HttpServletResponse
 
 // The idea is that as this file grows, I'll group helpers and split them off into files/classes with more
@@ -134,4 +135,13 @@ fun Controller.downloadFile(files: FileSystem,
     files.writeFileToOutputStream(absoluteFilePath, response.outputStream)
 
     return true
+}
+
+fun getDateStringFromVersionId(id: String): LocalDateTime
+{
+    val regex = Regex("(\\d{4})(\\d{2})(\\d{2})-(\\d{2})(\\d{2})(\\d{2})-([0-9a-f]{8})")
+    val match = regex.matchEntire(id)
+            ?.groupValues ?: throw Exception("Badly formatted report id $id")
+
+    return LocalDateTime.parse("${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}")
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Serializer.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Serializer.kt
@@ -1,16 +1,12 @@
 package org.vaccineimpact.orderlyweb
 
-import com.github.salomonbrys.kotson.addProperty
 import com.github.salomonbrys.kotson.jsonSerializer
 import com.github.salomonbrys.kotson.registerTypeAdapter
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import org.vaccineimpact.orderlyweb.models.Result
 import org.vaccineimpact.orderlyweb.models.ResultStatus
-import org.vaccineimpact.orderlyweb.viewmodels.ReportRowViewModel
-import kotlin.reflect.full.memberProperties
 
 open class Serializer
 {
@@ -39,7 +35,7 @@ open class Serializer
 
     open fun toResult(data: Any?): String = toJson(Result(ResultStatus.SUCCESS, data, emptyList()))
 
-    open fun toJson(result: org.vaccineimpact.orderlyweb.models.Result): String = gson.toJson(result)
+    open fun toJson(result: Result): String = gson.toJson(result)
 
     fun convertFieldName(name: String): String
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ArtefactController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ArtefactController.kt
@@ -1,7 +1,5 @@
 package org.vaccineimpact.orderlyweb.controllers.api
 
-import org.vaccineimpact.orderlyweb.models.Scope
-import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.controllers.Controller
 import org.vaccineimpact.orderlyweb.db.AppConfig
@@ -11,7 +9,6 @@ import org.vaccineimpact.orderlyweb.db.OrderlyClient
 import org.vaccineimpact.orderlyweb.db.repositories.ArtefactRepository
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyArtefactRepository
 import org.vaccineimpact.orderlyweb.errors.OrderlyFileNotFoundError
-import java.io.File
 
 class ArtefactController(context: ActionContext,
                          private val orderly: OrderlyClient,
@@ -32,7 +29,7 @@ class ArtefactController(context: ActionContext,
     {
         val name = context.params(":name")
         val version = context.params(":version")
-        orderly.checkVersionExistsForReport(name, version)
+        orderly.getReportVersion(name, version)
         return artefactRepository.getArtefactHashes(name, version)
     }
 
@@ -43,7 +40,7 @@ class ArtefactController(context: ActionContext,
         val artefactname = parseRouteParamToFilepath(context.params(":artefact"))
         val inline = context.queryParams("inline")?.toBoolean() ?: false
 
-        orderly.checkVersionExistsForReport(name, version)
+        orderly.getReportVersion(name, version)
         artefactRepository.getArtefactHash(name, version, artefactname)
 
         val filename = "$name/$version/$artefactname"

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/VersionController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/VersionController.kt
@@ -49,7 +49,7 @@ class VersionController(context: ActionContext,
     {
         val name = context.params(":name")
         val version = context.params(":version")
-        orderly.checkVersionExistsForReport(name, version)
+        orderly.getReportVersion(name, version)
         val absoluteFilePath = "${this.config["orderly.root"]}archive/$name/$version/orderly_run.rds"
         return downloadFile(files, absoluteFilePath, "\"$name/$version/orderly_run.rds\"", ContentTypes.binarydata)
     }
@@ -60,7 +60,7 @@ class VersionController(context: ActionContext,
         val version = context.params(":version")
 
         // check that the requested version exists for the given report
-        orderly.checkVersionExistsForReport(name, version)
+        orderly.getReportVersion(name, version)
 
         val response = context.getSparkResponse().raw()
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -32,7 +32,7 @@ class ReportController(context: ActionContext,
     {
         val reportName = context.params(":name")
         val versionId = context.params(":version")
-        orderly.checkVersionExistsForReport(reportName, versionId)
+        orderly.getReportVersion(reportName, versionId)
         val reportTags = context.postData<List<String>>("report_tags")
         val versionTags = context.postData<List<String>>("version_tags")
         tagRepository.updateTags(reportName, versionId, ReportVersionTags(versionTags, reportTags, listOf()))

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
@@ -10,13 +10,10 @@ interface OrderlyClient
 
     fun getAllReportVersions(): List<ReportVersion>
 
-    fun getGlobalPinnedReports(): List<ReportVersion>
+    fun getGlobalPinnedReports(): List<Report>
 
     @Throws(UnknownObjectError::class)
     fun getReportsByName(name: String): List<String>
-
-    @Throws(UnknownObjectError::class)
-    fun checkVersionExistsForReport(name: String, version: String)
 
     @Throws(UnknownObjectError::class)
     fun getDetailsByNameAndVersion(name: String, version: String): ReportVersionDetails
@@ -45,4 +42,5 @@ interface OrderlyClient
 
     fun getReportVersionTags(name: String, version: String): ReportVersionTags
 
+    fun getReportVersion(name: String, version: String): BasicReportVersion
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/OrderlyClient.kt
@@ -42,5 +42,6 @@ interface OrderlyClient
 
     fun getReportVersionTags(name: String, version: String): ReportVersionTags
 
+    @Throws(UnknownObjectError::class)
     fun getReportVersion(name: String, version: String): BasicReportVersion
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
@@ -9,14 +9,29 @@ constructor(val name: String,
             val displayName: String?,
             val latestVersion: String)
 
-data class ReportVersion
-@ConstructorProperties("name", "displayname", "id", "latestVersion", "published", "date", "customFields")
-constructor(val name: String,
-            val displayName: String?,
-            val id: String,
-            val latestVersion: String,
-            val published: Boolean,
-            val date: Instant,
-            val customFields: Map<String, String?>,
-            val parameterValues: Map<String, String>,
-            val tags: List<String>)
+interface Version
+{
+    val name: String
+    val displayName: String?
+    val id: String
+    val published: Boolean
+    val date: Instant
+    val latestVersion: String
+    val description: String?
+}
+
+data class BasicReportVersion
+@ConstructorProperties("name", "displayname", "id", "published", "date", "latestVersion", "description")
+constructor(override val name: String,
+            override val displayName: String?,
+            override val id: String,
+            override val published: Boolean,
+            override val date: Instant,
+            override val latestVersion: String,
+            override val description: String?) : Version
+
+data class ReportVersion(
+        val basicReportVersion: BasicReportVersion,
+        val customFields: Map<String, String?>,
+        val parameterValues: Map<String, String>,
+        val tags: List<String>) : Version by basicReportVersion

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
@@ -30,8 +30,17 @@ constructor(override val name: String,
             override val latestVersion: String,
             override val description: String?) : Version
 
-data class ReportVersion(
-        val basicReportVersion: BasicReportVersion,
+data class ReportVersion(@Transient val basicReportVersion: BasicReportVersion,
         val customFields: Map<String, String?>,
         val parameterValues: Map<String, String>,
         val tags: List<String>) : Version by basicReportVersion
+{
+    // we have to declare these overrides so that this gets serialised as a flat object
+    override val date: Instant = basicReportVersion.date
+    override val description: String? = basicReportVersion.description
+    override val displayName: String? = basicReportVersion.displayName
+    override val id: String = basicReportVersion.id
+    override val name: String = basicReportVersion.name
+    override val latestVersion: String = basicReportVersion.latestVersion
+    override val published: Boolean = basicReportVersion.published
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
@@ -9,38 +9,26 @@ constructor(val name: String,
             val displayName: String?,
             val latestVersion: String)
 
-interface Version
-{
-    val name: String
-    val displayName: String?
-    val id: String
-    val published: Boolean
-    val date: Instant
-    val latestVersion: String
-    val description: String?
-}
-
 data class BasicReportVersion
 @ConstructorProperties("name", "displayname", "id", "published", "date", "latestVersion", "description")
-constructor(override val name: String,
-            override val displayName: String?,
-            override val id: String,
-            override val published: Boolean,
-            override val date: Instant,
-            override val latestVersion: String,
-            override val description: String?) : Version
+constructor(val name: String,
+            val displayName: String?,
+            val id: String,
+            val published: Boolean,
+            val date: Instant,
+            val latestVersion: String,
+            val description: String?)
 
 data class ReportVersion(@Transient val basicReportVersion: BasicReportVersion,
         val customFields: Map<String, String?>,
         val parameterValues: Map<String, String>,
-        val tags: List<String>) : Version by basicReportVersion
+        val tags: List<String>)
 {
-    // we have to declare these overrides so that this gets serialised as a flat object
-    override val date: Instant = basicReportVersion.date
-    override val description: String? = basicReportVersion.description
-    override val displayName: String? = basicReportVersion.displayName
-    override val id: String = basicReportVersion.id
-    override val name: String = basicReportVersion.name
-    override val latestVersion: String = basicReportVersion.latestVersion
-    override val published: Boolean = basicReportVersion.published
+    val date: Instant = basicReportVersion.date
+    val description: String? = basicReportVersion.description
+    val displayName: String? = basicReportVersion.displayName
+    val id: String = basicReportVersion.id
+    val name: String = basicReportVersion.name
+    val published: Boolean = basicReportVersion.published
+    val latestVersion: String = basicReportVersion.latestVersion
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
@@ -9,26 +9,3 @@ constructor(val name: String,
             val displayName: String?,
             val latestVersion: String)
 
-data class BasicReportVersion
-@ConstructorProperties("name", "displayname", "id", "published", "date", "latestVersion", "description")
-constructor(val name: String,
-            val displayName: String?,
-            val id: String,
-            val published: Boolean,
-            val date: Instant,
-            val latestVersion: String,
-            val description: String?)
-
-data class ReportVersion(@Transient val basicReportVersion: BasicReportVersion,
-        val customFields: Map<String, String?>,
-        val parameterValues: Map<String, String>,
-        val tags: List<String>)
-{
-    val date: Instant = basicReportVersion.date
-    val description: String? = basicReportVersion.description
-    val displayName: String? = basicReportVersion.displayName
-    val id: String = basicReportVersion.id
-    val name: String = basicReportVersion.name
-    val published: Boolean = basicReportVersion.published
-    val latestVersion: String = basicReportVersion.latestVersion
-}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersion.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersion.kt
@@ -1,0 +1,28 @@
+package org.vaccineimpact.orderlyweb.models
+
+import java.beans.ConstructorProperties
+import java.time.Instant
+
+data class BasicReportVersion
+@ConstructorProperties("name", "displayname", "id", "published", "date", "latestVersion", "description")
+constructor(val name: String,
+            val displayName: String?,
+            val id: String,
+            val published: Boolean,
+            val date: Instant,
+            val latestVersion: String,
+            val description: String?)
+
+data class ReportVersion(@Transient val basicReportVersion: BasicReportVersion,
+                         val customFields: Map<String, String?>,
+                         val parameterValues: Map<String, String>,
+                         val tags: List<String>)
+{
+    val date: Instant = basicReportVersion.date
+    val description: String? = basicReportVersion.description
+    val displayName: String? = basicReportVersion.displayName
+    val id: String = basicReportVersion.id
+    val name: String = basicReportVersion.name
+    val published: Boolean = basicReportVersion.published
+    val latestVersion: String = basicReportVersion.latestVersion
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
@@ -1,16 +1,9 @@
 package org.vaccineimpact.orderlyweb.models
 
-import java.time.Instant
-
-data class ReportVersionDetails(val name: String,
-                                val displayName: String?,
-                                val id: String,
-                                val published: Boolean,
-                                val date: Instant,
-                                val description: String?,
+data class ReportVersionDetails(val basicReportVersion: BasicReportVersion,
                                 val artefacts: List<Artefact>,
                                 val resources: List<FileInfo>,
                                 val dataInfo: List<DataInfo>,
-                                val parameterValues: Map<String, String>)
+                                val parameterValues: Map<String, String>): Version by basicReportVersion
 
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
@@ -6,14 +6,12 @@ data class ReportVersionDetails(@Transient val basicReportVersion: BasicReportVe
                                 val artefacts: List<Artefact>,
                                 val resources: List<FileInfo>,
                                 val dataInfo: List<DataInfo>,
-                                val parameterValues: Map<String, String>) : Version by basicReportVersion
+                                val parameterValues: Map<String, String>)
 {
-    // we have to declare these overrides so that this gets serialised as a flat object
-    override val date: Instant = basicReportVersion.date
-    override val description: String? = basicReportVersion.description
-    override val displayName: String? = basicReportVersion.displayName
-    override val id: String = basicReportVersion.id
-    override val name: String = basicReportVersion.name
-    override val latestVersion: String = basicReportVersion.latestVersion
-    override val published: Boolean = basicReportVersion.published
+    val date: Instant = basicReportVersion.date
+    val description: String? = basicReportVersion.description
+    val displayName: String? = basicReportVersion.displayName
+    val id: String = basicReportVersion.id
+    val name: String = basicReportVersion.name
+    val published: Boolean = basicReportVersion.published
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionDetails.kt
@@ -1,9 +1,19 @@
 package org.vaccineimpact.orderlyweb.models
 
-data class ReportVersionDetails(val basicReportVersion: BasicReportVersion,
+import java.time.Instant
+
+data class ReportVersionDetails(@Transient val basicReportVersion: BasicReportVersion,
                                 val artefacts: List<Artefact>,
                                 val resources: List<FileInfo>,
                                 val dataInfo: List<DataInfo>,
-                                val parameterValues: Map<String, String>): Version by basicReportVersion
-
-
+                                val parameterValues: Map<String, String>) : Version by basicReportVersion
+{
+    // we have to declare these overrides so that this gets serialised as a flat object
+    override val date: Instant = basicReportVersion.date
+    override val description: String? = basicReportVersion.description
+    override val displayName: String? = basicReportVersion.displayName
+    override val id: String = basicReportVersion.id
+    override val name: String = basicReportVersion.name
+    override val latestVersion: String = basicReportVersion.latestVersion
+    override val published: Boolean = basicReportVersion.published
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/IndexViewModel.kt
@@ -3,6 +3,8 @@ package org.vaccineimpact.orderlyweb.viewmodels
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.web.Serialise
 import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.getDateStringFromVersionId
+import org.vaccineimpact.orderlyweb.models.Report
 import org.vaccineimpact.orderlyweb.models.ReportVersion
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
@@ -34,7 +36,7 @@ data class IndexViewModel(@Serialise("reportsJson") val reports: List<ReportRowV
         fun build(reports: List<ReportVersion>,
                   reportTags: Map<String, List<String>>,
                   allTags: List<String>,
-                  pinnedReports: List<ReportVersion>,
+                  pinnedReports: List<Report>,
                   context: ActionContext): IndexViewModel
         {
             val emptyCustomFields: Map<String, String?> = if (reports.count() > 0)
@@ -76,6 +78,11 @@ private object IndexViewDateFormatter
     fun format(date: Instant): String
     {
         return formatter.format(LocalDateTime.ofInstant(date, ZoneId.of("UTC")))
+    }
+
+    fun format(id: String): String
+    {
+        return formatter.format(getDateStringFromVersionId(id))
     }
 }
 
@@ -144,15 +151,15 @@ data class PinnedReportViewModel(val name: String,
 {
     companion object
     {
-        fun buildList(versions: List<ReportVersion>): List<PinnedReportViewModel>
+        fun buildList(versions: List<Report>): List<PinnedReportViewModel>
         {
             return versions.map {
 
-                val reportFileViewModelBuilder = ReportFileViewModelBuilder(it.name, it.id)
+                val reportFileViewModelBuilder = ReportFileViewModelBuilder(it.name, it.latestVersion)
                 PinnedReportViewModel(it.name,
-                        it.id,
+                        it.latestVersion,
                         it.displayName ?: it.name,
-                        IndexViewDateFormatter.format(it.date),
+                        IndexViewDateFormatter.format(it.latestVersion),
                         reportFileViewModelBuilder.buildZipFileViewModel())
             }
         }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -1,18 +1,15 @@
 package org.vaccineimpact.orderlyweb.viewmodels
 
-import org.vaccineimpact.orderlyweb.ActionContext
-import org.vaccineimpact.orderlyweb.byteCountToDisplaySize
-import org.vaccineimpact.orderlyweb.canRenderInBrowser
+import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.controllers.web.Serialise
 import org.vaccineimpact.orderlyweb.db.AppConfig
-import org.vaccineimpact.orderlyweb.isImage
 import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
-import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+private val formatter = DateTimeFormatter.ofPattern("EEE MMM dd yyyy, HH:mm")
 
-data class ReportVersionPageViewModel(@Serialise("reportJson") val report: ReportVersionDetails,
+data class ReportVersionPageViewModel(@Serialise("reportJson") val report: BasicReportVersion,
                                       val focalArtefactUrl: String?,
                                       val isRunner: Boolean,
                                       val artefacts: List<ArtefactViewModel>,
@@ -75,7 +72,8 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                 null
             }
 
-            return ReportVersionPageViewModel(report.copy(displayName = displayName),
+            return ReportVersionPageViewModel(
+                    report.basicReportVersion.copy(displayName = displayName),
                     focalArtefactUrl,
                     isRunner,
                     artefactViewModels,
@@ -151,21 +149,9 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
         private fun buildVersionPickerViewModel(reportName: String, currentVersion: String, id: String): VersionPickerViewModel
         {
             val date = getDateStringFromVersionId(id)
-            return VersionPickerViewModel("${AppConfig()["app.url"]}/report/$reportName/$id", date,
+            return VersionPickerViewModel("${AppConfig()["app.url"]}/report/$reportName/$id", formatter.format(date),
                     selected = id == currentVersion)
         }
-
-        fun getDateStringFromVersionId(id: String): String
-        {
-            val formatter = DateTimeFormatter.ofPattern("EEE MMM dd yyyy, HH:mm")
-            val regex = Regex("(\\d{4})(\\d{2})(\\d{2})-(\\d{2})(\\d{2})(\\d{2})-([0-9a-f]{8})")
-            val match = regex.matchEntire(id)
-                    ?.groupValues ?: throw Exception("Badly formatted report id $id")
-
-            val date = LocalDateTime.parse("${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}")
-            return formatter.format(date)
-        }
-
     }
 }
 
@@ -198,7 +184,7 @@ data class ChangelogViewModel(val date: String, val version: String, val entries
     {
         fun build(id: String, changelog: List<Changelog>): ChangelogViewModel
         {
-            val date = ReportVersionPageViewModel.getDateStringFromVersionId(id)
+            val date = getDateStringFromVersionId(id)
 
             val entries = changelog.map {
                 val cssClass = if (it.public)
@@ -211,7 +197,7 @@ data class ChangelogViewModel(val date: String, val version: String, val entries
                 }
                 ChangelogItemViewModel(it.label, it.value, cssClass)
             }
-            return ChangelogViewModel(date, id, entries)
+            return ChangelogViewModel(formatter.format(date), id, entries)
         }
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
@@ -270,9 +270,9 @@ class VersionTests : CleanDatabaseTests()
 
         assertThat(results.count()).isEqualTo(2)
         assertThat(results[0].name).isEqualTo("test3")
-        assertThat(results[0].id).isEqualTo("test3_1_pub")
+        assertThat(results[0].latestVersion).isEqualTo("test3_1_pub")
         assertThat(results[1].name).isEqualTo("test1")
-        assertThat(results[1].id).isEqualTo("test1_2_pub")
+        assertThat(results[1].latestVersion).isEqualTo("test1_2_pub")
     }
 
     @Test
@@ -298,10 +298,10 @@ class VersionTests : CleanDatabaseTests()
 
         assertThat(results.count()).isEqualTo(3)
         assertThat(results[0].name).isEqualTo("test4")
-        assertThat(results[0].id).isEqualTo("test4_1_unpub")
+        assertThat(results[0].latestVersion).isEqualTo("test4_1_unpub")
         assertThat(results[1].name).isEqualTo("test3")
-        assertThat(results[1].id).isEqualTo("test3_1_pub")
+        assertThat(results[1].latestVersion).isEqualTo("test3_1_pub")
         assertThat(results[2].name).isEqualTo("test1")
-        assertThat(results[2].id).isEqualTo("test1_3_unpub")
+        assertThat(results[2].latestVersion).isEqualTo("test1_3_unpub")
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
@@ -250,15 +250,15 @@ class VersionTests : CleanDatabaseTests()
     @Test
     fun `reader can get latest published versions of pinned reports`()
     {
-        insertReport("test1", "test1_1_pub")
-        insertReport("test1", "test1_2_pub")
-        insertReport("test1", "test1_3_unpub", published = false)
+        insertReport("test1", "20170103-143015-1234pub")
+        insertReport("test1", "20180103-143015-1234pub")
+        insertReport("test1", "20190103-143015-1234unpub", published = false)
 
-        insertReport("test2", "test2_1_pub")
+        insertReport("test2", "20160203-143015-1234pub")
 
-        insertReport("test3", "test3_1_pub")
+        insertReport("test3", "20170203-143015-1234pub")
 
-        insertReport("test4", "test4_1_unpub", published = false)
+        insertReport("test4", "20180203-143015-1234unpub", published = false)
 
         insertGlobalPinnedReport("test4", 0)
         insertGlobalPinnedReport("test3", 1)
@@ -270,23 +270,23 @@ class VersionTests : CleanDatabaseTests()
 
         assertThat(results.count()).isEqualTo(2)
         assertThat(results[0].name).isEqualTo("test3")
-        assertThat(results[0].latestVersion).isEqualTo("test3_1_pub")
+        assertThat(results[0].latestVersion).isEqualTo("20170203-143015-1234pub")
         assertThat(results[1].name).isEqualTo("test1")
-        assertThat(results[1].latestVersion).isEqualTo("test1_2_pub")
+        assertThat(results[1].latestVersion).isEqualTo("20180103-143015-1234pub")
     }
 
     @Test
     fun `reviewer can get latest published and unpublished versions of pinned reports`()
     {
-        insertReport("test1", "test1_1_pub")
-        insertReport("test1", "test1_2_pub")
-        insertReport("test1", "test1_3_unpub", published = false)
+        insertReport("test1", "20170103-143015-1234pub")
+        insertReport("test1", "20180103-143015-1234pub")
+        insertReport("test1", "20190103-143015-1234unpub", published = false)
 
-        insertReport("test2", "test2_1_pub")
+        insertReport("test2", "20160203-143015-1234pub")
 
-        insertReport("test3", "test3_1_pub")
+        insertReport("test3", "20170203-143015-1234pub")
 
-        insertReport("test4", "test4_1_unpub", published = false)
+        insertReport("test4", "20180203-143015-1234unpub", published = false)
 
         insertGlobalPinnedReport("test4", 0)
         insertGlobalPinnedReport("test3", 1)
@@ -298,10 +298,10 @@ class VersionTests : CleanDatabaseTests()
 
         assertThat(results.count()).isEqualTo(3)
         assertThat(results[0].name).isEqualTo("test4")
-        assertThat(results[0].latestVersion).isEqualTo("test4_1_unpub")
+        assertThat(results[0].latestVersion).isEqualTo("20180203-143015-1234unpub")
         assertThat(results[1].name).isEqualTo("test3")
-        assertThat(results[1].latestVersion).isEqualTo("test3_1_pub")
+        assertThat(results[1].latestVersion).isEqualTo("20170203-143015-1234pub")
         assertThat(results[2].name).isEqualTo("test1")
-        assertThat(results[2].latestVersion).isEqualTo("test1_3_unpub")
+        assertThat(results[2].latestVersion).isEqualTo("20190103-143015-1234unpub")
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
@@ -29,12 +29,13 @@ class TemplateObjectWrapperTests : TeamcityTests()
     {
         val now = Instant.now()
         val artFiles = listOf(FileInfo("graph.png", 1234))
-        val report = ReportVersionDetails("r1",
+        val report = ReportVersionDetails(BasicReportVersion("r1",
                 "first report",
                 "v1",
                 true,
                 now,
-                "a fake report",
+                "v1",
+                "a fake report"),
                 listOf(Artefact(ArtefactFormat.DATA, "a graph", artFiles)),
                 listOf(),
                 listOf(DataInfo("hash", 1234, 2345)),
@@ -63,8 +64,6 @@ class TemplateObjectWrapperTests : TeamcityTests()
         val dataModel = data[0] as StringModel
         assertThat(dataModel["name"].toString()).isEqualTo("hash")
         assertThat(dataModel["csvSize"].toString()).isEqualTo("1234")
-
-        val tags = result["tags"]
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ArtefactControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ArtefactControllerTests.kt
@@ -60,7 +60,7 @@ class ArtefactControllerTests : ControllerTest()
         val orderly = mock<OrderlyClient>()
         val sut = ArtefactController(actionContext, orderly, repo, mock<FileSystem>(), mockConfig)
         sut.getMetaData()
-        verify(orderly).checkVersionExistsForReport(name, version)
+        verify(orderly).getReportVersion(name, version)
     }
 
     @Test
@@ -105,7 +105,7 @@ class ArtefactControllerTests : ControllerTest()
             on { this.params(":artefact") } doReturn artefact
         }
         val orderly = mock<OrderlyClient> {
-            on {this.checkVersionExistsForReport(name, version)} doThrow UnknownObjectError("report", "")
+            on {this.getReportVersion(name, version)} doThrow UnknownObjectError("report", "")
         }
 
         val sut = ArtefactController(actionContext, orderly, repo, mock<FileSystem>(), mockConfig)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
@@ -15,6 +15,7 @@ import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.db.OrderlyClient
 import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
+import org.vaccineimpact.orderlyweb.models.BasicReportVersion
 import org.vaccineimpact.orderlyweb.models.Changelog
 import org.vaccineimpact.orderlyweb.models.Report
 import org.vaccineimpact.orderlyweb.models.ReportVersion
@@ -35,9 +36,9 @@ class ReportControllerTests : ControllerTest()
 
 
     private val reportVersions = listOf(
-            ReportVersion(reportName, "display1", "v1", "v1", true, Instant.now(),
+            ReportVersion(BasicReportVersion(reportName, "display1", "v1", true, Instant.now(), "v1", "desc"),
                     mapOf("author" to "auth", "requester" to "req"), mapOf("p1" to "v1"), listOf("t1", "t2")),
-            ReportVersion("r2", "display2", "v2", "v2", true, Instant.now(),
+            ReportVersion(BasicReportVersion("r2", "display2", "v2", true, Instant.now(), "v1", "v2"),
                     mapOf("author" to "auth", "requester" to "req"), mapOf("p1" to "v1", "p2" to "v2"), listOf("t1"))
     )
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
@@ -14,10 +14,7 @@ import org.vaccineimpact.orderlyweb.db.OrderlyClient
 import org.vaccineimpact.orderlyweb.db.repositories.ArtefactRepository
 import org.vaccineimpact.orderlyweb.errors.OrderlyFileNotFoundError
 import org.vaccineimpact.orderlyweb.errors.UnknownObjectError
-import org.vaccineimpact.orderlyweb.models.Changelog
-import org.vaccineimpact.orderlyweb.models.ReportVersionDetails
-import org.vaccineimpact.orderlyweb.models.ReportVersionTags
-import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import java.io.File
@@ -85,7 +82,7 @@ class VersionControllerTests : ControllerTest()
         val version = "testversion"
 
         val mockOrderlyClient = mock<OrderlyClient>() {
-            on { checkVersionExistsForReport(name, version) } doThrow UnknownObjectError(version, "version")
+            on { getReportVersion(name, version) } doThrow UnknownObjectError(version, "version")
         }
 
         val actionContext = mock<ActionContext> {
@@ -107,8 +104,8 @@ class VersionControllerTests : ControllerTest()
         val reportName = "reportName"
         val reportVersion = "reportVersion"
 
-        val report = ReportVersionDetails(displayName = "displayName", id = "id", date = Instant.now(),
-                name = "name", published = true, description = "description",
+        val report = ReportVersionDetails(BasicReportVersion(displayName = "displayName", id = "id", date = Instant.now(),
+                name = "name", published = true, description = "description", latestVersion = "v1"),
                 artefacts = listOf(),
                 resources = listOf(), dataInfo = listOf(), parameterValues = mapOf())
 
@@ -209,7 +206,7 @@ class VersionControllerTests : ControllerTest()
 
         val mockZipClient = mock<ZipClient>()
         val mockOrderlyClient = mock<OrderlyClient> {
-            on { checkVersionExistsForReport(reportName, reportVersion) } doThrow
+            on { getReportVersion(reportName, reportVersion) } doThrow
                     UnknownObjectError(reportVersion, "report")
         }
         val sut = VersionController(actionContext, mockOrderlyClient, mock(), mockZipClient,

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/IndexControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/IndexControllerTests.kt
@@ -122,8 +122,8 @@ class IndexControllerTests : TeamcityTests()
     @Test
     fun `builds pinned versions`()
     {
-        val r1v1 = Report("r1", "r1", "20190706-143015-1234abcd")
-        val r1v2 = Report("r2", "r2 display name", "20190806-143015-1234abcd")
+        val r1v1 = Report("r1", "r1", "20190607-143015-1234abcd")
+        val r1v2 = Report("r2", "r2 display name", "20190608-143015-1234abcd")
 
         val fakeReports = listOf(r1v1, r1v2)
 
@@ -135,10 +135,23 @@ class IndexControllerTests : TeamcityTests()
         val result = sut.index().pinnedReports
 
         val expected = listOf(
-                PinnedReportViewModel("r1", "v1", "r1", "Fri Jun 07 2019",
-                        DownloadableFileViewModel("r1-v1.zip", "http://localhost:8888/report/r1/version/v1/all/", null)),
-                PinnedReportViewModel("r2", "v2", "r2 display name", "Sat Jun 08 2019",
-                        DownloadableFileViewModel("r2-v2.zip", "http://localhost:8888/report/r2/version/v2/all/", null))
+                PinnedReportViewModel(
+                        "r1",
+                        "20190607-143015-1234abcd",
+                        "r1", "Fri Jun 07 2019",
+                        DownloadableFileViewModel(
+                                "r1-20190607-143015-1234abcd.zip",
+                                "http://localhost:8888/report/r1/version/20190607-143015-1234abcd/all/",
+                                null)),
+                PinnedReportViewModel(
+                        "r2",
+                        "20190608-143015-1234abcd",
+                        "r2 display name",
+                        "Sat Jun 08 2019",
+                        DownloadableFileViewModel(
+                                "r2-20190608-143015-1234abcd.zip",
+                                "http://localhost:8888/report/r2/version/20190608-143015-1234abcd/all/",
+                                null))
         )
 
         assertThat(result.count()).isEqualTo(2)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/IndexControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/IndexControllerTests.kt
@@ -8,6 +8,8 @@ import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.web.IndexController
 import org.vaccineimpact.orderlyweb.db.OrderlyClient
 import org.vaccineimpact.orderlyweb.db.repositories.TagRepository
+import org.vaccineimpact.orderlyweb.models.BasicReportVersion
+import org.vaccineimpact.orderlyweb.models.Report
 import org.vaccineimpact.orderlyweb.models.ReportVersion
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
@@ -32,15 +34,15 @@ class IndexControllerTests : TeamcityTests()
     {
         val someDate = Instant.parse("2019-05-23T12:31:00.613Z")
 
-        val r1v1 = ReportVersion("r1", null, "v1", "v2", true, someDate,
+        val r1v1 = ReportVersion(BasicReportVersion("r1", null, "v1", true, someDate, "v2", "desc"),
                 mapOf("author" to "author1", "requester" to "requester1"), mapOf("p1" to "v1", "p2" to "v2"), listOf("t1", "t2"))
-        val r1v2 = r1v1.copy(
-                id = "v2",
+        val r1v2Basic = r1v1.basicReportVersion.copy(id = "v2",
                 displayName = "r1 display name",
                 published = false,
                 date = someDate.plus(Duration.ofDays(1)))
+        val r1v2 = r1v1.copy(basicReportVersion = r1v2Basic)
 
-        val r2v1 = ReportVersion("r2", null, "r2v1", "r2v1", true, someDate.minus(Duration.ofDays(2)),
+        val r2v1 = ReportVersion(BasicReportVersion("r2", null, "r2v1", true, someDate.minus(Duration.ofDays(2)), "r2v1", "desc"),
                 mapOf("author" to "another author", "requester" to "another requester"), mapOf(), listOf())
 
         val fakeReports = listOf(r1v1, r1v2, r2v1)
@@ -120,15 +122,8 @@ class IndexControllerTests : TeamcityTests()
     @Test
     fun `builds pinned versions`()
     {
-        val someDate = Instant.parse("2019-06-07T12:31:00.613Z")
-
-        val r1v1 = ReportVersion("r1", null, "v1", "v2", true, someDate,
-                mapOf("author" to "author1", "requester" to "requester1"), mapOf("p" to "v"), listOf())
-        val r1v2 = r1v1.copy(
-                name = "r2",
-                id = "v2",
-                displayName = "r2 display name",
-                date = someDate.plus(Duration.ofDays(1)))
+        val r1v1 = Report("r1", "r1", "20190706-143015-1234abcd")
+        val r1v2 = Report("r2", "r2 display name", "20190806-143015-1234abcd")
 
         val fakeReports = listOf(r1v1, r1v2)
 
@@ -160,7 +155,7 @@ class IndexControllerTests : TeamcityTests()
         }
 
         val mockOrderly = mock<OrderlyClient> {
-            on { this.getGlobalPinnedReports() } doReturn listOf<ReportVersion>()
+            on { this.getGlobalPinnedReports() } doReturn listOf<Report>()
         }
 
         val mockRepo = mock<TagRepository> {
@@ -180,7 +175,7 @@ class IndexControllerTests : TeamcityTests()
         }
 
         val mockOrderly = mock<OrderlyClient> {
-            on { this.getGlobalPinnedReports() } doReturn listOf<ReportVersion>()
+            on { this.getGlobalPinnedReports() } doReturn listOf<Report>()
         }
 
         val noPermsContext = mock<ActionContext> {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
@@ -17,12 +17,13 @@ import java.time.Instant
 class GetByNameAndVersionTests : TeamcityTests()
 {
     private val versionId = "20170103-143015-1234abcd"
-    private val mockReportDetails = ReportVersionDetails("r1",
+    private val mockReportDetails = ReportVersionDetails(BasicReportVersion("r1",
             "a fake report",
             versionId,
             true,
             Instant.now(),
-            "a fake report",
+            "latest v",
+            "a fake report"),
             listOf(),
             listOf(),
             listOf(),
@@ -58,9 +59,10 @@ class GetByNameAndVersionTests : TeamcityTests()
     @Test
     fun `getByNameAndVersion uses name for display name if not present`()
     {
+        val noDisplayName = mockReportDetails.basicReportVersion.copy(displayName = null)
         val orderly = mock<OrderlyClient> {
             on { this.getDetailsByNameAndVersion("r1", versionId) } doReturn
-                    mockReportDetails.copy(displayName = null)
+                    mockReportDetails.copy(basicReportVersion = noDisplayName)
         }
 
         val sut = ReportController(mockActionContext, orderly, mock())

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
@@ -53,7 +53,7 @@ class GetByNameAndVersionTests : TeamcityTests()
         val sut = ReportController(mockActionContext, mockOrderly, mock())
         val result = sut.getByNameAndVersion()
 
-        assertThat(result.report).isEqualTo(mockReportDetails)
+        assertThat(result.report.displayName).isEqualTo( "a fake report")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/TagTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/TagTests.kt
@@ -32,6 +32,6 @@ class TagTests : TeamcityTests()
         val result = sut.tagVersion()
         assertThat(result).isEqualTo("OK")
         verify(mockTagRepo).updateTags(eq("r1"), eq("v1"), eq(ReportVersionTags(listOf("v-tag"), listOf("r-tag"), listOf())))
-        verify(mockOrderly).checkVersionExistsForReport("r1", "v1")
+        verify(mockOrderly).getReportVersion("r1", "v1")
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPageTests.kt
@@ -14,6 +14,7 @@ import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.models.Artefact
 import org.vaccineimpact.orderlyweb.models.ArtefactFormat
+import org.vaccineimpact.orderlyweb.models.BasicReportVersion
 import org.vaccineimpact.orderlyweb.models.ReportVersionDetails
 import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
 import org.vaccineimpact.orderlyweb.tests.unit_tests.templates.rules.FreemarkerTestRule
@@ -32,12 +33,13 @@ class VersionPageTests : TeamcityTests()
         val template = FreemarkerTestRule("report-page.ftl")
     }
 
-    private val testReport = ReportVersionDetails(name = "r1",
+    private val testReport = ReportVersionDetails(BasicReportVersion(name = "r1",
             displayName = "r1 display",
             id = "r1-v1",
             published = true,
             date = Timestamp(System.currentTimeMillis()).toInstant(),
-            description = "description",
+            latestVersion = "v1",
+            description = "description"),
             artefacts = listOf(),
             resources = listOf(),
             dataInfo = listOf(),
@@ -82,7 +84,7 @@ class VersionPageTests : TeamcityTests()
             breadcrumbs = listOf(Breadcrumb("name", "url")))
 
     private val testModel = ReportVersionPageViewModel(
-            testReport,
+            testReport.basicReportVersion,
             "/testFocalArtefactUrl",
             false,
             testArtefactViewModels,


### PR DESCRIPTION
Prior to factoring out a `ReportRepository` and `ReportLogic`, this refactors the `ReportVersion` models - this is so that the repo can return basic objects derived from the `REPORT` and `REPORT_VERSION` tables and then the logic class can compose the complex objects that require also fetching from other tables (`ARTEFACT`, `RESOURCE`, etc.) 