### PR TITLE
mrc-1898 Add kill running report endpoint

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/HttpClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/HttpClient.kt
@@ -30,6 +30,6 @@ class KHttpClient : HttpClient
 
     override fun delete(url: String, headers: Map<String, String>): Response
     {
-        return khttp.delete(url, headers)
+        return  khttp.delete(url, headers)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/HttpClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/HttpClient.kt
@@ -6,6 +6,7 @@ interface HttpClient
 {
     fun post(url: String, headers: Map<String, String>, json: Map<String, String> = mapOf()): Response
     fun get(url: String, headers: Map<String, String>): Response
+    fun delete(url: String, headers: Map<String, String>): Response
 }
 
 class KHttpClient : HttpClient
@@ -25,5 +26,10 @@ class KHttpClient : HttpClient
     override fun get(url: String, headers: Map<String, String>): Response
     {
         return khttp.get(url, headers)
+    }
+
+    override fun delete(url: String, headers: Map<String, String>): Response
+    {
+        return khttp.delete(url, headers)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/HttpClient.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/HttpClient.kt
@@ -30,6 +30,6 @@ class KHttpClient : HttpClient
 
     override fun delete(url: String, headers: Map<String, String>): Response
     {
-        return  khttp.delete(url, headers)
+        return khttp.delete(url, headers)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -17,6 +17,9 @@ interface OrderlyServerAPI
     @Throws(OrderlyServerError::class)
     fun get(url: String, context: ActionContext): OrderlyServerResponse
 
+    @Throws(OrderlyServerError::class)
+    fun delete(url: String, context: ActionContext): OrderlyServerResponse
+
     fun throwOnError(): OrderlyServerAPI
 }
 
@@ -70,6 +73,13 @@ class OrderlyServer(private val config: Config,
     {
         val fullUrl = buildFullUrl(url, context.queryString())
         val response = httpClient.get(fullUrl, standardHeaders)
+        return transformResponse(url, response)
+    }
+
+    override fun delete(url: String, context: ActionContext): OrderlyServerResponse
+    {
+        val fullUrl = buildFullUrl(url, context.queryString())
+        val response = httpClient.delete(fullUrl, standardHeaders)
         return transformResponse(url, response)
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -90,6 +90,7 @@ class OrderlyServer(private val config: Config,
         val detailKey = "detail"
 
         val json = rawResponse.jsonObject
+
         val newErrors = JSONArray()
         if (json.has(errorsKey) && json[errorsKey] is JSONArray)
         {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/ReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/ReportRouteConfig.kt
@@ -33,6 +33,10 @@ object ReportRouteConfig : RouteConfig
             APIEndpoint("/reports/:key/status/", controller, "status")
                     .json()
                     .secure(runReports),
+            APIEndpoint("/reports/:key/kill/", controller, "status",
+                    method = HttpMethod.delete)
+                    .json()
+                    .secure(runReports),
 
             APIEndpoint("/reports/:name/latest/changelog/", controller, "getLatestChangelogByName")
                     .json()

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/ReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/ReportRouteConfig.kt
@@ -33,7 +33,7 @@ object ReportRouteConfig : RouteConfig
             APIEndpoint("/reports/:key/status/", controller, "status")
                     .json()
                     .secure(runReports),
-            APIEndpoint("/reports/:key/kill/", controller, "status",
+            APIEndpoint("/reports/:key/kill/", controller, "kill",
                     method = HttpMethod.delete)
                     .json()
                     .secure(runReports),

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
@@ -48,6 +48,13 @@ class ReportController(context: ActionContext,
         return passThroughResponse(response)
     }
 
+    fun kill(): String
+    {
+        val key = context.params(":key")
+        val response = orderlyServerAPI.delete("/v1/reports/$key/kill/", context)
+        return passThroughResponse(response)
+    }
+
     fun getAllReports(): List<Report>
     {
         if (!canReadReports())

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/APIPermissionChecker.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/APIPermissionChecker.kt
@@ -36,7 +36,7 @@ class APIPermissionChecker(url: String,
             }
             else ->
             {
-                throw InvalidOperationError("Only GET and POST supported")
+                throw InvalidOperationError("Only GET, POST and DELETE supported")
             }
         }
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/APIPermissionChecker.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/APIPermissionChecker.kt
@@ -30,6 +30,10 @@ class APIPermissionChecker(url: String,
             {
                 requestHelper.postWithPermissions(this.url, this.postData, this.contentType, permissions)
             }
+            HttpMethod.delete ->
+            {
+                requestHelper.deleteWithPermissions(this.url, this.contentType, permissions)
+            }
             else ->
             {
                 throw InvalidOperationError("Only GET and POST supported")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/APIRequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/APIRequestHelper.kt
@@ -35,6 +35,17 @@ class APIRequestHelper : RequestHelper()
         return get(url, contentType, MontaguTestUser)
     }
 
+    fun deleteWithPermissions(url: String,
+                           contentType: String = ContentTypes.json,
+                           withPermissions: Set<ReifiedPermission> = setOf()): Response
+    {
+        userRepo.addUser(MontaguTestUser, "test.user", "Test User", UserSource.CLI)
+        withPermissions.forEach {
+            authRepo.ensureUserGroupHasPermission(MontaguTestUser, it)
+        }
+        return delete(url, contentType, MontaguTestUser)
+    }
+
     fun postWithPermissions(url: String,
                             body: Map<String, Any>?,
                             contentType: String = ContentTypes.json,
@@ -53,6 +64,14 @@ class APIRequestHelper : RequestHelper()
         val token = generateToken(userEmail)
         val headers = standardHeaders(contentType).withAuthorizationHeader(token)
         return get(baseUrl + url, headers)
+    }
+
+    fun delete(url: String, contentType: String = ContentTypes.json,
+            userEmail: String = fakeGlobalReportReader()): Response
+    {
+        val token = generateToken(userEmail)
+        val headers = standardHeaders(contentType).withAuthorizationHeader(token)
+        return khttp.delete(baseUrl + url, headers)
     }
 
     fun post(url: String, body: Map<String, Any>?, contentType: String = ContentTypes.json,

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
@@ -209,6 +209,7 @@ class OrderlyServerTests : TeamcityTests()
         val mockClient = mock<HttpClient> {
             on { this.get(any(), any()) } doReturn mockRawResponse
             on { this.post(any(), any(), any()) } doReturn mockRawResponse
+            on { this.delete(any(), any()) } doReturn mockRawResponse
         }
         val mapper = ObjectMapper()
         val expectedJson = mapper.readTree(expectedTranslatedResponse)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
@@ -27,6 +27,7 @@ class OrderlyServerTests : TeamcityTests()
     private val mockHttpclient = mock<HttpClient> {
         on { this.get(any(), any()) } doReturn mockResponse
         on { this.post(any(), any(), any()) } doReturn mockResponse
+        on { this.delete(any(), any()) } doReturn mockResponse
     }
     private val mockConfig = mock<Config>() {
         on { this.get("orderly.server") } doReturn "http://orderly"
@@ -71,6 +72,18 @@ class OrderlyServerTests : TeamcityTests()
         sut.get("/some/path/", mockContext)
 
         verify(mockHttpclient).get("http://orderly/some/path/?key1=val1", standardHeaders)
+    }
+
+    @Test
+    fun `makes DELETE call on http client`()
+    {
+        val mockContext = mock<ActionContext>() {
+            on { this.queryString() } doReturn "key1=val1"
+        }
+        val sut = OrderlyServer(mockConfig, mockHttpclient)
+        sut.delete("/some/path/", mockContext)
+
+        verify(mockHttpclient).delete("http://orderly/some/path/?key1=val1", standardHeaders)
     }
 
     @Test
@@ -208,6 +221,10 @@ class OrderlyServerTests : TeamcityTests()
         assertThat(getResult.statusCode).isEqualTo(400)
 
         val postResult = sut.get("anyUrl", mock())
+        assertThat(mapper.readTree(postResult.text).equals(expectedJson)).isTrue()
+        assertThat(postResult.statusCode).isEqualTo(400)
+
+        val deleteResult = sut.delete("anyUrl", mock())
         assertThat(mapper.readTree(postResult.text).equals(expectedJson)).isTrue()
         assertThat(postResult.statusCode).isEqualTo(400)
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
@@ -31,6 +31,7 @@ class ReportControllerTests : ControllerTest()
     }
 
     private val reportName = "report1"
+    private val reportKey = "123"
 
     private val reports = listOf(Report(reportName, "test full name 1", "v1"),
             Report("testname2", "test full name 2", "v1"))
@@ -68,6 +69,25 @@ class ReportControllerTests : ControllerTest()
         val sut = ReportController(actionContext, mock(), mockReportRepo, apiClient, mockConfig)
 
         val result = sut.run()
+
+        assertThat(result).isEqualTo("okayresponse")
+    }
+
+    @Test
+    fun `kills a report`()
+    {
+        val actionContext = mock<ActionContext> {
+            on { this.params(":key") } doReturn reportKey
+        }
+
+        val mockAPIResponse = OrderlyServerResponse("okayresponse", 200)
+
+        val apiClient = mock<OrderlyServerAPI>() {
+            on { this.delete("/v1/reports/$reportKey/kill/", actionContext) } doReturn mockAPIResponse
+        }
+
+        val sut = ReportController(actionContext, mock(), mockReportRepo, apiClient, mockConfig)
+        val result = sut.kill()
 
         assertThat(result).isEqualTo("okayresponse")
     }


### PR DESCRIPTION
To be used by diagnostic report runner task when receiving request to run report for a group/disease who already have a report run in progress. 