### PR TITLE
mrc-1601 add utils to orderlyserver api client

### DIFF
--- a/src/.idea/codeStyles/Project.xml
+++ b/src/.idea/codeStyles/Project.xml
@@ -1,6 +1,22 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="LBRACE_ON_NEXT_LINE" value="true" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="Vue">

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -1,19 +1,47 @@
 package org.vaccineimpact.orderlyweb
 
+import com.google.gson.JsonElement
+import com.google.gson.JsonParser
+import com.google.gson.reflect.TypeToken
 import khttp.responses.Response
 import org.json.JSONArray
 import org.json.JSONObject
 import org.vaccineimpact.orderlyweb.db.Config
+import org.vaccineimpact.orderlyweb.errors.OrderlyServerError
 
 interface OrderlyServerAPI
 {
     fun post(url: String, context: ActionContext): OrderlyServerResponse
     fun get(url: String, context: ActionContext): OrderlyServerResponse
+
+    fun throwOnError(): OrderlyServerAPI
 }
 
-data class OrderlyServerResponse(val text: String, val statusCode: Int)
+data class OrderlyServerResponse(val text: String, val statusCode: Int) {
 
-class OrderlyServer(config: Config, private val httpClient: HttpClient) : OrderlyServerAPI
+    fun <T> data(klass: Class<T>): T
+    {
+        val data = parseJson(text)
+        return Serializer.instance.gson.fromJson(data, klass)
+    }
+
+    fun <T> listData(klass: Class<T>): List<T>
+    {
+        val data = parseJson(text)
+        val type = TypeToken.getParameterized(List::class.java, klass).type
+        return Serializer.instance.gson.fromJson(data, type)
+    }
+
+    private fun parseJson(jsonAsString: String): JsonElement
+    {
+        val element = JsonParser().parse(jsonAsString)
+        return element.asJsonObject["data"]
+    }
+}
+
+class OrderlyServer(private val config: Config,
+                    private val httpClient: HttpClient,
+                    private val throwOnError: Boolean = false) : OrderlyServerAPI
 {
     private val urlBase: String = "${config["orderly.server"]}/v1"
 
@@ -22,22 +50,27 @@ class OrderlyServer(config: Config, private val httpClient: HttpClient) : Orderl
             "Accept-Encoding" to "gzip"
     )
 
+    override fun throwOnError(): OrderlyServerAPI
+    {
+        return OrderlyServer(config, httpClient, true)
+    }
+
     override fun post(url: String, context: ActionContext): OrderlyServerResponse
     {
         val fullUrl = buildFullUrl(url, context.queryString())
         val postData = context.postData<String>()
-        val response =  httpClient.post(fullUrl, standardHeaders, postData)
-        return transformResponse(response)
+        val response = httpClient.post(fullUrl, standardHeaders, postData)
+        return transformResponse(url, response)
     }
 
     override fun get(url: String, context: ActionContext): OrderlyServerResponse
     {
         val fullUrl = buildFullUrl(url, context.queryString())
         val response = httpClient.get(fullUrl, standardHeaders)
-        return transformResponse(response)
+        return transformResponse(url, response)
     }
 
-    private fun transformResponse(rawResponse: Response): OrderlyServerResponse
+    private fun transformResponse(url: String, rawResponse: Response): OrderlyServerResponse
     {
         val errorsKey = "errors"
         val messageKey = "message"
@@ -72,6 +105,10 @@ class OrderlyServer(config: Config, private val httpClient: HttpClient) : Orderl
         }
         json.put("errors", newErrors)
 
+        if (rawResponse.statusCode > 200 && throwOnError)
+        {
+            throw OrderlyServerError(url, rawResponse.statusCode)
+        }
         return OrderlyServerResponse(json.toString(), rawResponse.statusCode)
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/OrderlyServerError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/OrderlyServerError.kt
@@ -1,0 +1,7 @@
+package org.vaccineimpact.orderlyweb.errors
+
+import org.vaccineimpact.orderlyweb.models.ErrorInfo
+
+class OrderlyServerError(url: String, statusCode: Int) : OrderlyWebError(statusCode, listOf(
+        ErrorInfo("orderly-server-error", "Orderly server request failed for url $url")
+))


### PR DESCRIPTION
Previously our usage of the API has been very simple - OW endpoints just make a single request and pass it straight back out to the client, so no parsing of responses, and we just pass the status code and text along.

With the runner we will need to make multiple calls to the API in a single OW request and e.g. combine the results into a viewmodel. So this PR adds some utilities to the orderly server API client to help with that:

* parsing response data
* option to throw on error 