### PR TITLE
mrc-1687 add endpoint for bulk publishing

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
@@ -43,6 +43,7 @@ object WebReportRouteConfig : RouteConfig
                     "/publish-reports/",
                     ReportController::class, "publishReports")
                     .post()
+                    .json()
                     .secure(reviewReports)
     )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
@@ -40,7 +40,7 @@ object WebReportRouteConfig : RouteConfig
                     ReportController::class, "getRunReport")
                     .secure(runReports),
             WebEndpoint(
-                    "/publish-reports/",
+                    "/bulk-publish/",
                     ReportController::class, "publishReports")
                     .post()
                     .json()

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
@@ -10,6 +10,7 @@ object WebReportRouteConfig : RouteConfig
 {
     private val readReports = setOf("report:<name>/reports.read")
     private val runReports = setOf("*/reports.run")
+    private val reviewReports = setOf("*/reports.review")
     private val configureReports = setOf("*/pinned-reports.manage")
 
     override val endpoints = listOf(
@@ -37,6 +38,11 @@ object WebReportRouteConfig : RouteConfig
             WebEndpoint(
                     "/run-report/",
                     ReportController::class, "getRunReport")
-                    .secure(runReports)
+                    .secure(runReports),
+            WebEndpoint(
+                    "/publish-reports/",
+                    ReportController::class, "publishReports")
+                    .post()
+                    .secure(reviewReports)
     )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -90,8 +90,10 @@ class ReportController(context: ActionContext,
         return okayResponse()
     }
 
-    fun publishReports() {
+    fun publishReports(): String
+    {
         val ids = context.postData<List<String>>("ids")
         reportRepository.publish(ids)
+        return okayResponse()
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -89,4 +89,9 @@ class ReportController(context: ActionContext,
 
         return okayResponse()
     }
+
+    fun publishReports() {
+        val ids = context.postData<List<String>>("ids")
+        reportRepository.publish(ids)
+    }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
@@ -43,6 +43,8 @@ interface ReportRepository
 
     fun getReportsWithPublishStatus(): List<ReportWithPublishStatus>
 
+    fun publish(ids: List<String>)
+
 }
 
 class OrderlyReportRepository(val isReviewer: Boolean,
@@ -351,6 +353,16 @@ class OrderlyReportRepository(val isReviewer: Boolean,
                     .on(ORDERLYWEB_REPORT_VERSION_FULL.REPORT.eq(REPORT.NAME))
                     .orderBy(ORDERLYWEB_REPORT_VERSION_FULL.DATE.desc())
                     .fetchInto(ReportWithPublishStatus::class.java)
+        }
+    }
+
+    override fun publish(ids: List<String>)
+    {
+        JooqContext().use {
+            it.dsl.update(ORDERLYWEB_REPORT_VERSION)
+                    .set(ORDERLYWEB_REPORT_VERSION.PUBLISHED, true)
+                    .where(ORDERLYWEB_REPORT_VERSION.ID.`in`(ids))
+                    .execute()
         }
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/VersionTests.kt
@@ -295,4 +295,19 @@ class VersionTests : CleanDatabaseTests()
         }.isInstanceOf(UnknownObjectError::class.java)
     }
 
+    @Test
+    fun `can publish multiple versions at once`()
+    {
+        insertReport("test", "v1", published = false)
+        insertReport("test", "v2", published = false)
+        insertReport("anotherreport", "b1", published = false)
+
+        val sut = createSut(true)
+        sut.publish(listOf("v1", "b1"))
+
+        assertThat(sut.getReportVersion("test", "v1").published).isTrue()
+        assertThat(sut.getReportVersion("test", "v2").published).isFalse()
+        assertThat(sut.getReportVersion("anotherreport", "b1").published).isTrue()
+    }
+
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportTests.kt
@@ -6,6 +6,7 @@ import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyReportRepository
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
 import spark.route.HttpMethod
 
@@ -50,5 +51,31 @@ class ReportTests : IntegrationTest()
         val pinnedReports = OrderlyReportRepository(true, true).getGlobalPinnedReports()
         assertThat(pinnedReports.count()).isEqualTo(1)
         assertThat(pinnedReports[0].name).isEqualTo("html")
+    }
+
+    @Test
+    fun `only report reviewers can publish reports`()
+    {
+        val url = "/publish-reports"
+        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.review", Scope.Global())),
+                method = HttpMethod.post, contentType = ContentTypes.json)
+    }
+
+    @Test
+    fun `report reviewers can publish reports`()
+    {
+        insertReport("report", "v1", published = false)
+        insertReport("report", "v2", published = false)
+
+        val url = "/publish-reports"
+        webRequestHelper.loginWithMontaguAndMakeRequest(url,
+                setOf(ReifiedPermission("reports.review", Scope.Global())),
+                method = HttpMethod.post,
+                postData = mapOf("ids" to listOf("v1", "v2")),
+                contentType = ContentTypes.json)
+
+        val repo = OrderlyReportRepository(true, true)
+        assertThat(repo.getReportVersion("report", "v1").published).isTrue()
+        assertThat(repo.getReportVersion("report", "v2").published).isTrue()
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportTests.kt
@@ -56,7 +56,7 @@ class ReportTests : IntegrationTest()
     @Test
     fun `only report reviewers can publish reports`()
     {
-        val url = "/publish-reports/"
+        val url = "/bulk-publish/"
         assertWebUrlSecured(url,
                 setOf(ReifiedPermission("reports.review", Scope.Global())),
                 method = HttpMethod.post,
@@ -70,7 +70,7 @@ class ReportTests : IntegrationTest()
         insertReport("report", "v1", published = false)
         insertReport("report", "v2", published = false)
 
-        val url = "/publish-reports/"
+        val url = "/bulk-publish/"
         webRequestHelper.loginWithMontaguAndMakeRequest(url,
                 setOf(ReifiedPermission("reports.review", Scope.Global())),
                 method = HttpMethod.post,

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportTests.kt
@@ -56,9 +56,12 @@ class ReportTests : IntegrationTest()
     @Test
     fun `only report reviewers can publish reports`()
     {
-        val url = "/publish-reports"
-        assertWebUrlSecured(url, setOf(ReifiedPermission("reports.review", Scope.Global())),
-                method = HttpMethod.post, contentType = ContentTypes.json)
+        val url = "/publish-reports/"
+        assertWebUrlSecured(url,
+                setOf(ReifiedPermission("reports.review", Scope.Global())),
+                method = HttpMethod.post,
+                contentType = ContentTypes.json,
+                postData = mapOf("ids" to listOf("v1")))
     }
 
     @Test
@@ -67,7 +70,7 @@ class ReportTests : IntegrationTest()
         insertReport("report", "v1", published = false)
         insertReport("report", "v2", published = false)
 
-        val url = "/publish-reports"
+        val url = "/publish-reports/"
         webRequestHelper.loginWithMontaguAndMakeRequest(url,
                 setOf(ReifiedPermission("reports.review", Scope.Global())),
                 method = HttpMethod.post,
@@ -75,6 +78,7 @@ class ReportTests : IntegrationTest()
                 contentType = ContentTypes.json)
 
         val repo = OrderlyReportRepository(true, true)
+
         assertThat(repo.getReportVersion("report", "v1").published).isTrue()
         assertThat(repo.getReportVersion("report", "v2").published).isTrue()
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/PublishTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/PublishTests.kt
@@ -15,7 +15,7 @@ class PublishTests : TeamcityTests() {
     fun `can publish multiple versions`() {
         val mockRepo = mock<ReportRepository>()
         val mockContext = mock<ActionContext> {
-            on { postData<List<String>>("versions")} doReturn listOf("v1", "v2")
+            on { postData<List<String>>("ids")} doReturn listOf("v1", "v2")
         }
         val sut = ReportController(mockContext, mock(), mockRepo, mock())
         sut.publishReports()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/PublishTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/PublishTests.kt
@@ -1,0 +1,25 @@
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.controllers.web.ReportController
+import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
+import org.vaccineimpact.orderlyweb.test_helpers.TeamcityTests
+
+class PublishTests : TeamcityTests() {
+
+    @Test
+    fun `can publish multiple versions`() {
+        val mockRepo = mock<ReportRepository>()
+        val mockContext = mock<ActionContext> {
+            on { postData<List<String>>("versions")} doReturn listOf("v1", "v2")
+        }
+        val sut = ReportController(mockContext, mock(), mockRepo, mock())
+        sut.publishReports()
+
+        verify(mockRepo).publish(listOf("v1", "v2"))
+    }
+}


### PR DESCRIPTION
Adds a web endpoint, locked down to report reviewers, that accepts a list of ids and publishes the corresponding reports.