### PR TITLE
vimc-4228 always use public docker hub for proxy image

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   proxy:
-    image: docker.montagu.dide.ic.ac.uk:5000/montagu-reverse-proxy-minimal:master
+    image: vimc/montagu-reverse-proxy-minimal:master
     ports:
     - 80:80
     depends_on:


### PR DESCRIPTION
Should be merged along with https://github.com/vimc/montagu-proxy/pull/54