### PR TITLE
mrc-1485 further tiny refactor

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
@@ -250,7 +250,6 @@ class OrderlyReportRepository(val isReviewer: Boolean,
             it.dsl.select(changelogReportVersionColumnForUser.`as`("REPORT_VERSION"),
                     CHANGELOG.LABEL,
                     CHANGELOG.VALUE,
-                    CHANGELOG.FROM_FILE,
                     CHANGELOG_LABEL.PUBLIC)
                     .fromJoinPath(CHANGELOG, CHANGELOG_LABEL)
                     .join(ORDERLYWEB_REPORT_VERSION_FULL)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Changelog.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Changelog.kt
@@ -3,9 +3,8 @@ package org.vaccineimpact.orderlyweb.models
 import java.beans.ConstructorProperties
 
 data class Changelog
-@ConstructorProperties("reportVersion", "label", "value", "fromFile", "public")
+@ConstructorProperties("reportVersion", "label", "value", "public")
 constructor(val reportVersion: String,
             val label: String,
             val value: String,
-            val fromFile: Boolean,
             val public: Boolean)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/OrderlyTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/OrderlyTests.kt
@@ -41,9 +41,9 @@ class OrderlyTests : CleanDatabaseTests()
         on { getParametersForVersions(listOf("v1")) } doReturn mapOf("v1" to mapOf("p1" to "param1", "p2" to "param2"))
         on { getLatestVersion("test") } doReturn basicReportVersion.copy(id = "latest", date = now.minusSeconds(100))
         on { getDatedChangelogForReport("test", now.minusSeconds(100)) } doReturn
-                listOf(Changelog("v1", "public", "getLatestChangelog", true, true))
+                listOf(Changelog("v1", "public", "getLatestChangelog", true))
         on { getDatedChangelogForReport("test", now) } doReturn
-                listOf(Changelog("v1", "public", "getByNameAndVersion", true, true))
+                listOf(Changelog("v1", "public", "getByNameAndVersion", true))
     }
 
     private fun createSut(isReviewer: Boolean = false): OrderlyClient
@@ -224,7 +224,7 @@ class OrderlyTests : CleanDatabaseTests()
         val result = sut.getLatestChangelogByName("test")
         assertThat(result.count()).isEqualTo(1)
         assertThat(result[0])
-                .isEqualToComparingFieldByField(Changelog("v1", "public", "getLatestChangelog", true, true))
+                .isEqualToComparingFieldByField(Changelog("v1", "public", "getLatestChangelog", true))
     }
 
     @Test
@@ -234,7 +234,7 @@ class OrderlyTests : CleanDatabaseTests()
         val result = sut.getChangelogByNameAndVersion("test", "v1")
         assertThat(result.count()).isEqualTo(1)
         assertThat(result[0])
-                .isEqualToComparingFieldByField(Changelog("v1", "public", "getByNameAndVersion", true, true))
+                .isEqualToComparingFieldByField(Changelog("v1", "public", "getByNameAndVersion", true))
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/ChangelogTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/ChangelogTests.kt
@@ -52,8 +52,8 @@ class ChangelogTests : CleanDatabaseTests()
         Assertions.assertThat(results.count()).isEqualTo(2)
 
         //changelog items are returned in desc order
-        assertChangelogValuesMatch(results[0], "version1", "internal", "did something awful", false, false)
-        assertChangelogValuesMatch(results[1], "version1", "public", "did something great", true, true)
+        assertChangelogValuesMatch(results[0], "version1", "internal", "did something awful", false)
+        assertChangelogValuesMatch(results[1], "version1", "public", "did something great", true)
     }
 
     @Test
@@ -84,7 +84,7 @@ class ChangelogTests : CleanDatabaseTests()
 
         Assertions.assertThat(results.count()).isEqualTo(1)
 
-        assertChangelogValuesMatch(results[0], "version1", "public", "did something great", true, true)
+        assertChangelogValuesMatch(results[0], "version1", "public", "did something great", true)
     }
 
     @Test
@@ -291,24 +291,24 @@ class ChangelogTests : CleanDatabaseTests()
 
         if (latestVersion == "version3")
         {
-            assertChangelogValuesMatch(results[0], "version3", "internal", "everything is broken", false, false)
-            assertChangelogValuesMatch(results[1], "version3", "internal", "did something awful v3", false, false)
-            assertChangelogValuesMatch(results[2], "version3", "public", "did something great v3", true, true)
+            assertChangelogValuesMatch(results[0], "version3", "internal", "everything is broken", false)
+            assertChangelogValuesMatch(results[1], "version3", "internal", "did something awful v3", false)
+            assertChangelogValuesMatch(results[2], "version3", "public", "did something great v3", true)
 
             index += 3
         }
 
         if (latestVersion == "version2" || index > 0)
         {
-            assertChangelogValuesMatch(results[index], "version2", "public", "did something great v2", true, true)
+            assertChangelogValuesMatch(results[index], "version2", "public", "did something great v2", true)
 
             index++
         }
 
         if (latestVersion == "version1" || index > 0)
         {
-            assertChangelogValuesMatch(results[index], "version1", "internal", "did something awful v1", false, false)
-            assertChangelogValuesMatch(results[index + 1], "version1", "public", "did something great v1", true, true)
+            assertChangelogValuesMatch(results[index], "version1", "internal", "did something awful v1", false)
+            assertChangelogValuesMatch(results[index + 1], "version1", "public", "did something great v1", true)
 
             index += 2
         }
@@ -327,7 +327,7 @@ class ChangelogTests : CleanDatabaseTests()
 
         if (latestVersion == "version3")
         {
-            assertChangelogValuesMatch(results[0], "version3", "public", "did something great v3", true, true)
+            assertChangelogValuesMatch(results[0], "version3", "public", "did something great v3", true)
 
             index++
         }
@@ -335,7 +335,7 @@ class ChangelogTests : CleanDatabaseTests()
         if (latestVersion == "version2" || index > 0)
         {
             //The public version of this changelog item is version3, while the 'real' version is version2
-            assertChangelogValuesMatch(results[index], "version3", "public", "did something great v2", true, true)
+            assertChangelogValuesMatch(results[index], "version3", "public", "did something great v2", true)
 
             index++
         }
@@ -352,11 +352,9 @@ class ChangelogTests : CleanDatabaseTests()
                                            report_version: String,
                                            label: String,
                                            value: String,
-                                           fromFile: Boolean,
                                            public: Boolean)
     {
         Assertions.assertThat(changelog.reportVersion).isEqualTo(report_version)
-        Assertions.assertThat(changelog.fromFile).isEqualTo(fromFile)
         Assertions.assertThat(changelog.label).isEqualTo(label)
         Assertions.assertThat(changelog.value).isEqualTo(value)
         Assertions.assertThat(changelog.public).isEqualTo(public)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
@@ -126,8 +126,8 @@ class ReportControllerTests : ControllerTest()
         val reportName = "reportName"
 
         val latestVersion = "latestVersion"
-        val changelogs = listOf(Changelog(latestVersion, "public", "did a thing", true, true),
-                Changelog(latestVersion, "public", "did another thing", true, true))
+        val changelogs = listOf(Changelog(latestVersion, "public", "did a thing", true),
+                Changelog(latestVersion, "public", "did another thing", true))
 
         val orderly = mock<OrderlyClient> {
             on { this.getLatestChangelogByName(reportName) } doReturn changelogs

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
@@ -130,8 +130,8 @@ class VersionControllerTests : ControllerTest()
     @Test
     fun `getChangelogByNameAndVersion returns changelog`()
     {
-        val changelogs = listOf(Changelog(reportVersion, "public", "did a thing", true, true),
-                Changelog(reportVersion, "public", "did another thing", true, true))
+        val changelogs = listOf(Changelog(reportVersion, "public", "did a thing", true),
+                Changelog(reportVersion, "public", "did another thing", true))
 
         val orderly = mock<OrderlyClient> {
             on { this.getChangelogByNameAndVersion(reportName, reportVersion) } doReturn changelogs

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
@@ -30,10 +30,10 @@ class GetByNameAndVersionTests : TeamcityTests()
             listOf(),
             mapOf("p1" to "v1", "p2" to "v2"))
 
-    private val mockChangelog = listOf(Changelog("20160103-143015-1234abcd", "internal", "something internal", true, false),
-            Changelog("20160103-143015-1234abcd", "public", "something public", true, true),
-            Changelog("20170106-143015-1234abcd", "internal", "something internal in 2017", true, false),
-            Changelog("20180103-143015-1234abcd", "public", "something public in 2018", true, true))
+    private val mockChangelog = listOf(Changelog("20160103-143015-1234abcd", "internal", "something internal", false),
+            Changelog("20160103-143015-1234abcd", "public", "something public", true),
+            Changelog("20170106-143015-1234abcd", "internal", "something internal in 2017", false),
+            Changelog("20180103-143015-1234abcd", "public", "something public in 2018", true))
 
     private val mockActionContext = mock<ActionContext> {
         on { this.params(":name") } doReturn "r1"

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/ReportDraftTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/ReportDraftTests.kt
@@ -71,8 +71,8 @@ class ReportDraftTests : TeamcityTests()
                         date,
                         false,
                         mapOf("p1" to "param1", "p2" to "param2"),
-                        listOf(Changelog("v1-1", "public", "something public", true, true),
-                                Changelog("v1-1", "internal", "something internal", true, false))))
+                        listOf(Changelog("v1-1", "public", "something public", true),
+                                Changelog("v1-1", "internal", "something internal", false))))
 
         val result = sut.getReportDrafts(fakeReports, fakeDrafts)
         assertThat(result.count()).isEqualTo(1)
@@ -91,8 +91,8 @@ class ReportDraftTests : TeamcityTests()
                         date,
                         false,
                         mapOf("p1" to "param1", "p2" to "param2"),
-                        listOf(Changelog("v1-1", "published", "something public", true, true),
-                                Changelog("v1-1", "draft", "something internal", true, false))))
+                        listOf(Changelog("v1-1", "published", "something public", true),
+                                Changelog("v1-1", "draft", "something internal", false))))
 
         val result = sut.getReportDrafts(fakeReports, fakeDrafts)
         val draft = result[0].dateGroups[0].drafts[0]


### PR DESCRIPTION
`changelog.fromFile` is an internal orderly property that never gets reflected back out to the client, so we should just drop it from our internal changelog model