### PR TITLE
mrc-1604 Run report placeholder page and vue component

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
@@ -33,6 +33,10 @@ object WebReportRouteConfig : RouteConfig
             WebEndpoint("/report/:name/actions/status/:key/",
                     org.vaccineimpact.orderlyweb.controllers.api.ReportController::class, "status")
                     .json()
+                    .secure(runReports),
+            WebEndpoint(
+                    "/run-report/",
+                    ReportController::class, "getRunReport")
                     .secure(runReports)
     )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -2,7 +2,6 @@ package org.vaccineimpact.orderlyweb.controllers.web
 
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.Controller
-import org.vaccineimpact.orderlyweb.db.JooqContext
 import org.vaccineimpact.orderlyweb.db.Orderly
 import org.vaccineimpact.orderlyweb.db.OrderlyClient
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyReportRepository
@@ -11,7 +10,7 @@ import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
 import org.vaccineimpact.orderlyweb.db.repositories.TagRepository
 import org.vaccineimpact.orderlyweb.errors.BadRequest
 import org.vaccineimpact.orderlyweb.models.ReportVersionTags
-import org.vaccineimpact.orderlyweb.viewmodels.ReportVersionPageViewModel
+import org.vaccineimpact.orderlyweb.viewmodels.*
 
 class ReportController(context: ActionContext,
                        val orderly: OrderlyClient,
@@ -30,6 +29,12 @@ class ReportController(context: ActionContext,
         val versions = reportRepository.getReportsByName(reportName)
         val changelog = orderly.getChangelogByNameAndVersion(reportName, version)
         return ReportVersionPageViewModel.build(reportDetails, versions, changelog, context)
+    }
+
+    @Template("run-report-page.ftl")
+    fun getRunReport(): RunReportViewModel
+    {
+        return RunReportViewModel(context)
     }
 
     fun tagVersion(): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/RunReportViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/RunReportViewModel.kt
@@ -1,0 +1,16 @@
+package org.vaccineimpact.orderlyweb.viewmodels
+
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.db.AppConfig
+
+data class RunReportViewModel(val appViewModel: AppViewModel)
+    : AppViewModel by appViewModel
+{
+    constructor(context: ActionContext)
+            : this(DefaultViewModel(context, IndexViewModel.breadcrumb, breadcrumb))
+
+    companion object
+    {
+        val breadcrumb = Breadcrumb("Run a report", "${AppConfig()["app.url"]}/run-report")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RunReportPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RunReportPageTests.kt
@@ -1,0 +1,31 @@
+package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
+
+import org.assertj.core.api.Assertions
+import org.jsoup.Jsoup
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.models.Scope
+import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
+
+class RunReportPageTests : IntegrationTest()
+{
+    private val runReportsPerm = setOf(ReifiedPermission("reports.run", Scope.Global()))
+
+    @Test
+    fun `only report runners can see the page`()
+    {
+        val url = "/run-report"
+        assertWebUrlSecured(url, runReportsPerm)
+    }
+
+    @Test
+    fun `correct page is served`()
+    {
+        val sessionCookie = webRequestHelper.webLoginWithMontagu(runReportsPerm)
+        val response = webRequestHelper.requestWithSessionCookie("/run-report", sessionCookie)
+        Assertions.assertThat(response.statusCode).isEqualTo(200)
+
+        val page = Jsoup.parse(response.text)
+        Assertions.assertThat(page.selectFirst("#runReportVueApp")).isNotNull()
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunReportTests.kt
@@ -1,0 +1,22 @@
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+
+import com.nhaarman.mockito_kotlin.mock
+import org.junit.Test
+import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.controllers.web.ReportController
+import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+
+class RunReportTests: TeamcityTests()
+{
+    @Test
+    fun `getRunReport creates viewmodel`()
+    {
+        val mockContext = mock<ActionContext>()
+        val sut = ReportController(mockContext, mock(), mock(), mock())
+        val result = sut.getRunReport()
+        assertThat(result.breadcrumbs.count()).isEqualTo(2)
+        assertThat(result.breadcrumbs[1].name).isEqualTo("Run a report")
+        assertThat(result.breadcrumbs[1].url).isEqualTo("http://localhost:8888/run-report")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/RunReportPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/RunReportPageTests.kt
@@ -1,0 +1,68 @@
+package org.vaccineimpact.orderlyweb.tests.unit_tests.templates
+
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions
+import org.junit.ClassRule
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+import org.vaccineimpact.orderlyweb.tests.unit_tests.templates.rules.FreemarkerTestRule
+import org.vaccineimpact.orderlyweb.viewmodels.RunReportViewModel
+
+class RunReportPageTests : TeamcityTests()
+{
+    companion object
+    {
+        @ClassRule
+        @JvmField
+        val template = FreemarkerTestRule("run-report-page.ftl")
+    }
+
+    private val testModel = RunReportViewModel(mock<ActionContext>())
+
+    @Test
+    fun `renders outline correctly`()
+    {
+        val doc = RunReportPageTests.template.jsoupDocFor(testModel)
+
+        Assertions.assertThat(doc.select(".nav-item")[0].text()).isEqualTo("Run a report")
+        Assertions.assertThat(doc.select(".nav-item")[1].text()).isEqualTo("Report logs")
+
+        Assertions.assertThat(doc.selectFirst("#run-tab").hasClass("tab-pane active pt-4 pt-md-1")).isTrue()
+        Assertions.assertThat(doc.selectFirst("#logs-tab").hasClass("tab-pane pt-4 pt-md-1")).isTrue()
+    }
+
+    @Test
+    fun `renders breadcrumbs correctly`()
+    {
+        val doc = RunReportPageTests.template.jsoupDocFor(testModel)
+        val breadcrumbs = doc.select(".crumb-item")
+
+        Assertions.assertThat(breadcrumbs.count()).isEqualTo(2)
+        Assertions.assertThat(breadcrumbs[0].child(0).text()).isEqualTo("Main menu")
+        Assertions.assertThat(breadcrumbs[0].child(0).attr("href")).isEqualTo("http://localhost:8888")
+        Assertions.assertThat(breadcrumbs[1].child(0).text()).isEqualTo("Run a report")
+        Assertions.assertThat(breadcrumbs[1].child(0).attr("href")).isEqualTo("http://localhost:8888/run-report")
+    }
+
+    @Test
+    fun `renders run tab correctly`()
+    {
+        val doc = RunReportPageTests.template.jsoupDocFor(testModel)
+        val tab = doc.select("#run-tab")
+
+        Assertions.assertThat(tab.select("h2").text()).isEqualToIgnoringWhitespace("Run a report")
+        Assertions.assertThat(tab.select("#runReportVueApp").select("run-report").count()).isEqualTo(1)
+
+    }
+
+    @Test
+    fun `renders logs tab correctly`()
+    {
+        val doc = RunReportPageTests.template.jsoupDocFor(testModel)
+        val tab = doc.select("#logs-tab")
+
+        Assertions.assertThat(tab.select("h2").text()).isEqualToIgnoringWhitespace("Report logs")
+        Assertions.assertThat(tab.select("p").text()).isEqualToIgnoringWhitespace("Report logs coming soon!")
+    }
+}

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+        Run report coming soon!
+    </div>
+</template>
+
+<script>
+    export default {
+        name: "runReport"
+    }
+</script>

--- a/src/app/static/src/js/runReport.js
+++ b/src/app/static/src/js/runReport.js
@@ -1,0 +1,15 @@
+import Vue from 'vue';
+import $ from 'jquery';
+
+import runReport from './components/runReport/runReport.vue'
+
+$(document).ready(() => {
+    if ($('#runReportVueApp').length > 0) {
+        new Vue({
+            el: '#runReportVueApp',
+            components: {
+                runReport: runReport
+            }
+        });
+    }
+});

--- a/src/app/static/src/tests/components/runReport/runReport.test.js
+++ b/src/app/static/src/tests/components/runReport/runReport.test.js
@@ -1,0 +1,9 @@
+import {shallowMount} from "@vue/test-utils";
+import RunReport from "../../../js/components/runReport/runReport.vue";
+
+describe("reportTags", () => {
+    it("renders as expected", () => {
+        const wrapper = shallowMount(RunReport);
+        expect(wrapper.text()).toBe("Run report coming soon!")
+    });
+});

--- a/src/app/templates/run-report-page.ftl
+++ b/src/app/templates/run-report-page.ftl
@@ -26,7 +26,9 @@
         <div class="col-12 col-md-8 tab-content">
             <div class="tab-pane active pt-4 pt-md-1" role="tabpanel" id="run-tab">
                 <h2>Run a report</h2>
-                <p>Report run coming soon!</p>
+                <div id="runReportVueApp">
+                    <run-report></run-report>
+                </div>
             </div>
             <div class="tab-pane pt-4 pt-md-1" role="tabpanel" id="logs-tab">
                <h2>Report logs</h2>
@@ -35,6 +37,7 @@
         </div>
     </div>
     <#macro scripts>
+        <script type="text/javascript" src="${appUrl}/js/runReport.bundle.js"></script>
         <script type="text/javascript" src="${appUrl}/js/lib/bootstrap.min.js"></script>
     </#macro>
 </@layoutwide>

--- a/src/app/templates/run-report-page.ftl
+++ b/src/app/templates/run-report-page.ftl
@@ -13,10 +13,10 @@
                     <div class="d-md-block mt-4 mt-md-0 collapse navbar-collapse" id="sidebar">
                         <ul class="nav flex-column list-unstyled mb-0">
                             <li class="nav-item">
-                                <a class="nav-link active" data-toggle="tab" href="#run-tab" role="tab">Run a report</a>
+                                <a id="run-link" class="nav-link active" data-toggle="tab" href="#run-tab" role="tab">Run a report</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" data-toggle="tab" href="#logs-tab" role="tab">Report logs</a>
+                                <a id="logs-link" class="nav-link" data-toggle="tab" href="#logs-tab" role="tab">Report logs</a>
                             </li>
                         </ul>
                     </div>
@@ -31,7 +31,7 @@
                 </div>
             </div>
             <div class="tab-pane pt-4 pt-md-1" role="tabpanel" id="logs-tab">
-               <h2>Report logs</h2>
+                <h2>Report logs</h2>
                 <p>Report logs coming soon!</p>
             </div>
         </div>

--- a/src/app/templates/run-report-page.ftl
+++ b/src/app/templates/run-report-page.ftl
@@ -1,0 +1,40 @@
+<@layoutwide>
+    <#macro styles>
+        <link rel="stylesheet" href="${appUrl}/css/report-page.min.css"/>
+    </#macro>
+    <div class="row">
+        <div class="col-12 col-md-4 col-xl-3">
+            <div class="sidebar pb-4 pb-md-0">
+                <nav class="pl-0 pr-0 pr-md-4 navbar navbar-light">
+                    <button type="button" class="d-md-none navbar-toggler" data-toggle="collapse"
+                            data-target="#sidebar">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="d-md-block mt-4 mt-md-0 collapse navbar-collapse" id="sidebar">
+                        <ul class="nav flex-column list-unstyled mb-0">
+                            <li class="nav-item">
+                                <a class="nav-link active" data-toggle="tab" href="#run-tab" role="tab">Run a report</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" data-toggle="tab" href="#logs-tab" role="tab">Report logs</a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+            </div>
+        </div>
+        <div class="col-12 col-md-8 tab-content">
+            <div class="tab-pane active pt-4 pt-md-1" role="tabpanel" id="run-tab">
+                <h2>Run a report</h2>
+                <p>Report run coming soon!</p>
+            </div>
+            <div class="tab-pane pt-4 pt-md-1" role="tabpanel" id="logs-tab">
+               <h2>Report logs</h2>
+                <p>Report logs coming soon!</p>
+            </div>
+        </div>
+    </div>
+    <#macro scripts>
+        <script type="text/javascript" src="${appUrl}/js/lib/bootstrap.min.js"></script>
+    </#macro>
+</@layoutwide>

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -1,0 +1,50 @@
+package org.vaccineimpact.orderlyweb.customConfigTests
+
+import org.junit.Test
+import org.junit.Before
+import org.openqa.selenium.By
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.assertj.core.api.Assertions.assertThat
+import org.vaccineimpact.orderlyweb.db.JooqContext
+import org.vaccineimpact.orderlyweb.test_helpers.giveUserGroupGlobalPermission
+import org.vaccineimpact.orderlyweb.test_helpers.insertUserAndGroup
+
+class RunReportPageTests : SeleniumTest()
+{
+    @Before
+    fun setUp()
+    {
+        JooqContext().use {
+            insertUserAndGroup(it, "test.user@example.com")
+            giveUserGroupGlobalPermission(it, "test.user@example.com", "reports.run")
+        }
+
+        startApp("auth.provider=montagu")
+
+        loginWithMontagu()
+
+        val url = RequestHelper.webBaseUrl + "/run-report/"
+        driver.get(url)
+    }
+
+    @Test
+    fun `can view run tab`()
+    {
+        val tab = driver.findElement(By.id("run-tab"))
+
+        assertThat(tab.findElement(By.tagName("h2")).text).isEqualTo("Run a report")
+        assertThat(tab.findElement(By.id("runReportVueApp")).text).isEqualTo("Run report coming soon!")
+    }
+
+    @Test
+    fun `can view logs tab`()
+    {
+        driver.findElement(By.id("logs-link")).click()
+
+        val tab = driver.findElement(By.id("logs-tab"))
+        wait.until(ExpectedConditions.attributeToBe(tab,"display", "block"))
+
+        assertThat(tab.findElement(By.tagName("h2")).text).isEqualTo("Report logs")
+        assertThat(tab.findElement(By.tagName("p")).text).isEqualTo("Report logs coming soon!")
+    }
+}


### PR DESCRIPTION
This branch just wires up a route, page and front end component for the run report functionality, no actual content yet. 
- Adds a run-report route 
- Adds a template page, which includes tabs for 'Run report' and 'Report logs' and an element picked up by the front end to show..
- ..a placeholder runReport vue component, which will contain the report runner form, and handle requests to backend to fetch details and run report. 

There is already a runReport vue component, in the reports folder. This is the simple runner from the reportVersion page, which will be removed when this work is completed. 

There is no link to the new page from the index page, but you can see it by browsing to /run-report.