### PR TITLE
mrc-2036 Add Codecov to Buildkite

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,24 @@ rm -r app/demo && rm rm -r app/git ./gradlew :app:generateTestData
 ```
 
 ## Docker build
-The app is dockerised by running `./buildkite/build-app.sh` which does the following:
+The app is dockerised by running the `./buildkite/build-app.sh` script, which does the following:
 1. Calls `./buildkite/make-build-env.sh` which builds a docker image based on the `Dockerfile` which contains all the gradle and npm dependencies needed to 
 distribute the app. This image will also be re-used for the blackbox tests.
 1. Builds the app specific build environment image based on `app.Dockerfile` which inherits from the above.
 1. Generates an orderly-web database containing test data with `./buildkite/make-db.sh`
 1. Runs all dependencies needed for tests as a docker network
-1. Runs the image created in step 2. which tests the app and if successful, runs the `distDocker` task which builds and 
-pushes the final docker image containing just the compiled app.
+1. Runs the image created in step 2. which tests the app and if successful, uploads coverage to Codecov and runs the
+`distDocker` task which builds and pushes the final docker image containing just the compiled app. Note that `CI_ENV` is
+used to pass relevant variables from the Buildkite environment into the Docker container for coverage upload,
+specifically metadata on the most recent git revision and the Codecov upload token.
 
-This script is designed to be run on Buildkite, but can also be run locally.
+This script is designed to be run on Buildkite, but can also be run locally. In this case you will need to set the
+following environment variables for Codecov:
+```bash
+export CODECOV_TOKEN=xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # See https://app.codecov.io/gh/vimc/orderly-web/settings
+export VCS_COMMIT_ID=$(git log -1 --format="%H")
+export VCS_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+```
  
 ### Buildkite
 The Buildkite build runs a series of independent steps, some of which are run in parallel. See `/buildkite/pipeline.yml` where

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -15,6 +15,7 @@ RUN touch /etc/orderly/web/go_signal
 
 CMD docker build --tag orderly-web-dist-base --file dist.Dockerfile . \
     && ./gradlew :app:test :app:distDocker -i -Pdocker_version=$GIT_ID -Pdocker_name=$APP_DOCKER_TAG \
+    && ./gradlew :app:jacocoTestReport && curl -s https://codecov.io/bash | bash -s -- -f src/app/coverage/test/*.xml \
     && docker tag $APP_DOCKER_COMMIT_TAG $APP_DOCKER_BRANCH_TAG \
     && docker push $APP_DOCKER_BRANCH_TAG \
     && docker push $APP_DOCKER_COMMIT_TAG \

--- a/buildkite/build-app.sh
+++ b/buildkite/build-app.sh
@@ -24,10 +24,12 @@ export ORDERLY_SERVER_USER_ID=$UID
 $here/../scripts/run-dependencies.sh
 
 # Run the created image
+CI_ENV=$(curl -s https://codecov.io/env | bash)
 docker run --rm \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $BUILDKITE_DOCKER_AUTH_PATH:/root/.docker/config.json \
     -v $PWD/demo:/api/src/app/demo \
     -v $PWD/git:/api/src/app/git \
     --network=host \
+    $CI_ENV \
     orderly-web-app-build


### PR DESCRIPTION
This produces a coverage report using JaCoCo and uploads it to Codecov.

It works slightly differently to [Travis](https://github.com/vimc/orderly-web/blob/master/.travis.yml#L48) and [HINT](https://github.com/mrc-ide/hint/pull/381/files). OrderlyWeb is built and tested in a container, inside which neither the Buildkite environment or git repository are available, so we use Codecov's suggested approach to pass the relevant variables (Codecov token, git commit and branch identifiers etc) to the container at runtime.