### PR TITLE
mrc-1490 Make Admin role non-editable in front end

### DIFF
--- a/src/app/static/src/js/components/admin/manageRolePermissions.vue
+++ b/src/app/static/src/js/components/admin/manageRolePermissions.vue
@@ -10,7 +10,7 @@
                                  cssClass="children"
                                  :permissions="role.permissions"
                                  :user-group="role.name"
-                                 :canRemove="role.name !== 'Admin'"
+                                 :can-remove="role.name !== 'Admin'"
                                  @added="function(p) {addPermission(p, role)}"
                                  @removed="function(p) {removePermission(p, role.name)}"></permission-list>
             </li>

--- a/src/app/static/src/js/components/admin/manageRolePermissions.vue
+++ b/src/app/static/src/js/components/admin/manageRolePermissions.vue
@@ -10,6 +10,7 @@
                                  cssClass="children"
                                  :permissions="role.permissions"
                                  :user-group="role.name"
+                                 :canRemove="role.name !== 'Admin'"
                                  @added="function(p) {addPermission(p, role)}"
                                  @removed="function(p) {removePermission(p, role.name)}"></permission-list>
             </li>

--- a/src/app/static/src/js/components/admin/manageRolePermissions.vue
+++ b/src/app/static/src/js/components/admin/manageRolePermissions.vue
@@ -10,7 +10,7 @@
                                  cssClass="children"
                                  :permissions="role.permissions"
                                  :user-group="role.name"
-                                 :can-remove="role.name !== 'Admin'"
+                                 :can-edit="role.name !== 'Admin'"
                                  @added="function(p) {addPermission(p, role)}"
                                  @removed="function(p) {removePermission(p, role.name)}"></permission-list>
             </li>

--- a/src/app/static/src/js/components/admin/manageUserPermissions.vue
+++ b/src/app/static/src/js/components/admin/manageUserPermissions.vue
@@ -13,7 +13,7 @@
                 <permission-list v-show="expanded[u.email]"
                                  :permissions="u.direct_permissions.concat(u.role_permissions)"
                                  :user-group="u.email"
-                                 :can-remove="true"
+                                 :can-edit="true"
                                  @added="function(p) {addPermission(p, u)}"
                                  @removed="function(p) {removePermission(p, u)}"></permission-list>
             </li>

--- a/src/app/static/src/js/components/admin/manageUserPermissions.vue
+++ b/src/app/static/src/js/components/admin/manageUserPermissions.vue
@@ -13,6 +13,7 @@
                 <permission-list v-show="expanded[u.email]"
                                  :permissions="u.direct_permissions.concat(u.role_permissions)"
                                  :user-group="u.email"
+                                 :can-remove="true"
                                  @added="function(p) {addPermission(p, u)}"
                                  @removed="function(p) {removePermission(p, u)}"></permission-list>
             </li>

--- a/src/app/static/src/js/components/admin/permissionList.vue
+++ b/src/app/static/src/js/components/admin/permissionList.vue
@@ -2,9 +2,9 @@
     <div>
         <ul v-if="permissions.length > 0" class="list-unstyled children mt-1">
             <li v-for="p in sortedPermissions">
-                <span class="name" :class="{'text-muted': !isDirect(p)}" :name="p.name">{{p.name}} <span
+                <span class="name" :class="{'text-muted': !canRemovePermission(p)}" :name="p.name">{{p.name}} <span
                         v-if="p.scope_prefix">/ {{p.scope_prefix}}:{{p.scope_id}}</span></span>
-                <span v-if="isDirect(p)" v-on:click="function() {remove(p)}"
+                <span v-if="canRemovePermission(p)" v-on:click="function() {remove(p)}"
                       class="remove d-inline-block ml-2 large">×</span>
                 <span v-if="!isDirect(p)" class="text-muted source small">(via {{p.source}})</span>
             </li>
@@ -22,7 +22,7 @@
     export default {
         name: "permissionList",
         components: {AddPermission, ErrorInfo},
-        props: ["permissions", "userGroup"],
+        props: ["permissions", "userGroup", "canRemove"],
         data() {
             return {
                 error: "",
@@ -56,6 +56,9 @@
             },
             add(p) {
                 this.$emit("added", p);
+            },
+            canRemovePermission(p) {
+                return this.canRemove && this.isDirect(p)
             },
             isDirect(p) {
                 return p.source === this.userGroup

--- a/src/app/static/src/js/components/admin/permissionList.vue
+++ b/src/app/static/src/js/components/admin/permissionList.vue
@@ -9,7 +9,7 @@
                 <span v-if="!isDirect(p)" class="text-muted source small">(via {{p.source}})</span>
             </li>
         </ul>
-        <add-permission :user-group="userGroup" :available-permissions="availablePermissions" @added="add"></add-permission>
+        <add-permission v-if="canEdit" :user-group="userGroup" :available-permissions="availablePermissions" @added="add"></add-permission>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>
     </div>
 </template>
@@ -22,7 +22,7 @@
     export default {
         name: "permissionList",
         components: {AddPermission, ErrorInfo},
-        props: ["permissions", "userGroup", "canRemove"],
+        props: ["permissions", "userGroup", "canEdit"],
         data() {
             return {
                 error: "",
@@ -58,7 +58,7 @@
                 this.$emit("added", p);
             },
             canRemovePermission(p) {
-                return this.canRemove && this.isDirect(p)
+                return this.canEdit && this.isDirect(p)
             },
             isDirect(p) {
                 return p.source === this.userGroup

--- a/src/app/static/src/tests/components/admin/manageRolePermisisons.test.js
+++ b/src/app/static/src/tests/components/admin/manageRolePermisisons.test.js
@@ -45,7 +45,22 @@ describe("manageRolePermissions", () => {
         expect(listItems.at(1).find('span').text()).toBe("Science");
         expect(listItems.at(1).findAll(PermissionList).length).toBe(1);
         expect(listItems.at(1).find(PermissionList).props().permissions.length).toBe(0);
+        expect(listItems.at(1).find(PermissionList).props().canRemove).toBe(true);
 
+    });
+
+    it('renders PermissionList with canRemove false for Admin role', () => {
+        const wrapper = shallowMount(ManageRolePermissions, {
+            propsData: {
+                roles: [
+                    {name: "Admin", permissions: []}
+                ]
+            }
+        });
+
+        const listItems = wrapper.findAll("li");
+        expect(listItems.length).toBe(1);
+        expect(listItems.at(0).find(PermissionList).props().canRemove).toBe(false);
     });
 
     it('renders with error', async () => {

--- a/src/app/static/src/tests/components/admin/manageRolePermisisons.test.js
+++ b/src/app/static/src/tests/components/admin/manageRolePermisisons.test.js
@@ -45,11 +45,11 @@ describe("manageRolePermissions", () => {
         expect(listItems.at(1).find('span').text()).toBe("Science");
         expect(listItems.at(1).findAll(PermissionList).length).toBe(1);
         expect(listItems.at(1).find(PermissionList).props().permissions.length).toBe(0);
-        expect(listItems.at(1).find(PermissionList).props().canRemove).toBe(true);
+        expect(listItems.at(1).find(PermissionList).props().canEdit).toBe(true);
 
     });
 
-    it('renders PermissionList with canRemove false for Admin role', () => {
+    it('renders PermissionList with canEdit false for Admin role', () => {
         const wrapper = shallowMount(ManageRolePermissions, {
             propsData: {
                 roles: [
@@ -60,7 +60,7 @@ describe("manageRolePermissions", () => {
 
         const listItems = wrapper.findAll("li");
         expect(listItems.length).toBe(1);
-        expect(listItems.at(0).find(PermissionList).props().canRemove).toBe(false);
+        expect(listItems.at(0).find(PermissionList).props().canEdit).toBe(false);
     });
 
     it('renders with error', async () => {

--- a/src/app/static/src/tests/components/admin/manageUserPermissions.test.js
+++ b/src/app/static/src/tests/components/admin/manageUserPermissions.test.js
@@ -105,7 +105,7 @@ describe("manage users", () => {
         expect(rendered.findAll("li").length).toBe(2);
         expect(rendered.findAll(PermissionList).length).toBe(2);
 
-        expect(rendered.find(PermissionList).props().canRemove).toBe(true);
+        expect(rendered.find(PermissionList).props().canEdit).toBe(true);
 
         expect(rendered.findAll("li").at(0).classes("has-children")).toBe(true);
         expect(rendered.findAll("li").at(1).classes("has-children")).toBe(true);

--- a/src/app/static/src/tests/components/admin/manageUserPermissions.test.js
+++ b/src/app/static/src/tests/components/admin/manageUserPermissions.test.js
@@ -105,6 +105,8 @@ describe("manage users", () => {
         expect(rendered.findAll("li").length).toBe(2);
         expect(rendered.findAll(PermissionList).length).toBe(2);
 
+        expect(rendered.find(PermissionList).props().canRemove).toBe(true);
+
         expect(rendered.findAll("li").at(0).classes("has-children")).toBe(true);
         expect(rendered.findAll("li").at(1).classes("has-children")).toBe(true);
     });

--- a/src/app/static/src/tests/components/admin/permissionList.test.js
+++ b/src/app/static/src/tests/components/admin/permissionList.test.js
@@ -19,7 +19,7 @@ describe("permission list", () => {
             {
                 propsData: {
                     permissions: [],
-                    canRemove: true,
+                    canEdit: true,
                     ...propsData
                 }
             });
@@ -173,7 +173,7 @@ describe("permission list", () => {
         expect(rendered.findAll("span").at(1).text()).toBe("(via something else)");
     });
 
-    it("permissions cannot be removed if canRemove is false", () => {
+    it("permissions cannot be removed if canEdit is false", () => {
         const rendered = getWrapper({
             userGroup: "test",
             permissions: [
@@ -188,7 +188,7 @@ describe("permission list", () => {
                     scope_prefix: null,
                     source: "something else"
                 }],
-                canRemove: false
+                canEdit: false
         });
 
         const items = rendered.findAll("li");
@@ -204,5 +204,10 @@ describe("permission list", () => {
         expect(indirect.findAll("span").length).toBe(2);
         expect(indirect.findAll("span").at(1).classes()).toContain("text-muted");
         expect(indirect.findAll("span").at(1).text()).toBe("(via something else)");
+    });
+
+    it("permissions cannot be added if canEdit is false", () => {
+        const rendered = getWrapper({canEdit: false});
+        expect(rendered.findAll(AddPermission).length).toBe(0);
     });
 });


### PR DESCRIPTION
I wondered about not showing the Admin permissions at all rather than showing them without user being able to change them - but it could be useful to be able to see the permissions you'd be giving a user by putting them in the Admin role. 