### PR TITLE
mrc-2043 Update Kotlin to latest v1.3.x

### DIFF
--- a/src/build.gradle
+++ b/src/build.gradle
@@ -2,7 +2,7 @@ group 'org.vaccineimpact'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.0'
+    ext.kotlin_version = '1.3.72'
 
     repositories {
         mavenCentral()

--- a/src/gradle/wrapper/gradle-wrapper.properties
+++ b/src/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Jun 25 16:03:04 BST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip


### PR DESCRIPTION
Bump Kotlin to latest point release (1.3.72) as precursor to fixing any deprecations and eventually upgrading to Kotlin 1.4.

This requires a point-upgrade of Gradle for compatibility with the Kotlin plugin, which was performed by:
```sh
./gradlew wrapper --gradle-version 4.9
```