### PR TITLE
mrc-1476 refactor getAllReportVersions

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -21,28 +21,8 @@ class Orderly(val isReviewer: Boolean,
 
     override fun getAllReportVersions(): List<ReportVersion>
     {
-        JooqContext().use {
-            // create a temp table containing the latest version ID for each report name
-            val latestVersionForEachReport = getLatestVersionsForReports(it)
-
-            val versions = it.dsl.withTemporaryTable(latestVersionForEachReport)
-                    .select(REPORT_VERSION.REPORT.`as`("name"),
-                            REPORT_VERSION.DISPLAYNAME,
-                            REPORT_VERSION.ID,
-                            REPORT_VERSION.PUBLISHED,
-                            REPORT_VERSION.DATE,
-                            latestVersionForEachReport.field<String>("latestVersion"),
-                            REPORT_VERSION.DESCRIPTION
-                    )
-                    .from(REPORT_VERSION)
-                    .join(latestVersionForEachReport.tableName)
-                    .on(REPORT_VERSION.REPORT.eq(latestVersionForEachReport.field("report")))
-                    .where(shouldIncludeReportVersion)
-                    .orderBy(REPORT_VERSION.REPORT, REPORT_VERSION.ID)
-                    .fetchInto(BasicReportVersion::class.java)
-
-            return mapToReportVersions(it, versions)
-        }
+        val basicVersions = reportRepository.getAllReportVersions()
+        return mapToReportVersions(basicVersions)
     }
 
     override fun getDetailsByNameAndVersion(name: String, version: String): ReportVersionDetails
@@ -51,7 +31,7 @@ class Orderly(val isReviewer: Boolean,
         JooqContext().use {
 
             val artefacts = artefactRepository.getArtefacts(name, version)
-            val parameterValues = getParametersForVersions(listOf(version))[version]?: mapOf()
+            val parameterValues = getParametersForVersions(listOf(version))[version] ?: mapOf()
 
             return ReportVersionDetails(basicReportVersion,
                     artefacts = artefacts,
@@ -155,28 +135,14 @@ class Orderly(val isReviewer: Boolean,
         JooqContext().use {
             return getDatedChangelogForReport(basicVersion.name, Timestamp.from(basicVersion.date), it)
         }
-
     }
 
-    private fun mapToReportVersions(ctx: JooqContext,
-                                    basicVersions: List<BasicReportVersion>): List<ReportVersion>
+    private fun mapToReportVersions(basicVersions: List<BasicReportVersion>): List<ReportVersion>
     {
-        val allCustomFields = ctx.dsl.select(
-                CUSTOM_FIELDS.ID)
-                .from(CUSTOM_FIELDS)
-                .fetch()
-                .associate { r -> r[CUSTOM_FIELDS.ID] to null as String? }
 
         val versionIds = basicVersions.map { it.id }
-        val customFieldsForVersions = ctx.dsl.select(
-                REPORT_VERSION_CUSTOM_FIELDS.KEY,
-                REPORT_VERSION_CUSTOM_FIELDS.VALUE,
-                REPORT_VERSION_CUSTOM_FIELDS.REPORT_VERSION)
-                .from(REPORT_VERSION_CUSTOM_FIELDS)
-                .where(REPORT_VERSION_CUSTOM_FIELDS.REPORT_VERSION.`in`(versionIds))
-                .fetch()
-                .groupBy { it[REPORT_VERSION_CUSTOM_FIELDS.REPORT_VERSION] }
-
+        val allCustomFields = reportRepository.getAllCustomFields()
+        val customFieldsForVersions = reportRepository.getCustomFieldsForVersions(versionIds)
         val parametersForVersions = getParametersForVersions(versionIds)
 
         val allVersionTags = getVersionTags(versionIds)
@@ -189,11 +155,7 @@ class Orderly(val isReviewer: Boolean,
             val versionCustomFields = mutableMapOf<String, String?>()
 
             versionCustomFields.putAll(allCustomFields)
-            if (customFieldsForVersions.containsKey(versionId))
-            {
-                versionCustomFields.putAll(customFieldsForVersions[versionId]!!
-                        .associate { f -> f[REPORT_VERSION_CUSTOM_FIELDS.KEY] to f[REPORT_VERSION_CUSTOM_FIELDS.VALUE] })
-            }
+            versionCustomFields.putAll(customFieldsForVersions[versionId]?: mapOf())
 
             val versionParameters = parametersForVersions[versionId] ?: mapOf()
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/Orderly.kt
@@ -259,19 +259,6 @@ class Orderly(val isReviewer: Boolean,
         }
     }
 
-    private fun getLatestVersionsForReports(db: JooqContext): TempTable
-    {
-        return db.dsl.select(
-                REPORT_VERSION.REPORT,
-                REPORT_VERSION.ID.`as`("latestVersion"),
-                REPORT_VERSION.DATE.max().`as`("maxDate")
-        )
-                .from(REPORT_VERSION)
-                .where(shouldIncludeReportVersion)
-                .groupBy(REPORT_VERSION.REPORT)
-                .asTemporaryTable(name = "latest_version_for_each_report")
-    }
-
     private fun getDatedChangelogForReport(report: String, latestDate: Timestamp, ctx: JooqContext): List<Changelog>
     {
         return ctx.dsl

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.orderlyweb.db.repositories
 
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.db.*
+import org.vaccineimpact.orderlyweb.db.Tables.*
 import org.vaccineimpact.orderlyweb.errors.UnknownObjectError
 import org.vaccineimpact.orderlyweb.models.BasicReportVersion
 import org.vaccineimpact.orderlyweb.models.Report
@@ -18,6 +19,12 @@ interface ReportRepository
 
     @Throws(UnknownObjectError::class)
     fun getReportVersion(name: String, version: String): BasicReportVersion
+
+    fun getAllReportVersions(): List<BasicReportVersion>
+
+    fun getCustomFieldsForVersions(versionIds: List<String>): Map<String, Map<String, String>>
+
+    fun getAllCustomFields(): Map<String, String?>
 }
 
 class OrderlyReportRepository(val isReviewer: Boolean,
@@ -35,14 +42,14 @@ class OrderlyReportRepository(val isReviewer: Boolean,
             val latestVersionForEachReport = getLatestVersionsForReports(it)
 
             return it.dsl.withTemporaryTable(latestVersionForEachReport)
-                    .select(Tables.REPORT_VERSION.REPORT.`as`("name"),
-                            Tables.REPORT_VERSION.DISPLAYNAME,
-                            Tables.REPORT_VERSION.ID.`as`("latestVersion"))
-                    .from(Tables.REPORT_VERSION)
+                    .select(REPORT_VERSION.REPORT.`as`("name"),
+                            REPORT_VERSION.DISPLAYNAME,
+                            REPORT_VERSION.ID.`as`("latestVersion"))
+                    .from(REPORT_VERSION)
                     .join(latestVersionForEachReport.tableName)
-                    .on(Tables.REPORT_VERSION.ID.eq(latestVersionForEachReport.field("latestVersion")))
+                    .on(REPORT_VERSION.ID.eq(latestVersionForEachReport.field("latestVersion")))
                     .where(shouldIncludeReportVersion)
-                    .orderBy(Tables.REPORT_VERSION.REPORT)
+                    .orderBy(REPORT_VERSION.REPORT)
                     .fetchInto(Report::class.java)
         }
     }
@@ -51,9 +58,9 @@ class OrderlyReportRepository(val isReviewer: Boolean,
     {
         JooqContext().use {
 
-            val result = it.dsl.select(Tables.REPORT_VERSION.ID)
-                    .from(Tables.REPORT_VERSION)
-                    .where(Tables.REPORT_VERSION.REPORT.eq(name)
+            val result = it.dsl.select(REPORT_VERSION.ID)
+                    .from(REPORT_VERSION)
+                    .where(REPORT_VERSION.REPORT.eq(name)
                             .and(shouldIncludeReportVersion))
 
             if (result.count() == 0)
@@ -74,11 +81,11 @@ class OrderlyReportRepository(val isReviewer: Boolean,
             val versions = it.dsl
                     .select(Tables.ORDERLYWEB_PINNED_REPORT_GLOBAL.ORDERING,
                             Tables.ORDERLYWEB_PINNED_REPORT_GLOBAL.REPORT.`as`("name"),
-                            Tables.REPORT_VERSION.DISPLAYNAME,
-                            Tables.REPORT_VERSION.ID.`as`("latestVersion"))
-                    .fromJoinPath(Tables.ORDERLYWEB_PINNED_REPORT_GLOBAL, Tables.REPORT)
-                    .join(Tables.REPORT_VERSION)
-                    .on(Tables.REPORT_VERSION.REPORT.eq(Tables.ORDERLYWEB_PINNED_REPORT_GLOBAL.REPORT))
+                            REPORT_VERSION.DISPLAYNAME,
+                            REPORT_VERSION.ID.`as`("latestVersion"))
+                    .fromJoinPath(Tables.ORDERLYWEB_PINNED_REPORT_GLOBAL, REPORT)
+                    .join(REPORT_VERSION)
+                    .on(REPORT_VERSION.REPORT.eq(Tables.ORDERLYWEB_PINNED_REPORT_GLOBAL.REPORT))
                     .where(shouldIncludeReportVersion)
                     .fetch()
 
@@ -97,17 +104,67 @@ class OrderlyReportRepository(val isReviewer: Boolean,
         }
     }
 
+    override fun getAllReportVersions(): List<BasicReportVersion>
+    {
+        JooqContext().use {
+            // create a temp table containing the latest version ID for each report name
+            val latestVersionForEachReport = getLatestVersionsForReports(it)
+
+            return it.dsl.withTemporaryTable(latestVersionForEachReport)
+                    .select(REPORT_VERSION.REPORT.`as`("name"),
+                            REPORT_VERSION.DISPLAYNAME,
+                            REPORT_VERSION.ID,
+                            REPORT_VERSION.PUBLISHED,
+                            REPORT_VERSION.DATE,
+                            latestVersionForEachReport.field<String>("latestVersion"),
+                            REPORT_VERSION.DESCRIPTION
+                    )
+                    .from(REPORT_VERSION)
+                    .join(latestVersionForEachReport.tableName)
+                    .on(REPORT_VERSION.REPORT.eq(latestVersionForEachReport.field("report")))
+                    .where(shouldIncludeReportVersion)
+                    .orderBy(REPORT_VERSION.REPORT, REPORT_VERSION.ID)
+                    .fetchInto(BasicReportVersion::class.java)
+        }
+    }
+
     override fun togglePublishStatus(name: String, version: String): Boolean
     {
         JooqContext().use {
             val existing = getReportVersion(name, version, it)
             val newStatus = !existing.published
-            it.dsl.update(Tables.REPORT_VERSION)
-                    .set(Tables.REPORT_VERSION.PUBLISHED, newStatus)
-                    .where(Tables.REPORT_VERSION.ID.eq(version))
+            it.dsl.update(REPORT_VERSION)
+                    .set(REPORT_VERSION.PUBLISHED, newStatus)
+                    .where(REPORT_VERSION.ID.eq(version))
                     .execute()
 
             return newStatus
+        }
+    }
+
+    override fun getAllCustomFields(): Map<String, String?>
+    {
+        JooqContext().use {
+            return it.dsl.select(
+                    CUSTOM_FIELDS.ID)
+                    .from(CUSTOM_FIELDS)
+                    .fetch()
+                    .associate { r -> r[CUSTOM_FIELDS.ID] to null as String? }
+        }
+    }
+
+    override fun getCustomFieldsForVersions(versionIds: List<String>): Map<String, Map<String, String>>
+    {
+        JooqContext().use {
+            return it.dsl.select(
+                    REPORT_VERSION_CUSTOM_FIELDS.KEY,
+                    REPORT_VERSION_CUSTOM_FIELDS.VALUE,
+                    REPORT_VERSION_CUSTOM_FIELDS.REPORT_VERSION)
+                    .from(REPORT_VERSION_CUSTOM_FIELDS)
+                    .where(REPORT_VERSION_CUSTOM_FIELDS.REPORT_VERSION.`in`(versionIds))
+                    .fetch()
+                    .groupBy { it[REPORT_VERSION_CUSTOM_FIELDS.REPORT_VERSION] }
+                    .mapValues { it.value.associate { it[REPORT_VERSION_CUSTOM_FIELDS.KEY] to it[REPORT_VERSION_CUSTOM_FIELDS.VALUE] } }
         }
     }
 
@@ -116,18 +173,18 @@ class OrderlyReportRepository(val isReviewer: Boolean,
         val latestVersionForEachReport = getLatestVersionsForReports(ctx)
 
         return ctx.dsl.withTemporaryTable(latestVersionForEachReport)
-                .select(Tables.REPORT_VERSION.REPORT.`as`("name"),
-                        Tables.REPORT_VERSION.DISPLAYNAME,
-                        Tables.REPORT_VERSION.ID,
-                        Tables.REPORT_VERSION.PUBLISHED,
-                        Tables.REPORT_VERSION.DATE,
+                .select(REPORT_VERSION.REPORT.`as`("name"),
+                        REPORT_VERSION.DISPLAYNAME,
+                        REPORT_VERSION.ID,
+                        REPORT_VERSION.PUBLISHED,
+                        REPORT_VERSION.DATE,
                         latestVersionForEachReport.field<String>("latestVersion"),
-                        Tables.REPORT_VERSION.DESCRIPTION)
-                .from(Tables.REPORT_VERSION)
+                        REPORT_VERSION.DESCRIPTION)
+                .from(REPORT_VERSION)
                 .join(latestVersionForEachReport.tableName)
-                .on(Tables.REPORT_VERSION.REPORT.eq(latestVersionForEachReport.field("report")))
-                .where(Tables.REPORT_VERSION.REPORT.eq(name))
-                .and(Tables.REPORT_VERSION.ID.eq(version))
+                .on(REPORT_VERSION.REPORT.eq(latestVersionForEachReport.field("report")))
+                .where(REPORT_VERSION.REPORT.eq(name))
+                .and(REPORT_VERSION.ID.eq(version))
                 .and(shouldIncludeReportVersion)
                 .singleOrNull()
                 ?.into(BasicReportVersion::class.java)
@@ -137,19 +194,19 @@ class OrderlyReportRepository(val isReviewer: Boolean,
     private fun getLatestVersionsForReports(db: JooqContext): TempTable
     {
         return db.dsl.select(
-                Tables.REPORT_VERSION.REPORT,
-                Tables.REPORT_VERSION.ID.`as`("latestVersion"),
-                Tables.REPORT_VERSION.DATE.max().`as`("maxDate")
+                REPORT_VERSION.REPORT,
+                REPORT_VERSION.ID.`as`("latestVersion"),
+                REPORT_VERSION.DATE.max().`as`("maxDate")
         )
-                .from(Tables.REPORT_VERSION)
+                .from(REPORT_VERSION)
                 .where(shouldIncludeReportVersion)
-                .groupBy(Tables.REPORT_VERSION.REPORT)
+                .groupBy(REPORT_VERSION.REPORT)
                 .asTemporaryTable(name = "latest_version_for_each_report")
     }
 
     // shouldInclude for the relational schema
     private val shouldIncludeReportVersion =
-            (Tables.REPORT_VERSION.REPORT.`in`(reportReadingScopes).or(isGlobalReader.or(isReviewer)))
-                    .and(Tables.REPORT_VERSION.PUBLISHED.bitOr(isReviewer))
+            (REPORT_VERSION.REPORT.`in`(reportReadingScopes).or(isGlobalReader.or(isReviewer)))
+                    .and(REPORT_VERSION.PUBLISHED.bitOr(isReviewer))
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/ReportTests.kt
@@ -1,16 +1,15 @@
-package org.vaccineimpact.orderlyweb.tests.database_tests
+package org.vaccineimpact.orderlyweb.tests.database_tests.ReportRepositoryTests
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ActionContext
-import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyReportRepository
 import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
 import org.vaccineimpact.orderlyweb.test_helpers.*
 
-class ReportRepositoryTests : CleanDatabaseTests()
+class ReportTests : CleanDatabaseTests()
 {
     private fun createSut(isReviewer: Boolean = false): ReportRepository
     {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/VersionTests.kt
@@ -11,6 +11,7 @@ import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
 import org.vaccineimpact.orderlyweb.errors.UnknownObjectError
 import org.vaccineimpact.orderlyweb.test_helpers.CleanDatabaseTests
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
+import org.vaccineimpact.orderlyweb.test_helpers.insertReportWithCustomFields
 
 class VersionTests: CleanDatabaseTests() {
 
@@ -189,5 +190,32 @@ class VersionTests: CleanDatabaseTests() {
         Assertions.assertThat(results[6].name).isEqualTo("test3")
         Assertions.assertThat(results[6].id).isEqualTo("test3versionunpublished")
         Assertions.assertThat(results[6].latestVersion).isEqualTo("test3versionunpublished")
+    }
+
+    @Test
+    fun `can get all custom fields`()
+    {
+        val sut = createSut()
+        val result = sut.getAllCustomFields()
+        Assertions.assertThat(result.keys).containsExactly("author", "requester")
+        Assertions.assertThat(result["author"]).isEqualTo(null)
+        Assertions.assertThat(result["requester"]).isEqualTo(null)
+    }
+
+    @Test
+    fun `can get custom fields for versions`()
+    {
+        insertReportWithCustomFields("test1", "v1", mapOf("author" to "authorer"))
+        insertReportWithCustomFields("test2", "v2", mapOf())
+        insertReportWithCustomFields("test2", "v3", mapOf("requester" to "requester mcfunderface"))
+
+        val sut = createSut()
+        val result = sut.getCustomFieldsForVersions(listOf("v1", "v2", "v3"))
+
+        Assertions.assertThat(result.keys).containsExactly("v1", "v3")
+        Assertions.assertThat(result["v1"]!!.keys).containsExactly("author")
+        Assertions.assertThat(result["v1"]!!["author"]).isEqualTo("authorer")
+        Assertions.assertThat(result["v3"]!!.keys).containsExactly("requester")
+        Assertions.assertThat(result["v3"]!!["requester"]).isEqualTo("requester mcfunderface")
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/VersionTests.kt
@@ -1,0 +1,193 @@
+package org.vaccineimpact.orderlyweb.tests.database_tests.ReportRepositoryTests
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.db.repositories.OrderlyReportRepository
+import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
+import org.vaccineimpact.orderlyweb.errors.UnknownObjectError
+import org.vaccineimpact.orderlyweb.test_helpers.CleanDatabaseTests
+import org.vaccineimpact.orderlyweb.test_helpers.insertReport
+
+class VersionTests: CleanDatabaseTests() {
+
+    private fun createSut(isReviewer: Boolean = false): ReportRepository
+    {
+        return OrderlyReportRepository(isReviewer, true, listOf())
+    }
+
+    @Test
+    fun `getAllReportVersions returns report names user is authorized to see`()
+    {
+        insertReport("goodname", "va")
+        insertReport("badname", "vb")
+
+        val mockContext = mock<ActionContext> {
+            on { it.reportReadingScopes } doReturn listOf("goodname")
+        }
+
+        val sut = OrderlyReportRepository(mockContext)
+
+        val result = sut.getAllReportVersions()
+        Assertions.assertThat(result).hasSize(1)
+        Assertions.assertThat(result[0].name).isEqualTo("goodname")
+    }
+
+    @Test
+    fun `getAllReportVersions returns all report names if user has global read permissions`()
+    {
+        insertReport("goodname", "va")
+        insertReport("anothername", "vb")
+
+        val mockContext = mock<ActionContext> {
+            on { it.isGlobalReader() } doReturn true
+        }
+
+        val sut = OrderlyReportRepository(mockContext)
+
+        val results = sut.getAllReportVersions()
+        Assertions.assertThat(results.count()).isEqualTo(2)
+    }
+
+    @Test
+    fun `getReportVersion throws unknown object error if report version not published`()
+    {
+        insertReport("test", "version1", published = false)
+
+        val sut = createSut()
+        Assertions.assertThatThrownBy { sut.getReportVersion("test", "version1") }
+                .isInstanceOf(UnknownObjectError::class.java)
+    }
+
+    @Test
+    fun `getReportVersion throws unknown object error if report version doesnt exist`()
+    {
+        insertReport("test", "version1")
+
+        val sut = createSut()
+
+        Assertions.assertThatThrownBy { sut.getReportVersion("test", "dsajkdsj") }
+                .isInstanceOf(UnknownObjectError::class.java)
+    }
+
+
+    @Test
+    fun `getReportVersion throws unknown object error if report name not found`()
+    {
+        insertReport("test", "version1")
+
+        val sut = createSut()
+
+        Assertions.assertThatThrownBy { sut.getReportVersion("dsajkdsj", "version") }
+                .isInstanceOf(UnknownObjectError::class.java)
+    }
+
+    @Test
+    fun `reviewer can get unpublished version details`()
+    {
+        insertReport("test", "version1", published = false)
+
+        val sut = createSut(isReviewer = true)
+
+        val result = sut.getReportVersion("test", "version1")
+
+        assertThat(result.name).isEqualTo("test")
+        assertThat(result.id).isEqualTo("version1")
+        assertThat(result.published).isFalse()
+    }
+
+    @Test
+    fun `reader can get all published report versions`()
+    {
+        insertReport("test", "va")
+        insertReport("test", "vz")
+        insertReport("test2", "vc")
+        insertReport("test2", "vb")
+        insertReport("test2", "vd")
+        insertReport("test3", "test3version")
+        insertReport("test3", "test3versionunpublished", published = false)
+
+        val sut = createSut()
+
+        val results = sut.getAllReportVersions()
+
+        Assertions.assertThat(results.count()).isEqualTo(6)
+
+        Assertions.assertThat(results[0].name).isEqualTo("test")
+        Assertions.assertThat(results[0].displayName).isEqualTo("display name test")
+        Assertions.assertThat(results[0].latestVersion).isEqualTo("vz")
+        Assertions.assertThat(results[0].id).isEqualTo("va")
+        Assertions.assertThat(results[0].published).isTrue()
+
+        Assertions.assertThat(results[1].name).isEqualTo("test")
+        Assertions.assertThat(results[1].id).isEqualTo("vz")
+        Assertions.assertThat(results[1].latestVersion).isEqualTo("vz")
+
+        Assertions.assertThat(results[2].name).isEqualTo("test2")
+        Assertions.assertThat(results[2].id).isEqualTo("vb")
+        Assertions.assertThat(results[2].latestVersion).isEqualTo("vd")
+
+        Assertions.assertThat(results[3].name).isEqualTo("test2")
+        Assertions.assertThat(results[3].id).isEqualTo("vc")
+        Assertions.assertThat(results[3].latestVersion).isEqualTo("vd")
+
+        Assertions.assertThat(results[4].name).isEqualTo("test2")
+        Assertions.assertThat(results[4].id).isEqualTo("vd")
+        Assertions.assertThat(results[4].latestVersion).isEqualTo("vd")
+
+        Assertions.assertThat(results[5].name).isEqualTo("test3")
+        Assertions.assertThat(results[5].id).isEqualTo("test3version")
+        Assertions.assertThat(results[5].latestVersion).isEqualTo("test3version")
+    }
+
+    @Test
+    fun `reviewer can get all published and unpublished report versions`()
+    {
+        insertReport("test", "va")
+        insertReport("test", "vz")
+        insertReport("test2", "vc")
+        insertReport("test2", "vb")
+        insertReport("test2", "vd")
+        insertReport("test3", "test3version")
+        insertReport("test3", "test3versionunpublished", published = false)
+
+        val sut = createSut(isReviewer = true)
+
+        val results = sut.getAllReportVersions()
+
+        Assertions.assertThat(results.count()).isEqualTo(7)
+
+        Assertions.assertThat(results[0].name).isEqualTo("test")
+        Assertions.assertThat(results[0].displayName).isEqualTo("display name test")
+        Assertions.assertThat(results[0].latestVersion).isEqualTo("vz")
+        Assertions.assertThat(results[0].id).isEqualTo("va")
+        Assertions.assertThat(results[0].published).isTrue()
+
+        Assertions.assertThat(results[1].name).isEqualTo("test")
+        Assertions.assertThat(results[1].id).isEqualTo("vz")
+        Assertions.assertThat(results[1].latestVersion).isEqualTo("vz")
+
+        Assertions.assertThat(results[2].name).isEqualTo("test2")
+        Assertions.assertThat(results[2].id).isEqualTo("vb")
+        Assertions.assertThat(results[2].latestVersion).isEqualTo("vd")
+
+        Assertions.assertThat(results[3].name).isEqualTo("test2")
+        Assertions.assertThat(results[3].id).isEqualTo("vc")
+        Assertions.assertThat(results[3].latestVersion).isEqualTo("vd")
+
+        Assertions.assertThat(results[4].name).isEqualTo("test2")
+        Assertions.assertThat(results[4].id).isEqualTo("vd")
+        Assertions.assertThat(results[4].latestVersion).isEqualTo("vd")
+
+        Assertions.assertThat(results[5].name).isEqualTo("test3")
+        Assertions.assertThat(results[5].id).isEqualTo("test3version")
+        Assertions.assertThat(results[5].latestVersion).isEqualTo("test3versionunpublished")
+
+        Assertions.assertThat(results[6].name).isEqualTo("test3")
+        Assertions.assertThat(results[6].id).isEqualTo("test3versionunpublished")
+        Assertions.assertThat(results[6].latestVersion).isEqualTo("test3versionunpublished")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/VersionTests.kt
@@ -1,11 +1,8 @@
 package org.vaccineimpact.orderlyweb.tests.database_tests
 
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.db.OrderlyClient
 import org.vaccineimpact.orderlyweb.errors.UnknownObjectError
@@ -24,7 +21,7 @@ class VersionTests : CleanDatabaseTests()
     }
 
     @Test
-    fun `reader can get published report version details`()
+    fun `can get report version details`()
     {
         val now = Timestamp(System.currentTimeMillis())
         insertReport("test", "version1", date = now,
@@ -92,163 +89,6 @@ class VersionTests : CleanDatabaseTests()
                 .isInstanceOf(UnknownObjectError::class.java)
     }
 
-    @Test
-    fun `getDetailsByNameAndVersion throws unknown object error if report version not published`()
-    {
-        insertReport("test", "version1", published = false)
-
-        val sut = createSut()
-        Assertions.assertThatThrownBy { sut.getDetailsByNameAndVersion("test", "version1") }
-                .isInstanceOf(UnknownObjectError::class.java)
-    }
-
-    @Test
-    fun `getDetailsByNameAndVersion throws unknown object error if report version doesnt exist`()
-    {
-        insertReport("test", "version1")
-
-        val sut = createSut()
-
-        Assertions.assertThatThrownBy { sut.getDetailsByNameAndVersion("test", "dsajkdsj") }
-                .isInstanceOf(UnknownObjectError::class.java)
-    }
-
-
-    @Test
-    fun `getDetailsByNameAndVersion throws unknown object error if report name not found`()
-    {
-        insertReport("test", "version1")
-
-        val sut = createSut()
-
-        Assertions.assertThatThrownBy { sut.getDetailsByNameAndVersion("dsajkdsj", "version") }
-                .isInstanceOf(UnknownObjectError::class.java)
-    }
-
-    @Test
-    fun `reviewer can get unpublished version details`()
-    {
-        insertReport("test", "version1", published = false)
-
-        val sut = createSut(isReviewer = true)
-
-        val result = sut.getDetailsByNameAndVersion("test", "version1")
-
-        assertThat(result.name).isEqualTo("test")
-        assertThat(result.id).isEqualTo("version1")
-        assertThat(result.published).isFalse()
-    }
-
-    @Test
-    fun `reader can get all published report versions`()
-    {
-        insertReport("test", "va")
-
-        insertReport("test", "vz")
-        insertVersionParameterValues("vz", mapOf("p1" to "v1", "p2" to "v2"))
-
-        insertReport("test2", "vc")
-        insertReport("test2", "vb")
-        insertReportWithCustomFields("test2", "vd", mapOf("author" to "test2 author"))
-        insertReportWithCustomFields("test3", "test3version", mapOf())
-        insertReport("test3", "test3versionunpublished", published = false)
-
-        val sut = createSut()
-
-        val results = sut.getAllReportVersions()
-
-        Assertions.assertThat(results.count()).isEqualTo(6)
-
-        Assertions.assertThat(results[0].name).isEqualTo("test")
-        Assertions.assertThat(results[0].displayName).isEqualTo("display name test")
-        Assertions.assertThat(results[0].latestVersion).isEqualTo("vz")
-        Assertions.assertThat(results[0].id).isEqualTo("va")
-        Assertions.assertThat(results[0].published).isTrue()
-        Assertions.assertThat(results[0].customFields.keys.count()).isEqualTo(2)
-        Assertions.assertThat(results[0].customFields["author"]).isEqualTo("author authorson")
-        Assertions.assertThat(results[0].customFields["requester"]).isEqualTo("requester mcfunder")
-        Assertions.assertThat(results[0].parameterValues.keys.count()).isEqualTo(0)
-
-        Assertions.assertThat(results[1].name).isEqualTo("test")
-        Assertions.assertThat(results[1].id).isEqualTo("vz")
-        Assertions.assertThat(results[1].latestVersion).isEqualTo("vz")
-        Assertions.assertThat(results[1].parameterValues.keys.count()).isEqualTo(2)
-        Assertions.assertThat(results[1].parameterValues["p1"]).isEqualTo("v1")
-        Assertions.assertThat(results[1].parameterValues["p2"]).isEqualTo("v2")
-
-        Assertions.assertThat(results[2].name).isEqualTo("test2")
-        Assertions.assertThat(results[2].id).isEqualTo("vb")
-        Assertions.assertThat(results[2].latestVersion).isEqualTo("vd")
-
-        Assertions.assertThat(results[3].name).isEqualTo("test2")
-        Assertions.assertThat(results[3].id).isEqualTo("vc")
-        Assertions.assertThat(results[3].latestVersion).isEqualTo("vd")
-
-        Assertions.assertThat(results[4].name).isEqualTo("test2")
-        Assertions.assertThat(results[4].id).isEqualTo("vd")
-        Assertions.assertThat(results[4].latestVersion).isEqualTo("vd")
-        Assertions.assertThat(results[4].customFields.keys.count()).isEqualTo(2)
-        Assertions.assertThat(results[4].customFields["author"]).isEqualTo("test2 author")
-        Assertions.assertThat(results[4].customFields["requester"]).isEqualTo(null)
-
-        Assertions.assertThat(results[5].name).isEqualTo("test3")
-        Assertions.assertThat(results[5].id).isEqualTo("test3version")
-        Assertions.assertThat(results[5].latestVersion).isEqualTo("test3version")
-        Assertions.assertThat(results[5].customFields.keys.count()).isEqualTo(2)
-        Assertions.assertThat(results[5].customFields["author"]).isEqualTo(null)
-        Assertions.assertThat(results[5].customFields["requester"]).isEqualTo(null)
-
-    }
-
-    @Test
-    fun `reviewer can get all published and unpublished report versions`()
-    {
-        insertReport("test", "va")
-        insertReport("test", "vz")
-        insertReport("test2", "vc")
-        insertReport("test2", "vb")
-        insertReport("test2", "vd")
-        insertReport("test3", "test3version")
-        insertReport("test3", "test3versionunpublished", published = false)
-
-        val sut = createSut(isReviewer = true)
-
-        val results = sut.getAllReportVersions()
-
-        Assertions.assertThat(results.count()).isEqualTo(7)
-
-        Assertions.assertThat(results[0].name).isEqualTo("test")
-        Assertions.assertThat(results[0].displayName).isEqualTo("display name test")
-        Assertions.assertThat(results[0].latestVersion).isEqualTo("vz")
-        Assertions.assertThat(results[0].id).isEqualTo("va")
-        Assertions.assertThat(results[0].published).isTrue()
-        Assertions.assertThat(results[0].customFields["author"]).isEqualTo("author authorson")
-        Assertions.assertThat(results[0].customFields["requester"]).isEqualTo("requester mcfunder")
-
-        Assertions.assertThat(results[1].name).isEqualTo("test")
-        Assertions.assertThat(results[1].id).isEqualTo("vz")
-        Assertions.assertThat(results[1].latestVersion).isEqualTo("vz")
-
-        Assertions.assertThat(results[2].name).isEqualTo("test2")
-        Assertions.assertThat(results[2].id).isEqualTo("vb")
-        Assertions.assertThat(results[2].latestVersion).isEqualTo("vd")
-
-        Assertions.assertThat(results[3].name).isEqualTo("test2")
-        Assertions.assertThat(results[3].id).isEqualTo("vc")
-        Assertions.assertThat(results[3].latestVersion).isEqualTo("vd")
-
-        Assertions.assertThat(results[4].name).isEqualTo("test2")
-        Assertions.assertThat(results[4].id).isEqualTo("vd")
-        Assertions.assertThat(results[4].latestVersion).isEqualTo("vd")
-
-        Assertions.assertThat(results[5].name).isEqualTo("test3")
-        Assertions.assertThat(results[5].id).isEqualTo("test3version")
-        Assertions.assertThat(results[5].latestVersion).isEqualTo("test3versionunpublished")
-
-        Assertions.assertThat(results[6].name).isEqualTo("test3")
-        Assertions.assertThat(results[6].id).isEqualTo("test3versionunpublished")
-        Assertions.assertThat(results[6].latestVersion).isEqualTo("test3versionunpublished")
-    }
     @Test
     fun `getAllReportVersions returns version tags`()
     {
@@ -328,35 +168,64 @@ class VersionTests : CleanDatabaseTests()
     }
 
     @Test
-    fun `getAllReportVersions returns report names user is authorized to see`()
+    fun `can get report versions`()
     {
-        insertReport("goodname", "va")
-        insertReport("badname", "vb")
+        insertReport("test", "va")
 
-        val mockContext = mock<ActionContext> {
-            on { it.reportReadingScopes } doReturn listOf("goodname")
-        }
+        insertReport("test", "vz")
+        insertVersionParameterValues("vz", mapOf("p1" to "v1", "p2" to "v2"))
 
-        val sut = Orderly(mockContext)
+        insertReport("test2", "vc")
+        insertReport("test2", "vb")
+        insertReportWithCustomFields("test2", "vd", mapOf("author" to "test2 author"))
+        insertReportWithCustomFields("test3", "test3version", mapOf())
+        insertReport("test3", "test3versionunpublished", published = false)
 
-        val result = sut.getAllReportVersions()
-        assertThat(result).hasSize(1)
-        assertThat(result[0].name).isEqualTo("goodname")
-    }
-
-    @Test
-    fun `getAllReportVersions returns all report names if user has global read permissions`()
-    {
-        insertReport("goodname", "va")
-        insertReport("anothername", "vb")
-
-        val mockContext = mock<ActionContext> {
-            on { it.isGlobalReader() } doReturn true
-        }
-
-        val sut = Orderly(mockContext)
+        val sut = createSut()
 
         val results = sut.getAllReportVersions()
-        assertThat(results.count()).isEqualTo(2)
+
+        assertThat(results.count()).isEqualTo(6)
+
+        assertThat(results[0].name).isEqualTo("test")
+        assertThat(results[0].displayName).isEqualTo("display name test")
+        assertThat(results[0].latestVersion).isEqualTo("vz")
+        assertThat(results[0].id).isEqualTo("va")
+        assertThat(results[0].published).isTrue()
+        assertThat(results[0].customFields.keys.count()).isEqualTo(2)
+        assertThat(results[0].customFields["author"]).isEqualTo("author authorson")
+        assertThat(results[0].customFields["requester"]).isEqualTo("requester mcfunder")
+        assertThat(results[0].parameterValues.keys.count()).isEqualTo(0)
+
+        assertThat(results[1].name).isEqualTo("test")
+        assertThat(results[1].id).isEqualTo("vz")
+        assertThat(results[1].latestVersion).isEqualTo("vz")
+        assertThat(results[1].parameterValues.keys.count()).isEqualTo(2)
+        assertThat(results[1].parameterValues["p1"]).isEqualTo("v1")
+        assertThat(results[1].parameterValues["p2"]).isEqualTo("v2")
+
+        assertThat(results[2].name).isEqualTo("test2")
+        assertThat(results[2].id).isEqualTo("vb")
+        assertThat(results[2].latestVersion).isEqualTo("vd")
+
+        assertThat(results[3].name).isEqualTo("test2")
+        assertThat(results[3].id).isEqualTo("vc")
+        assertThat(results[3].latestVersion).isEqualTo("vd")
+
+        assertThat(results[4].name).isEqualTo("test2")
+        assertThat(results[4].id).isEqualTo("vd")
+        assertThat(results[4].latestVersion).isEqualTo("vd")
+        assertThat(results[4].customFields.keys.count()).isEqualTo(2)
+        assertThat(results[4].customFields["author"]).isEqualTo("test2 author")
+        assertThat(results[4].customFields["requester"]).isEqualTo(null)
+
+        assertThat(results[5].name).isEqualTo("test3")
+        assertThat(results[5].id).isEqualTo("test3version")
+        assertThat(results[5].latestVersion).isEqualTo("test3version")
+        assertThat(results[5].customFields.keys.count()).isEqualTo(2)
+        assertThat(results[5].customFields["author"]).isEqualTo(null)
+        assertThat(results[5].customFields["requester"]).isEqualTo(null)
+
     }
+
 }


### PR DESCRIPTION
Moves the initial data retrieval part of the `Orderly` method `getAllReportVersions` into the report repo.  

Contains commits from https://github.com/vimc/orderly-web/pull/222

Most of this changeset is re-writing tests.