### PR TITLE
mrc-1684 only show new version when run is complete

### DIFF
--- a/src/app/static/src/js/components/reports/runReportInline.vue
+++ b/src/app/static/src/js/components/reports/runReportInline.vue
@@ -18,7 +18,7 @@
         <button v-on:click="confirmRun" class="btn mt-2" type="submit">Run report</button>
         <div id="run-report-status" v-if="runningStatus" class="text-secondary mt-2">
             Running status: {{runningStatus}}
-            <div v-if="newVersionFromRun" id="run-report-new-version">
+            <div v-if="runHasCompleted && newVersionFromRun" id="run-report-new-version">
                 New version: <a v-bind:href="newVersionHref">{{newVersionDisplayName}}</a>
             </div>
             <button v-on:click="dismissRunStatus" id="run-report-dismiss" class="btn btn-link">Dismiss</button>

--- a/src/app/static/src/js/components/reports/runReportInline.vue
+++ b/src/app/static/src/js/components/reports/runReportInline.vue
@@ -9,19 +9,19 @@
                     <div class="mb-2 font-weight-bold">Confirm run report</div>
                     <div class="mb-2">Are you sure you want to run this report?</div>
                     <div class="modal-buttons">
-                        <button v-on:click="run" id="confirm-run-btn" class="btn submit mr-3">Yes</button>
-                        <button v-on:click="cancelRun" id="cancel-run-btn" class="btn btn-default">No</button>
+                        <button @click="run" id="confirm-run-btn" class="btn submit mr-3">Yes</button>
+                        <button @click="cancelRun" id="cancel-run-btn" class="btn btn-default">No</button>
                     </div>
                 </div>
             </div>
         </div>
-        <button v-on:click="confirmRun" class="btn mt-2" type="submit">Run report</button>
+        <button @click="confirmRun" class="btn mt-2" type="submit">Run report</button>
         <div id="run-report-status" v-if="runningStatus" class="text-secondary mt-2">
             Running status: {{runningStatus}}
             <div v-if="runHasCompleted && newVersionFromRun" id="run-report-new-version">
                 New version: <a v-bind:href="newVersionHref">{{newVersionDisplayName}}</a>
             </div>
-            <button v-on:click="dismissRunStatus" id="run-report-dismiss" class="btn btn-link">Dismiss</button>
+            <button @click="dismissRunStatus" id="run-report-dismiss" class="btn btn-link">Dismiss</button>
         </div>
     </div>
 </template>

--- a/src/app/static/src/js/report.js
+++ b/src/app/static/src/js/report.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import $ from 'jquery';
 
 import publishSwitch from './components/reports/publishSwitch.vue'
-import runReport from './components/reports/runReportInline.vue'
+import runReportInline from './components/reports/runReportInline.vue'
 import globalReportReadersList from './components/reports/globalReportReadersList'
 import reportReadersList from './components/reports/reportReadersList.vue'
 import globalReaderRolesList from './components/reports/globalReportReaderRolesList.vue'
@@ -37,7 +37,7 @@ $(document).ready(() => {
             el: '#runReportVueApp',
             data: data,
             components: {
-                runReport: runReport
+                runReportInline
             }
         });
     }

--- a/src/app/static/src/js/report.js
+++ b/src/app/static/src/js/report.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import $ from 'jquery';
 
 import publishSwitch from './components/reports/publishSwitch.vue'
-import runReport from './components/reports/runReport.vue'
+import runReport from './components/reports/runReportInline.vue'
 import globalReportReadersList from './components/reports/globalReportReadersList'
 import reportReadersList from './components/reports/reportReadersList.vue'
 import globalReaderRolesList from './components/reports/globalReportReaderRolesList.vue'

--- a/src/app/templates/report-page.ftl
+++ b/src/app/templates/report-page.ftl
@@ -54,7 +54,7 @@
                             </#if>
                             <#if isRunner || !fineGrainedAuth>
                                 <div id="runReportVueApp" class="mt-5">
-                                    <run-report :report=report></run-report>
+                                    <run-report-inline :report=report></run-report-inline>
                                 </div>
                             </#if>
                         </div>


### PR DESCRIPTION
At the moment, the new report version link appears before the version page actually exists. I found this recently when running a report and it was very confusing! I thought something had gone wrong and so ended up running the report multiple times.