### PR TITLE
mrc-1688 publish report page - allow reports to be selected 

### DIFF
--- a/src/.idea/codeStyles/Project.xml
+++ b/src/.idea/codeStyles/Project.xml
@@ -3,6 +3,12 @@
     <JetCodeStyleSettings>
       <option name="LBRACE_ON_NEXT_LINE" value="true" />
     </JetCodeStyleSettings>
+    <codeStyleSettings language="Vue">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="ELSE_ON_NEW_LINE" value="true" />
       <option name="CATCH_ON_NEW_LINE" value="true" />

--- a/src/app/static/src/js/components/publishReports/dateGroup.vue
+++ b/src/app/static/src/js/components/publishReports/dateGroup.vue
@@ -1,9 +1,20 @@
 <template>
     <div>
-        <h6>{{date}}</h6>
+        <div class="pr-2 d-inline custom-control custom-checkbox">
+            <input type="checkbox"
+                   class="custom-control-input"
+                   v-model="selected"
+                   :id="date">
+            <label class="custom-control-label h6"
+                   :for="date">
+                {{date}}
+            </label>
+        </div>
         <div class="ml-4">
             <report-draft v-for="draft in drafts"
                           :draft="draft"
+                          :selected-ids="selectedIds"
+                          @select-draft="handleDraftSelect"
                           :expand-clicked="expandClicked"
                           :collapse-clicked="collapseClicked"></report-draft>
         </div>
@@ -11,11 +22,40 @@
 </template>
 
 <script>
-    import ReportDraft from "./reportDraft";
+import ReportDraft from "./reportDraft";
 
-    export default {
-        name: "dateGroup",
-        components: {ReportDraft},
-        props: ["date", "drafts", "expandClicked", "collapseClicked"]
+export default {
+    name: "dateGroup",
+    components: {ReportDraft},
+    props: ["date", "drafts", "selectedIds", "selectedDates", "expandClicked", "collapseClicked"],
+    computed: {
+        selected: {
+            get() {
+                return this.selectedDates[this.date]
+            },
+            set(value) {
+                this.$emit("select-draft", {ids: this.draftIds, value});
+                this.$emit("select-group", {date: this.date, value});
+            }
+        },
+        draftIds() {
+            return this.drafts.map(d => d.id);
+        }
+    },
+    methods: {
+        selectGroup(e) {
+            const value = e.target.checked
+            this.selected = value
+            this.$emit("select-draft", {ids: this.draftIds, value});
+            this.$emit("select-group", {date: this.date, value});
+        },
+        handleDraftSelect(value) {
+            if (!value.value) {
+                // don't want the parent checkbox selected if any child is not
+                this.$emit("select-group", {date: this.date, value: false});
+            }
+            this.$emit("select-draft", value)
+        }
     }
+}
 </script>

--- a/src/app/static/src/js/components/publishReports/dateGroup.vue
+++ b/src/app/static/src/js/components/publishReports/dateGroup.vue
@@ -43,12 +43,6 @@ export default {
         }
     },
     methods: {
-        selectGroup(e) {
-            const value = e.target.checked
-            this.selected = value
-            this.$emit("select-draft", {ids: this.draftIds, value});
-            this.$emit("select-group", {date: this.date, value});
-        },
         handleDraftSelect(value) {
             if (!value.value) {
                 // don't want the parent checkbox selected if any child is not

--- a/src/app/static/src/js/components/publishReports/publishReports.vue
+++ b/src/app/static/src/js/components/publishReports/publishReports.vue
@@ -32,65 +32,81 @@
     </div>
 </template>
 <script>
-    import Report from "./report";
-    import {api} from "../../utils/api";
+import Report from "./report";
+import {api} from "../../utils/api";
 
-    export default {
-        name: "publishReports",
-        components: {Report},
-        data() {
-            return {
-                selectedDates: {},
-                selectedIds: {},
-                reportsWithDrafts: [],
-                publishedOnly: false,
-                expandClicked: 0,
-                collapseClicked: 0
-            }
-        },
-        methods: {
-            handleDraftSelect(value) {
-                if (value.id) {
-                    this.selectedIds[value.id] = value.value
-                }
-                if (value.ids) {
-                    value.ids.map(id => this.selectedIds[id] = value.value)
-                }
-            },
-            handleGroupSelect(value) {
-                if (value.date) {
-                    this.selectedDates[value.date] = value.value
-                }
-                if (value.dates) {
-                    value.dates.map(d => this.selectedDates[d] = value.value)
-                }
-            },
-            getReportsWithDrafts() {
-                api.get("/report-drafts/")
-                    .then(({data}) => {
-                        const selectedIds = {}
-                        const selectedDates = {}
-                        data.data.map(r => r.date_groups
-                            .map(g => {
-                                selectedDates[g.date] = false;
-                                g.drafts.map(d => selectedIds[d.id] = false)
-                            }));
-                        this.selectedDates = selectedDates
-                        this.selectedIds = selectedIds
-                        this.reportsWithDrafts = data.data
-                    })
-            },
-            expandChangelogs(e) {
-                e.preventDefault();
-                this.expandClicked = this.expandClicked + 1;
-            },
-            collapseChangelogs(e) {
-                e.preventDefault();
-                this.collapseClicked = this.collapseClicked + 1;
-            }
-        },
-        mounted() {
-            this.getReportsWithDrafts();
+export default {
+    name: "publishReports",
+    components: {Report},
+    data() {
+        return {
+            selectedDates: {},
+            selectedIds: {},
+            reportsWithDrafts: [],
+            publishedOnly: false,
+            expandClicked: 0,
+            collapseClicked: 0
         }
+    },
+    methods: {
+        handleDraftSelect(value) {
+            if (value.id) {
+                this.selectedIds[value.id] = value.value
+            }
+            if (value.ids) {
+                value.ids.map(id => this.selectedIds[id] = value.value)
+            }
+        },
+        handleGroupSelect(value) {
+            if (value.date) {
+                this.selectedDates[value.date] = value.value
+            }
+            if (value.dates) {
+                value.dates.map(d => this.selectedDates[d] = value.value)
+            }
+        },
+        getReportsWithDrafts() {
+            api.get("/report-drafts/")
+                .then(({data}) => {
+                    const selectedIds = {}
+                    const selectedDates = {}
+                    data.data.map(r => r.date_groups
+                        .map(g => {
+                            selectedDates[g.date] = false;
+                            g.drafts.map(d => selectedIds[d.id] = false)
+                        }));
+                    this.selectedDates = selectedDates
+                    this.selectedIds = selectedIds
+                    this.reportsWithDrafts = data.data
+                })
+        },
+        expandChangelogs(e) {
+            e.preventDefault();
+            this.expandClicked = this.expandClicked + 1;
+        },
+        collapseChangelogs(e) {
+            e.preventDefault();
+            this.collapseClicked = this.collapseClicked + 1;
+        }
+    },
+    watch: {
+        publishedOnly(newVal) {
+            if (newVal) {
+                this.reportsWithDrafts.map(r => {
+                    if (!r.previously_published) {
+                        // if this report has not been published, deselect all its dates and drafts
+                        r.date_groups
+                            .map(g => {
+                                this.selectedDates[g.date] = false;
+                                g.drafts.map(d => this.selectedIds[d.id] = false)
+                            })
+                    }
+                });
+            }
+        }
+    },
+    mounted() {
+        this.getReportsWithDrafts();
     }
+}
 </script>

--- a/src/app/static/src/js/components/publishReports/report.vue
+++ b/src/app/static/src/js/components/publishReports/report.vue
@@ -52,7 +52,6 @@ export default {
         },
         handleDraftSelect(value) {
             if (!value.value) {
-                console.log("hi")
                 // don't want the parent checkbox selected if any child is not
                 this.selected = false
             }

--- a/src/app/static/src/js/components/publishReports/report.vue
+++ b/src/app/static/src/js/components/publishReports/report.vue
@@ -1,0 +1,65 @@
+<template>
+    <div class="report">
+        <div class="pr-2 d-inline custom-control custom-checkbox">
+            <input type="checkbox"
+                   class="custom-control-input"
+                   :checked="selected"
+                   @change="selectReport"
+                   :id="report.display_name">
+            <label class="custom-control-label h5"
+                   :for="report.display_name">
+                {{ report.display_name }}
+            </label>
+        </div>
+        <div class="ml-4 mt-2">
+            <date-group v-for="group in report.date_groups"
+                        :date="group.date"
+                        :drafts="group.drafts"
+                        :selected-ids="selectedIds"
+                        :selected-dates="selectedDates"
+                        @select-draft="handleDraftSelect"
+                        @select-group="handleGroupSelect"
+                        :expand-clicked="expandClicked"
+                        :collapse-clicked="collapseClicked"></date-group>
+        </div>
+    </div>
+</template>
+<script>
+import DateGroup from "./dateGroup";
+
+export default {
+    components: {DateGroup},
+    props: ["report", "selectedIds", "selectedDates", "expandClicked", "collapseClicked"],
+    data() {
+        return {
+            selected: false
+        }
+    },
+    computed: {
+        dates() {
+            return this.report.date_groups.map(g => g.date)
+        },
+        draftIds() {
+            return [].concat.apply([], this.report.date_groups.map(g => g.drafts.map(d => d.id)))
+        }
+    },
+    methods: {
+        selectReport(e) {
+            const value = e.target.checked
+            this.selected = value
+            this.$emit("select-draft", {ids: this.draftIds, value});
+            this.$emit("select-group", {dates: this.dates, value});
+        },
+        handleDraftSelect(value) {
+            if (!value.value) {
+                // don't want the parent checkbox selected if any child is not
+                this.selected = false
+            }
+            this.$emit("select-draft", value)
+        },
+        handleGroupSelect(value) {
+            this.$emit("select-group", value);
+        }
+    }
+}
+</script>

--- a/src/app/static/src/js/components/publishReports/report.vue
+++ b/src/app/static/src/js/components/publishReports/report.vue
@@ -52,6 +52,7 @@ export default {
         },
         handleDraftSelect(value) {
             if (!value.value) {
+                console.log("hi")
                 // don't want the parent checkbox selected if any child is not
                 this.selected = false
             }

--- a/src/app/static/src/js/components/publishReports/reportDraft.vue
+++ b/src/app/static/src/js/components/publishReports/reportDraft.vue
@@ -1,6 +1,15 @@
 <template>
     <div class="mb-3">
-        <a :href="draft.url">{{draft.id}}</a>
+        <div class="pr-2 d-inline custom-control custom-checkbox">
+            <input type="checkbox"
+                   class="custom-control-input"
+                   v-model="selected"
+                   :id="draft.id">
+            <label class="custom-control-label"
+                   :for="draft.id">
+                <a :href="draft.url">{{draft.id}}</a>
+            </label>
+        </div>
         <span class="text-muted pl-3">{{draft.parameter_values}}</span>
         <div class="changelog-container" :class="{'open': showChangelog}">
             <a v-if="draft.changelog.length > 0" href="#" class="text-muted" @click="toggleChangelog">changelog</a>
@@ -14,27 +23,37 @@
     </div>
 </template>
 <script>
-    export default {
-        name: 'reportDraft',
-        props: ['draft', 'expandClicked', 'collapseClicked'],
-        data() {
-            return {
-                showChangelog: false
-            }
-        },
-        methods: {
-            toggleChangelog(e) {
-                e.preventDefault();
-                this.showChangelog = !this.showChangelog;
-            }
-        },
-        watch: {
-            expandClicked() {
-                this.showChangelog = true;
+export default {
+    name: 'reportDraft',
+    props: ['draft', 'selectedIds', 'expandClicked', 'collapseClicked'],
+    data() {
+        return {
+            showChangelog: false
+        }
+    },
+    computed: {
+        selected: {
+            get() {
+                return this.selectedIds[this.draft.id]
             },
-            collapseClicked() {
-                this.showChangelog = false;
+            set(value) {
+                this.$emit("select-draft", {id: this.draft.id, value})
             }
         }
+    },
+    methods: {
+        toggleChangelog(e) {
+            e.preventDefault();
+            this.showChangelog = !this.showChangelog;
+        }
+    },
+    watch: {
+        expandClicked() {
+            this.showChangelog = true;
+        },
+        collapseClicked() {
+            this.showChangelog = false;
+        }
     }
+}
 </script>

--- a/src/app/static/src/tests/components/publishReports/dateGroup.test.js
+++ b/src/app/static/src/tests/components/publishReports/dateGroup.test.js
@@ -1,6 +1,7 @@
 import dateGroup from "../../../js/components/publishReports/dateGroup";
 import {shallowMount} from "@vue/test-utils";
 import reportDraft from "../../../js/components/publishReports/reportDraft";
+import Vue from "vue";
 
 describe("dateGroup", () => {
     const testDateGroup = {
@@ -22,15 +23,111 @@ describe("dateGroup", () => {
     }
 
     it("displays date", () => {
-        const rendered = shallowMount(dateGroup, {propsData: {date: testDateGroup.date, drafts: testDateGroup.drafts}});
-        expect(rendered.find("h6").text()).toBe("Sat Jul 27 2019");
+        const rendered = shallowMount(dateGroup, {
+            propsData: {
+                date: testDateGroup.date, drafts: testDateGroup.drafts,
+                selectedIds: {}, selectedDates: {}
+            }
+        });
+        expect(rendered.find(".h6").text()).toBe("Sat Jul 27 2019");
     });
 
     it("displays drafts", () => {
-        const rendered = shallowMount(dateGroup, {propsData: {date: testDateGroup.date, drafts: testDateGroup.drafts}});
+        const rendered = shallowMount(dateGroup, {
+            propsData: {
+                date: testDateGroup.date,
+                drafts: testDateGroup.drafts,
+                selectedIds: {},
+                selectedDates: {}
+            }
+        });
         const drafts = rendered.findAll(reportDraft);
         expect(drafts.length).toBe(2);
         expect(drafts.at(0).props("draft")).toEqual(testDateGroup.drafts[0]);
         expect(drafts.at(1).props("draft")).toEqual(testDateGroup.drafts[1]);
     });
+
+    it("input is checked based on selectedDates", async () => {
+        const rendered = shallowMount(dateGroup, {
+            propsData: {
+                selectedDates: {"Sat Jul 27 2019": false},
+                date: testDateGroup.date,
+                drafts: testDateGroup.drafts,
+                selectedIds: {}
+            }
+        });
+
+        expect(rendered.find("input").element.checked).toBe(false);
+
+        rendered.setProps({selectedDates: {"Sat Jul 27 2019": true}});
+
+        await Vue.nextTick();
+
+        expect(rendered.find("input").element.checked).toBe(true);
+    });
+
+    it("emits select-group and select-draft events when checked or un-checked", async () => {
+        const rendered = shallowMount(dateGroup, {
+            propsData: {
+                date: testDateGroup.date,
+                drafts: testDateGroup.drafts,
+                selectedIds: {},
+                selectedDates: {}
+            }
+        });
+
+        rendered.find("input").setChecked(true);
+
+        await Vue.nextTick();
+
+        expect(rendered.emitted("select-draft")[0][0])
+            .toEqual({ids: ["20190727-123215-97e39008", "20190727-201131-d320fa9e"], value: true});
+
+        expect(rendered.emitted("select-group")[0][0])
+            .toEqual({date: "Sat Jul 27 2019", value: true});
+
+        rendered.find("input").setChecked(false);
+
+        await Vue.nextTick();
+
+        expect(rendered.emitted("select-draft")[1][0])
+            .toEqual({ids: ["20190727-123215-97e39008", "20190727-201131-d320fa9e"], value: false});
+
+        expect(rendered.emitted("select-group")[1][0])
+            .toEqual({date: "Sat Jul 27 2019", value: false});
+    });
+
+    it("deselects group if any child is unselected and passes on select-draft event", () => {
+        const rendered = shallowMount(dateGroup, {
+            propsData: {
+                date: testDateGroup.date,
+                drafts: testDateGroup.drafts,
+                selectedIds: {},
+                selectedDates: {}
+            }
+        });
+
+        rendered.find(reportDraft).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: false});
+        expect(rendered.emitted("select-group")[0][0])
+            .toEqual({date: "Sat Jul 27 2019", value: false});
+        expect(rendered.emitted("select-draft")[0][0])
+            .toEqual({id: "20190727-123215-97e39008", value: false});
+    });
+
+    it("passes select-draft event on if any child is selected", () => {
+        const rendered = shallowMount(dateGroup, {
+            propsData: {
+                date: testDateGroup.date,
+                drafts: testDateGroup.drafts,
+                selectedIds: {},
+                selectedDates: {}
+            }
+        });
+
+        rendered.find(reportDraft).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: true});
+        expect(rendered.emitted("select-group")).toBeUndefined();
+        expect(rendered.emitted("select-draft")[0][0])
+            .toEqual({id: "20190727-123215-97e39008", value: true});
+    });
+
 });

--- a/src/app/static/src/tests/components/publishReports/publishReports.test.js
+++ b/src/app/static/src/tests/components/publishReports/publishReports.test.js
@@ -135,6 +135,24 @@ describe("publishReports", () => {
         expect(reports.at(0).props("report")).toEqual(testReportsWithDrafts[0]);
     });
 
+    it("updates selectedIds and selectedDates when only previously published reports option is checked", async () => {
+        const rendered = shallowMount(publishReports);
+        rendered.setData({reportsWithDrafts: testReportsWithDrafts});
+        await Vue.nextTick();
+
+        rendered.find(report).vm.$emit("select-draft", {id: "20190824-161244-6e9b57d4", value: true});
+        expect(rendered.vm.$data["selectedIds"]["20190824-161244-6e9b57d4"]).toBe(true);
+        rendered.find(report).vm.$emit("select-group", {date: "Sat Jul 27 2019", value: true});
+        expect(rendered.vm.$data["selectedDates"]["Sat Jul 27 2019"]).toBe(true);
+
+        rendered.find("input").setChecked(true);
+
+        await Vue.nextTick();
+
+        expect(rendered.vm.$data["selectedIds"]["20190824-161244-6e9b57d4"]).toBe(false);
+        expect(rendered.vm.$data["selectedDates"]["Sat Jul 27 2019"]).toBe(false);
+    });
+
     it("updates selectedIds when select-draft event with single id is emitted", async () => {
         const rendered = shallowMount(publishReports);
         await Vue.nextTick();

--- a/src/app/static/src/tests/components/publishReports/report.test.js
+++ b/src/app/static/src/tests/components/publishReports/report.test.js
@@ -1,0 +1,108 @@
+import {shallowMount} from "@vue/test-utils";
+import dateGroup from "../../../js/components/publishReports/dateGroup";
+import report from "../../../js/components/publishReports/report";
+import Vue from "vue";
+import reportDraft from "../../../js/components/publishReports/reportDraft";
+
+describe("report component", () => {
+
+    const testReport =
+        {
+            "display_name": "another report",
+            "previously_published": true,
+            "date_groups": [
+                {
+                    "date": "Sat Jul 27 2019",
+                    "drafts": [{
+                        "id": "20190727-123215-97e39008",
+                        "url": "http://localhost:8888/other/20190727-123215-97e39008",
+                        "changelog": [],
+                        "parameter_values": ""
+                    }]
+                },
+                {
+                    "date": "Sat Jul 20 2019",
+                    "drafts": [{
+                        "id": "20190727-201131-d320fa9e",
+                        "url": "http://localhost:8888/other/20190720-201131-d320fa9e",
+                        "changelog": [],
+                        "parameter_values": "nmin=0"
+                    }]
+                }]
+        }
+
+    it("displays date groups", async () => {
+        const rendered = shallowMount(report, {propsData: {report: testReport}});
+        const groups = rendered.findAll(dateGroup);
+
+        expect(groups.length).toBe(2);
+        expect(groups.at(0).props("date")).toBe("Sat Jul 27 2019");
+        expect(groups.at(0).props("drafts")).toEqual([{
+            "id": "20190727-123215-97e39008",
+            "url": "http://localhost:8888/other/20190727-123215-97e39008",
+            "changelog": [],
+            "parameter_values": ""
+        }]);
+        expect(groups.at(1).props("date")).toBe("Sat Jul 20 2019");
+        expect(groups.at(1).props("drafts")).toEqual([{
+            "id": "20190727-201131-d320fa9e",
+            "url": "http://localhost:8888/other/20190720-201131-d320fa9e",
+            "changelog": [],
+            "parameter_values": "nmin=0"
+        }]);
+    });
+
+    it("emits select-group and select-draft events when checked or un-checked", async () => {
+        const rendered = shallowMount(report, {propsData: {report: testReport}});
+
+        rendered.find("input").setChecked(true);
+
+        await Vue.nextTick();
+
+        expect(rendered.emitted("select-draft")[0][0])
+            .toEqual({ids: ["20190727-123215-97e39008", "20190727-201131-d320fa9e"], value: true});
+
+        expect(rendered.emitted("select-group")[0][0])
+            .toEqual({dates: ["Sat Jul 27 2019", "Sat Jul 20 2019"], value: true});
+
+        rendered.find("input").setChecked(false);
+
+        await Vue.nextTick();
+
+        expect(rendered.emitted("select-draft")[1][0])
+            .toEqual({ids: ["20190727-123215-97e39008", "20190727-201131-d320fa9e"], value: false});
+
+        expect(rendered.emitted("select-group")[1][0])
+            .toEqual({dates: ["Sat Jul 27 2019", "Sat Jul 20 2019"], value: false});
+    });
+
+    it("deselects report if any child is unselected and passes on select-draft event", async () => {
+        const rendered = shallowMount(report, {propsData: {report: testReport}});
+        rendered.find("input").setChecked(true);
+
+        rendered.find(dateGroup).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: false});
+
+        expect(rendered.emitted("select-draft")[1][0])
+            .toEqual({id: "20190727-123215-97e39008", value: false});
+
+        expect(rendered.vm.$data["selected"]).toBe(false);
+    });
+
+    it("passes select-draft event on if any child is selected", () => {
+        const rendered = shallowMount(report, {propsData: {report: testReport}});
+
+        rendered.find(dateGroup).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: true});
+        expect(rendered.emitted("select-group")).toBeUndefined();
+        expect(rendered.emitted("select-draft")[0][0])
+            .toEqual({id: "20190727-123215-97e39008", value: true});
+    });
+
+    it("passes select-group event on if any child is selected", () => {
+        const rendered = shallowMount(report, {propsData: {report: testReport}});
+
+        rendered.find(dateGroup).vm.$emit("select-group", {date: "Sat Jul 27 2019", value: true});
+        expect(rendered.emitted("select-group")[0][0])
+            .toEqual({date: "Sat Jul 27 2019", value: true});
+    });
+
+});

--- a/src/app/static/src/tests/components/publishReports/reportDraft.test.js
+++ b/src/app/static/src/tests/components/publishReports/reportDraft.test.js
@@ -4,7 +4,7 @@ import reportDraft from "../../../js/components/publishReports/reportDraft";
 
 describe("reportDraft", () => {
 
-    const fakeDraft =  {
+    const fakeDraft = {
         "id": "20190824-161244-6e9b57d4",
         "url": "http://localhost:8888/changelog/20190824-161244-6e9b57d4",
         "changelog": [
@@ -23,18 +23,18 @@ describe("reportDraft", () => {
     }
 
     it("displays link to report", () => {
-        const rendered = shallowMount(reportDraft, {propsData: {draft: fakeDraft}});
+        const rendered = shallowMount(reportDraft, {propsData: {selectedIds: {}, draft: fakeDraft}});
         expect(rendered.find("a").text()).toBe("20190824-161244-6e9b57d4");
         expect(rendered.find("a").attributes("href")).toBe("http://localhost:8888/changelog/20190824-161244-6e9b57d4");
     });
 
     it("displays parameters", () => {
-        const rendered = shallowMount(reportDraft, {propsData: {draft: fakeDraft}});
+        const rendered = shallowMount(reportDraft, {propsData: {selectedIds: {}, draft: fakeDraft}});
         expect(rendered.find("span").text()).toBe("nmin=0");
     });
 
     it("renders changelogs", () => {
-        const rendered = shallowMount(reportDraft, {propsData: {draft: fakeDraft}});
+        const rendered = shallowMount(reportDraft, {propsData: {selectedIds: {}, draft: fakeDraft}});
         const logs = rendered.findAll(".changelog");
         expect(logs.length).toBe(2);
 
@@ -46,14 +46,14 @@ describe("reportDraft", () => {
 
     it("does not render changelog link if there are no changelogs", () => {
         const fakeDraftNoChangelogs = {...fakeDraft, changelog: []};
-        const rendered = shallowMount(reportDraft, {propsData: {draft: fakeDraftNoChangelogs}});
+        const rendered = shallowMount(reportDraft, {propsData: {selectedIds: {}, draft: fakeDraftNoChangelogs}});
 
         expect(rendered.findAll(".changelog").length).toBe(0);
         expect(rendered.find(".changelog-container").findAll("a").length).toBe(0);
     });
 
     it("can toggle changelog visibility", async () => {
-        const rendered = shallowMount(reportDraft, {propsData: {draft: fakeDraft}});
+        const rendered = shallowMount(reportDraft, {propsData: {selectedIds: {}, draft: fakeDraft}});
 
         let logs = rendered.findAll(".changelog");
         expect(logs.at(0).isVisible()).toBe(false);
@@ -85,7 +85,13 @@ describe("reportDraft", () => {
     });
 
     it("collapses changelog if collapse increments", async () => {
-        const rendered = shallowMount(reportDraft, {propsData: {draft: fakeDraft, collapseClicked: 0}});
+        const rendered = shallowMount(reportDraft, {
+            propsData: {
+                selectedIds: {},
+                draft: fakeDraft,
+                collapseClicked: 0
+            }
+        });
         expect(rendered.findAll(".changelog").length).toBe(2);
         expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(0);
 
@@ -104,7 +110,7 @@ describe("reportDraft", () => {
     });
 
     it("expands changelog if expand increments", async () => {
-        const rendered = shallowMount(reportDraft, {propsData: {draft: fakeDraft, expandClicked: 0}});
+        const rendered = shallowMount(reportDraft, {propsData: {selectedIds: {}, draft: fakeDraft, expandClicked: 0}});
         expect(rendered.findAll(".changelog").length).toBe(2);
         expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(0);
 
@@ -113,6 +119,45 @@ describe("reportDraft", () => {
         await Vue.nextTick();
 
         expect(rendered.findAll(".changelog").filter(c => c.isVisible()).length).toBe(2);
+    });
+
+    it("input is checked based on selectedIds", async () => {
+        const rendered = shallowMount(reportDraft, {
+            propsData: {
+                selectedIds: {[fakeDraft.id]: false},
+                draft: fakeDraft
+            }
+        });
+
+        expect(rendered.find("input").element.checked).toBe(false);
+
+        rendered.setProps({selectedIds: {[fakeDraft.id]: true}});
+
+        await Vue.nextTick();
+
+        expect(rendered.find("input").element.checked).toBe(true);
+    });
+
+    it("emits select-draft event when checked or un-checked", async () => {
+        const rendered = shallowMount(reportDraft, {
+            propsData: {
+                selectedIds: {},
+                draft: fakeDraft
+            }
+        });
+
+        rendered.find("input").setChecked(true);
+
+        await Vue.nextTick();
+
+        expect(rendered.emitted("select-draft")[0][0]).toEqual({id: fakeDraft.id, value: true});
+
+        rendered.find("input").setChecked(false);
+
+        await Vue.nextTick();
+
+        expect(rendered.emitted("select-draft")[1][0]).toEqual({id: fakeDraft.id, value: false});
+
     });
 
 });


### PR DESCRIPTION
This PR adds the ability to select report drafts (by report, date, or individually), ahead of being able to publish them. For another ticket - a select all / deselect all option will be useful.