### PR TITLE
mrc-2025 Save kotlin HTML test logs as build artefacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ gradle and npm dependencies needed to distribute the app. This image will also b
 1. Builds the app specific build environment image based on `app.Dockerfile` which inherits from the above.
 1. Generates an orderly-web database containing test data with `./buildkite/make-db.sh`
 1. Runs all dependencies needed for tests as a docker network
-1. Runs the image created in step 2. which tests the app and if successful, uploads coverage to Codecov and runs the
-`distDocker` task which builds and pushes the final docker image containing just the compiled app.
+1. Runs the image created in step 2. which tests the app and if successful runs the `distDocker` task which builds the
+   final docker image containing just the compiled app, and then tags the image and uploads it to Docker Hub
+1. Archives the linting and test reports, and uploads test coverage results to Codecov
 
 This script is designed to be run on Buildkite but can also be run locally, in which case you will need to set the
 following environment variable for Codecov:
@@ -107,8 +108,8 @@ export CODECOV_TOKEN=xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # See https://app.codec
 The Buildkite build runs a series of independent steps, some of which are run in parallel. See `/buildkite/pipeline.yml` where
 this is defined. These steps:
 1. Build, test and push the database migrations image with `./buildkite/make-migrate-image.sh`.
-1. Run `./buildkite/build-app.sh` which compiles code, run tests alongside a database containing test data and
- builds a Docker image containing the compiled app code (see steps [here](#docker-build))
+1. Run `./buildkite/build-app.sh` which compiles the code, run tests alongside a database containing test data, builds a
+   Docker image containing the compiled app code (see steps [here](#docker-build)) and uploads test results as artifacts
 1. Run `./buildkite/run-smoke-test.sh` which runs up the image and checks that the app starts ok
 1. Run `./buildkite/run-custom-config-tests-in-container.sh`
 1. Run `./buildkite/build-css-generator.sh` which creates a docker image that can compile the 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Python tests of the release scripts are in `/scripts/release/tests` and can be r
 directory by running `./scripts/release/tests/test-release.sh`
 
 ### Run linter
-To run (detekt)[https://detekt.github.io/detekt/index.html] against the main code (i.e. excluding tests):
+To run [detekt](https://detekt.github.io/detekt/index.html) against the main code (i.e. excluding tests):
 ```sh
 cd src
 ./gradlew :app:detektMain
@@ -89,22 +89,18 @@ rm -r app/demo && rm rm -r app/git ./gradlew :app:generateTestData
 
 ## Docker build
 The app is dockerised by running the `./buildkite/build-app.sh` script, which does the following:
-1. Calls `./buildkite/make-build-env.sh` which builds a docker image based on the `Dockerfile` which contains all the gradle and npm dependencies needed to 
-distribute the app. This image will also be re-used for the blackbox tests.
+1. Calls `./buildkite/make-build-env.sh` which builds a docker image based on the `Dockerfile` which contains all the
+gradle and npm dependencies needed to distribute the app. This image will also be re-used for the blackbox tests.
 1. Builds the app specific build environment image based on `app.Dockerfile` which inherits from the above.
 1. Generates an orderly-web database containing test data with `./buildkite/make-db.sh`
 1. Runs all dependencies needed for tests as a docker network
 1. Runs the image created in step 2. which tests the app and if successful, uploads coverage to Codecov and runs the
-`distDocker` task which builds and pushes the final docker image containing just the compiled app. Note that `CI_ENV` is
-used to pass relevant variables from the Buildkite environment into the Docker container for coverage upload,
-specifically metadata on the most recent git revision and the Codecov upload token.
+`distDocker` task which builds and pushes the final docker image containing just the compiled app.
 
-This script is designed to be run on Buildkite, but can also be run locally. In this case you will need to set the
-following environment variables for Codecov:
+This script is designed to be run on Buildkite but can also be run locally, in which case you will need to set the
+following environment variable for Codecov:
 ```bash
 export CODECOV_TOKEN=xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # See https://app.codecov.io/gh/vimc/orderly-web/settings
-export VCS_COMMIT_ID=$(git log -1 --format="%H")
-export VCS_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 ```
  
 ### Buildkite

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -10,12 +10,10 @@ ENV APP_DOCKER_TAG $registry/$name
 ENV APP_DOCKER_COMMIT_TAG $registry/$name:$git_id
 ENV APP_DOCKER_BRANCH_TAG $registry/$name:$git_branch
 
-RUN mkdir -p /etc/orderly/web
-RUN touch /etc/orderly/web/go_signal
+RUN mkdir -p /etc/orderly/web && touch /etc/orderly/web/go_signal
 
-CMD docker build --tag orderly-web-dist-base --file dist.Dockerfile . \
-    && ./gradlew :app:detektMain :app:test :app:distDocker -i -Pdocker_version=$GIT_ID -Pdocker_name=$APP_DOCKER_TAG \
-    && ./gradlew :app:jacocoTestReport && curl -s https://codecov.io/bash | bash -s -- -f src/app/coverage/test/*.xml \
+CMD docker build --file dist.Dockerfile --tag orderly-web-dist-base . \
+    && ./gradlew :app:detektMain :app:test :app:jacocoTestReport :app:distDocker -Pdocker_version=$GIT_ID -Pdocker_name=$APP_DOCKER_TAG \
     && docker tag $APP_DOCKER_COMMIT_TAG $APP_DOCKER_BRANCH_TAG \
     && docker push $APP_DOCKER_BRANCH_TAG \
-    && docker push $APP_DOCKER_COMMIT_TAG \
+    && docker push $APP_DOCKER_COMMIT_TAG

--- a/buildkite/build-app.sh
+++ b/buildkite/build-app.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 
-set -ex
+set -euxo pipefail
+
 here=$(dirname $0)
+
+# Set up environment
 . $here/common
 
-# Make the build environment image that is shared between multiple build targets
+# Make the build environment image that is shared between build targets
 $here/make-build-env.sh
 
-# Create an image based on the shared build env that compiles, tests and dockerises
-# the app
-docker build --tag orderly-web-app-build \
-	--build-arg git_id=$GIT_ID \
-	--build-arg git_branch=$GIT_BRANCH \
-    -f app.Dockerfile \
-	.
+# Create an image based on the build image to compile, test and package the app
+docker build \
+    --file app.Dockerfile \
+    --tag orderly-web-app-build \
+    --build-arg git_id=$GIT_ID \
+	  --build-arg git_branch=$GIT_BRANCH \
+	  .
 
 # Generate orderly data and migrate for orderly web tables
 $here/make-db.sh
@@ -23,13 +26,19 @@ export MONTAGU_ORDERLY_PATH=$PWD/git
 export ORDERLY_SERVER_USER_ID=$UID
 $here/../scripts/run-dependencies.sh
 
-# Run the created image
-CI_ENV=$(curl -s https://codecov.io/env | bash)
+# Compile, test and package the app
+function cleanup() {
+  zip -qr reports.zip reports
+  bash <(curl -s https://codecov.io/bash) -s coverage/
+  sudo chown -R $UID reports coverage
+}
+trap cleanup EXIT
 docker run --rm \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $BUILDKITE_DOCKER_AUTH_PATH:/root/.docker/config.json \
     -v $PWD/demo:/api/src/app/demo \
     -v $PWD/git:/api/src/app/git \
+    -v $PWD/reports:/api/src/app/build/reports \
+    -v $PWD/coverage:/api/src/app/coverage \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $BUILDKITE_DOCKER_AUTH_PATH:/root/.docker/config.json \
     --network=host \
-    $CI_ENV \
     orderly-web-app-build

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -6,6 +6,11 @@ steps:
 
     - label: ":mag: Build and test app"
       command: buildkite/build-app.sh
+      key: build-app
+      artifact_paths:
+        - reports.zip
+        - reports/tests/test/index.html
+        - reports/detekt/main.html
 
     - label: ":mag: Run custom config tests in container"
       command: buildkite/run-custom-config-tests-in-container.sh

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -79,7 +79,6 @@ docker {
 
 distDocker {
     dependsOn = [build]
-    push = true
     tag = api_docker_name
     tagVersion = api_docker_version
 }


### PR DESCRIPTION
Implemented:
* Provide access to detekt and junit summary reports, as well as full results (as a zip file) as Buildkite [artifacts](https://buildkite.com/mrc-ide/orderly-web/builds/156#025ac072-14e8-46bd-af4f-046469741c3f)
* Correspondingly reduce verbosity of logging during junit tests (in particular htmlunit, incidentally addressing mrc-1829)
* Remove redundant `CI_ENV` variable and necessity to specify git commit and branch for Codecov
* Don't push Docker image unless build succeeds

Notes:
* Artefacts are stored by Buildkite in Amazon S3. The relevant buckets have un-guessable URLs but are not private. I don't think that our JaCoCo, detekt or Junit reports contain any sensitive information, so this shouldn't be a problem.
* As noted on mrc-2025, the ideal situation would be to simply upload the test reports directly as artefacts - rather than a zip file - so that they could be viewed online. However, Buildkite uploads as individual S3 assets, meaning that links between the files don't work (neither hyperlinks nor JSS/CSS). We can revisit this if the situation changes.
