### PR TITLE
mrc-1690 expand/collapse all changelogs on bulk publish page

### DIFF
--- a/src/app/static/src/js/components/publishReports/dateGroup.vue
+++ b/src/app/static/src/js/components/publishReports/dateGroup.vue
@@ -1,17 +1,21 @@
 <template>
-<div>
-    <h6>{{date}}</h6>
-    <div class="ml-4">
-        <report-draft v-for="draft in drafts" :draft="draft"></report-draft>
+    <div>
+        <h6>{{date}}</h6>
+        <div class="ml-4">
+            <report-draft v-for="draft in drafts"
+                          :draft="draft"
+                          :expand="expand"
+                          :collapse="collapse"></report-draft>
+        </div>
     </div>
-</div>
 </template>
 
 <script>
     import ReportDraft from "./reportDraft";
+
     export default {
         name: "dateGroup",
         components: {ReportDraft},
-        props: ["date", "drafts"]
+        props: ["date", "drafts", "expand", "collapse"]
     }
 </script>

--- a/src/app/static/src/js/components/publishReports/publishReports.vue
+++ b/src/app/static/src/js/components/publishReports/publishReports.vue
@@ -1,12 +1,23 @@
 <template>
     <div>
-        <h2 class="h4 mb-4">Latest drafts</h2>
+        <div class="mb-4">
+            <h2 class="h4 mb-4">Latest drafts</h2>
+            <a href="#" @click="expandChangelogs">
+                Expand all changelogs
+            </a>
+            <span>&nbsp;/&nbsp;</span>
+            <a href="#" @click="collapseChangelogs">
+                Collapse all changelogs
+            </a>
+        </div>
         <div v-for="report in reportsWithDrafts" class="report">
             <h5>{{report.display_name}}</h5>
             <div class="ml-5">
                 <date-group v-for="group in report.date_groups"
                             :date="group.date"
-                            :drafts="group.drafts"></date-group>
+                            :drafts="group.drafts"
+                            :expand="expand"
+                            :collapse="collapse"></date-group>
             </div>
         </div>
     </div>
@@ -17,6 +28,22 @@
     export default {
         name: "publishReports",
         components: {DateGroup},
-        props: ["reportsWithDrafts"]
+        props: ["reportsWithDrafts"],
+        data() {
+            return {
+                expand: 0,
+                collapse: 0
+            }
+        },
+        methods: {
+            expandChangelogs(e) {
+                e.preventDefault();
+                this.expand = this.expand + 1;
+            },
+            collapseChangelogs(e) {
+                e.preventDefault();
+                this.collapse = this.collapse + 1;
+            }
+        }
     }
 </script>

--- a/src/app/static/src/js/components/publishReports/reportDraft.vue
+++ b/src/app/static/src/js/components/publishReports/reportDraft.vue
@@ -16,7 +16,7 @@
 <script>
     export default {
         name: 'reportDraft',
-        props: ['draft'],
+        props: ['draft', 'expand', 'collapse'],
         data() {
             return {
                 showChangelog: false
@@ -26,6 +26,14 @@
             toggleChangelog(e) {
                 e.preventDefault();
                 this.showChangelog = !this.showChangelog;
+            }
+        },
+        watch: {
+            expand() {
+                this.showChangelog = true;
+            },
+            collapse() {
+                this.showChangelog = false;
             }
         }
     }

--- a/src/app/static/src/tests/components/publishReports/publishReports.test.js
+++ b/src/app/static/src/tests/components/publishReports/publishReports.test.js
@@ -1,5 +1,6 @@
+import Vue from "vue";
 import publishReports from "../../../js/components/publishReports/publishReports";
-import {shallowMount} from "@vue/test-utils";
+import {mount, shallowMount} from "@vue/test-utils";
 import dateGroup from "../../../js/components/publishReports/dateGroup";
 
 describe("publishReports", () => {
@@ -29,6 +30,24 @@ describe("publishReports", () => {
                 }
             ]
         }]
+
+    const fakeDraft = {
+        "id": "20190824-161244-6e9b57d4",
+        "url": "http://localhost:8888/changelog/20190824-161244-6e9b57d4",
+        "changelog": [
+            {
+                "label": "public",
+                "value": "You think water moves fast? You should see ice. It moves like it has\na mind. Like it knows it killed the world once and got a taste for\nmurder. After the avalanche, it took us a week to climb out. Now, I\ndon't know exactly when we turned on each other, but I know that\nseven of us survived the slide... and only five made it out. Now we\ntook an oath, that I'm breaking now. We said we'd say it was the\nsnow that killed the other two, but it wasn't. Nature is lethal but\nit doesn't hold a candle to man.",
+                "css_class": "public"
+            },
+            {
+                "label": "internal",
+                "value": "Do you see any Teletubbies in here? Do you see a slender plastic tag\nclipped to my shirt with my name printed on it? Do you see a little\nAsian child with a blank expression on his face sitting outside on a\nmechanical helicopter that shakes when you put quarters in it? No?\nWell, that's what you see at a toy store. And you must think you're in\na toy store, because you're here shopping for an infant named Jeb.",
+                "css_class": "internal"
+            }
+        ],
+        "parameter_values": "nmin=0"
+    }
 
     it("displays report names", () => {
         const rendered = shallowMount(publishReports, {propsData: {reportsWithDrafts: testReportsWithDrafts}});
@@ -60,6 +79,32 @@ describe("publishReports", () => {
     it("renders title", () => {
         const rendered = shallowMount(publishReports, {propsData: {reportsWithDrafts: testReportsWithDrafts}});
         expect(rendered.find("h2").text()).toBe("Latest drafts")
-    })
+    });
+
+    it("can expand all changelogs", async () => {
+        const testReportsWithChangelogs = [...testReportsWithDrafts];
+        testReportsWithChangelogs[0].date_groups[0].drafts = [fakeDraft];
+        testReportsWithChangelogs[1].date_groups[0].drafts = [fakeDraft];
+
+        const rendered = mount(publishReports, {propsData: {reportsWithDrafts: testReportsWithChangelogs}});
+
+        expect(rendered.findAll(".changelog").length).toBe(4);
+        expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(0);
+
+        const links = rendered.findAll("a");
+        links.at(0).trigger("click");
+
+        await Vue.nextTick();
+
+        expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(4);
+
+        links.at(1).trigger("click");
+
+        await Vue.nextTick();
+
+        expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(0);
+
+    });
+
 
 });

--- a/src/app/static/src/tests/components/publishReports/reportDraft.test.js
+++ b/src/app/static/src/tests/components/publishReports/reportDraft.test.js
@@ -83,4 +83,36 @@ describe("reportDraft", () => {
         expect(logs.at(0).isVisible()).toBe(false);
         expect(logs.at(1).isVisible()).toBe(false);
     });
+
+    it("collapses changelog if collapse increments", async () => {
+        const rendered = shallowMount(reportDraft, {propsData: {draft: fakeDraft, collapse: 0}});
+        expect(rendered.findAll(".changelog").length).toBe(2);
+        expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(0);
+
+        const toggleLink = rendered.find(".changelog-container").find("a");
+        toggleLink.trigger("click");
+
+        await Vue.nextTick();
+
+        expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(2);
+
+        rendered.setProps({collapse: 1});
+
+        await Vue.nextTick();
+
+        expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(0);
+    });
+
+    it("expands changelog if expand increments", async () => {
+        const rendered = shallowMount(reportDraft, {propsData: {draft: fakeDraft, expand: 0}});
+        expect(rendered.findAll(".changelog").length).toBe(2);
+        expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(0);
+
+        rendered.setProps({expand: 1});
+
+        await Vue.nextTick();
+
+        expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(2);
+    });
+
 });


### PR DESCRIPTION
As requested by Kim on the mockups, a way to open/close all changelogs on the page at once.

Contains commits from https://github.com/vimc/orderly-web/pull/249, should be merged first and the base of this PR returned to `master`.

There are some file conflicts, probably easiest to merge https://github.com/vimc/orderly-web/pull/251 first and then I'll fix them.