### PR TITLE
mrc-1689 option to only show previously published reports on bulk publish page

### DIFF
--- a/src/app/static/src/js/components/publishReports/publishReports.vue
+++ b/src/app/static/src/js/components/publishReports/publishReports.vue
@@ -1,7 +1,15 @@
 <template>
     <div>
-        <h2 class="h4 mb-4">Latest drafts</h2>
-        <div v-for="report in reportsWithDrafts" class="report">
+        <div class="mb-4">
+            <label class="font-weight-bold h5 mb-4 d-inline">Latest drafts</label>
+            <div class="h5 ml-4 d-inline custom-control custom-checkbox">
+                <input type="checkbox" class="custom-control-input" id="publishedOnly" v-model="publishedOnly">
+                <label class="custom-control-label" for="publishedOnly">
+                    Only show reports with previously published versions
+                </label>
+            </div>
+        </div>
+        <div v-for="report in reportsWithDrafts" v-if="!publishedOnly || report.previously_published" class="report">
             <h5>{{report.display_name}}</h5>
             <div class="ml-5">
                 <date-group v-for="group in report.date_groups"
@@ -17,6 +25,11 @@
     export default {
         name: "publishReports",
         components: {DateGroup},
-        props: ["reportsWithDrafts"]
+        props: ["reportsWithDrafts"],
+        data() {
+            return {
+                publishedOnly: false
+            }
+        }
     }
 </script>

--- a/src/app/static/src/tests/components/publishReports/publishReports.test.js
+++ b/src/app/static/src/tests/components/publishReports/publishReports.test.js
@@ -1,3 +1,4 @@
+import Vue from "vue";
 import publishReports from "../../../js/components/publishReports/publishReports";
 import {shallowMount} from "@vue/test-utils";
 import dateGroup from "../../../js/components/publishReports/dateGroup";
@@ -59,7 +60,20 @@ describe("publishReports", () => {
 
     it("renders title", () => {
         const rendered = shallowMount(publishReports, {propsData: {reportsWithDrafts: testReportsWithDrafts}});
-        expect(rendered.find("h2").text()).toBe("Latest drafts")
-    })
+        expect(rendered.find("label").text()).toBe("Latest drafts")
+    });
+
+    it("displays only previously published reports when option is checked", async () => {
+        const rendered = shallowMount(publishReports, {propsData: {reportsWithDrafts: testReportsWithDrafts}});
+        let reports = rendered.findAll(".report");
+        expect(reports.length).toBe(2);
+        rendered.find("input").setChecked(true);
+
+        await Vue.nextTick();
+
+        reports = rendered.findAll(".report");
+        expect(reports.length).toBe(1);
+        expect(reports.at(0).find("h5").text()).toBe("another report");
+    });
 
 });


### PR DESCRIPTION
Contains commits from https://github.com/vimc/orderly-web/pull/249 which should be merged first, then the base of this PR set to master.