### PR TITLE
mrc-2065 Correctly handle requests with query parameters in OrderlyServerAPI

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -188,5 +188,16 @@ class OrderlyServer(config: Config,
         return OrderlyServerResponse(json.toString(), code)
     }
 
-    private fun buildFullUrl(url: String, queryString: String?) = "${urlBase}${url}?${queryString ?: ""}"
+    private fun buildFullUrl(url: String, queryString: String?): String
+    {
+        val parameters = if (queryString != null)
+        {
+            "?$queryString"
+        }
+        else
+        {
+            ""
+        }
+        return "$urlBase$url$parameters"
+    }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
@@ -44,6 +44,19 @@ class OrderlyServerTests
     }
 
     @Test
+    fun `passes query parameters from URL`()
+    {
+        val client = getHttpClient()
+        OrderlyServer(mockConfig, client).get("/some/path?key1=val1", mock())
+
+        verify(client).newCall(
+            check {
+                assertThat(it.url.toString()).isEqualTo("http://orderly/some/path?key1=val1")
+            }
+        )
+    }
+
+    @Test
     fun `passes through JSON POST body`()
     {
         val mockContext = mock<ActionContext> {
@@ -54,7 +67,7 @@ class OrderlyServerTests
 
         verify(client).newCall(
                 check {
-                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/?")
+                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/")
                     assertThat(it.headers).isEqualTo(standardHeaders.toHeaders())
                     val buffer = Buffer()
                     it.body!!.writeTo(buffer)
@@ -75,7 +88,7 @@ class OrderlyServerTests
 
         verify(client).newCall(
                 check {
-                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/?")
+                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/")
                     assertThat(it.headers).isEqualTo(standardHeaders.toHeaders())
                     val buffer = Buffer()
                     it.body!!.writeTo(buffer)
@@ -93,7 +106,7 @@ class OrderlyServerTests
 
         verify(client).newCall(
                 check {
-                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/?")
+                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/")
                     assertThat(it.headers).isEqualTo(emptyMap<String, String>().toHeaders())
                 }
         )

--- a/src/config/detekt/detekt.yml
+++ b/src/config/detekt/detekt.yml
@@ -6,8 +6,14 @@ complexity:
 
 formatting:
   Indentation:
-    active: true
+    active: false
+  NoLineBreakAfterElse:
+    active: false
   NoWildcardImports:
+    active: false
+  SpacingAroundCurly:
+    active: false
+  SpacingAroundKeyword:
     active: false
 
 style:

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -39,6 +39,14 @@ class RunReportPageTests : SeleniumTest()
     }
 
     @Test
+    fun `can view git commits`()
+    {
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("git-commit")))
+        val commitsSelect = Select(driver.findElement(By.id("git-commit")))
+        assertThat(commitsSelect.options.size).isEqualTo(2)
+    }
+
+    @Test
     fun `can view logs tab`()
     {
         driver.findElement(By.id("logs-link")).click()


### PR DESCRIPTION
This PR reverts a [recent change](https://github.com/vimc/orderly-web/commit/0993220ed4a6de4bba7a16822ac6f83c1f90ab3d#diff-1aafe52916a7595c2dc2e7dc95e9ed446fd9e8c2e4d56bfc6e896c9d8907dcd7R154) that added a `?` to the end of orderly.server API calls - which was problematic for reasons described in mrc-2065. It adds two tests that would have identified this issue.

This changeset also changes the detekt configuration to relax ktlint's formatting rules, as this is the first time they have been tested in anger for new code. Unfortunately those disabled include the basic indentation rule, which apparently can't be used in combination with our braces-on-newlines convention. This is not inconsistent with HINT, as it does not have any formatting rules enabled (it does not use the `detekt-formatting` plugin).