### PR TITLE
mrc-1599 Endpoint to get all reports user can run

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
@@ -40,6 +40,12 @@ object WebReportRouteConfig : RouteConfig
                     ReportController::class, "getRunReport")
                     .secure(runReports),
             WebEndpoint(
+                    "/list-reports/",
+                    ReportController::class, "getListReports")
+                    .json()
+                    .secure(runReports)
+                    .transform(),
+            WebEndpoint(
                     "/publish-reports/",
                     ReportController::class, "getPublishReports")
                     .secure(reviewReports),

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
@@ -40,8 +40,8 @@ object WebReportRouteConfig : RouteConfig
                     ReportController::class, "getRunReport")
                     .secure(runReports),
             WebEndpoint(
-                    "/list-reports/",
-                    ReportController::class, "getListReports")
+                    "/reports/runnable/",
+                    ReportController::class, "getRunnableReports")
                     .json()
                     .secure(runReports)
                     .transform(),

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -70,18 +70,11 @@ class ReportController(
         return RunReportViewModel(context, metadata, gitBranches)
     }
 
-    fun getListReports(): List<Map<String, Any?>>
+    fun getRunnableReports(): List<ReportWithDate>
     {
-        val response = orderlyServerAPI.get("/reports/source", context)
-        val versionedReports = reportRepository.getAllReportVersions()
-        return response
-            .listData(String::class.java)
-            .map { name ->
-                mapOf(
-                    "name" to name,
-                    "date" to versionedReports.find { it.name == name }?.date
-                )
-            }
+        val reports = orderlyServerAPI.get("/reports/source", context).listData(String::class.java)
+        val versionedReports = reportRepository.getLatestReportVersions(reports)
+        return reports.map { name -> ReportWithDate(name, versionedReports.find { it.name == name }?.date) }
     }
 
     fun tagVersion(): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -12,26 +12,27 @@ import org.vaccineimpact.orderlyweb.db.repositories.OrderlyWebTagRepository
 import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
 import org.vaccineimpact.orderlyweb.db.repositories.TagRepository
 import org.vaccineimpact.orderlyweb.errors.BadRequest
-import org.vaccineimpact.orderlyweb.models.GitBranch
-import org.vaccineimpact.orderlyweb.models.ReportVersionTags
-import org.vaccineimpact.orderlyweb.models.RunReportMetadata
+import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.viewmodels.PublishReportsViewModel
 import org.vaccineimpact.orderlyweb.viewmodels.ReportVersionPageViewModel
 import org.vaccineimpact.orderlyweb.viewmodels.ReportWithDraftsViewModel
 import org.vaccineimpact.orderlyweb.viewmodels.RunReportViewModel
 
-class ReportController(context: ActionContext,
-                       val orderly: OrderlyClient,
-                       val orderlyServerAPI: OrderlyServerAPI,
-                       private val reportRepository: ReportRepository,
-                       private val tagRepository: TagRepository) : Controller(context)
+class ReportController(
+    context: ActionContext,
+    val orderly: OrderlyClient,
+    private val orderlyServerAPI: OrderlyServerAPI,
+    private val reportRepository: ReportRepository,
+    private val tagRepository: TagRepository
+) : Controller(context)
 {
-    constructor(context: ActionContext)
-            : this(context,
-            Orderly(context),
-            OrderlyServer(AppConfig()),
-            OrderlyReportRepository(context),
-            OrderlyWebTagRepository())
+    constructor(context: ActionContext) : this(
+        context,
+        Orderly(context),
+        OrderlyServer(AppConfig()),
+        OrderlyReportRepository(context),
+        OrderlyWebTagRepository()
+    )
 
     @Template("report-page.ftl")
     fun getByNameAndVersion(): ReportVersionPageViewModel
@@ -69,6 +70,20 @@ class ReportController(context: ActionContext,
         return RunReportViewModel(context, metadata, gitBranches)
     }
 
+    fun getListReports(): List<Map<String, Any?>>
+    {
+        val response = orderlyServerAPI.get("/reports/source", context)
+        val versionedReports = reportRepository.getAllReportVersions()
+        return response
+            .listData(String::class.java)
+            .map { name ->
+                mapOf(
+                    "name" to name,
+                    "date" to versionedReports.find { it.name == name }?.date
+                )
+            }
+    }
+
     fun tagVersion(): String
     {
         val reportName = context.params(":name")
@@ -81,8 +96,7 @@ class ReportController(context: ActionContext,
     }
 
     @Template("publish-reports.ftl")
-    fun getPublishReports()
-            : PublishReportsViewModel
+    fun getPublishReports(): PublishReportsViewModel
     {
         return PublishReportsViewModel(context)
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
@@ -425,8 +425,7 @@ class OrderlyReportRepository(val isReviewer: Boolean,
                 ORDERLYWEB_REPORT_VERSION_FULL.DATE.max().`as`("date")
             )
                 .from(ORDERLYWEB_REPORT_VERSION_FULL)
-                .where(shouldIncludeReportVersion)
-                .and(ORDERLYWEB_REPORT_VERSION_FULL.REPORT.`in`(reports))
+                .where(ORDERLYWEB_REPORT_VERSION_FULL.REPORT.`in`(reports))
                 .groupBy(ORDERLYWEB_REPORT_VERSION_FULL.REPORT)
                 .fetchInto(ReportWithDate::class.java)
         }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
@@ -45,6 +45,8 @@ interface ReportRepository
 
     fun publish(ids: List<String>)
 
+    fun getLatestReportVersions(reports: List<String>): List<ReportWithDate>
+
 }
 
 class OrderlyReportRepository(val isReviewer: Boolean,
@@ -413,6 +415,21 @@ class OrderlyReportRepository(val isReviewer: Boolean,
                 .where(shouldIncludeReportVersion)
                 .groupBy(ORDERLYWEB_REPORT_VERSION_FULL.REPORT)
                 .asTemporaryTable(name = "latest_version_for_each_report")
+    }
+
+    override fun getLatestReportVersions(reports: List<String>): List<ReportWithDate>
+    {
+        JooqContext().use {
+            return it.dsl.select(
+                ORDERLYWEB_REPORT_VERSION_FULL.REPORT.`as`("name"),
+                ORDERLYWEB_REPORT_VERSION_FULL.DATE.max().`as`("date")
+            )
+                .from(ORDERLYWEB_REPORT_VERSION_FULL)
+                .where(shouldIncludeReportVersion)
+                .and(ORDERLYWEB_REPORT_VERSION_FULL.REPORT.`in`(reports))
+                .groupBy(ORDERLYWEB_REPORT_VERSION_FULL.REPORT)
+                .fetchInto(ReportWithDate::class.java)
+        }
     }
 
     // shouldInclude for the relational schema

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/GitCommit.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/GitCommit.kt
@@ -1,3 +1,3 @@
 package org.vaccineimpact.orderlyweb.models
 
-data class GitCommit(val id: String, val dateTime: String, val displayDateTime: String)
+data class GitCommit(val id: String, val dateTime: String, val age: Int)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
@@ -14,3 +14,6 @@ data class ReportWithPublishStatus
 constructor(val name: String,
             val displayName: String?,
             val hasBeenPublished: Boolean)
+
+data class ReportWithDate
+constructor(val name: String, val date: Instant?)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/ReportTests.kt
@@ -10,7 +10,10 @@ import org.vaccineimpact.orderlyweb.db.Tables.ORDERLYWEB_PINNED_REPORT_GLOBAL
 import org.vaccineimpact.orderlyweb.db.Tables.ORDERLYWEB_SETTINGS
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyReportRepository
 import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
+import org.vaccineimpact.orderlyweb.models.ReportWithDate
 import org.vaccineimpact.orderlyweb.test_helpers.*
+import java.sql.Timestamp
+import java.time.Instant
 
 class ReportTests : CleanDatabaseTests()
 {
@@ -326,5 +329,26 @@ class ReportTests : CleanDatabaseTests()
         assertThat(result[2].name).isEqualTo("test")
         assertThat(result[2].displayName).isEqualTo("newer display name")
         assertThat(result[2].hasBeenPublished).isEqualTo(true)
+    }
+
+    @Test
+    fun `can get latest dates for selected reports`()
+    {
+        val now = Instant.now()
+
+        insertReport("test1", "v1", date = Timestamp.from(now.minusSeconds(60)))
+        insertReport("test1", "v2", date = Timestamp.from(now))
+        insertReport("test1", "v3", date = Timestamp.from(now.minusSeconds(120)))
+        insertReport("test2", "v4", date = Timestamp.from(now))
+
+        val sut = createSut()
+        val result = sut.getLatestReportVersions(listOf(
+            "test1",
+            "test2"
+        ))
+        assertThat(result).containsExactly(
+            ReportWithDate("test1", now),
+            ReportWithDate("test2", now)
+        )
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
@@ -257,11 +257,11 @@ class OrderlyServerTests
     fun `can parse object data and transform snake case to camel case`()
     {
         val text = """{"status": "success", "data": {"id": "12345", "date_time": "2019-03-29 16:25:48",
-            |"display_date_time": "Monday"}, "errors": []}""".trimMargin()
+            |"age": 3600}, "errors": []}""".trimMargin()
         val response = OrderlyServerResponse(text, 200)
         val data = response.data(GitCommit::class.java)
         assertThat(data.dateTime).isEqualTo("2019-03-29 16:25:48")
-        assertThat(data.displayDateTime).isEqualTo("Monday")
+        assertThat(data.age).isEqualTo(3600)
         assertThat(data.id).isEqualTo("12345")
     }
 
@@ -269,12 +269,12 @@ class OrderlyServerTests
     fun `can parse list data`()
     {
         val text = """{"status": "success", "data": [{"id": "12345", "date_time": "2019-03-29 16:25:48",
-            |"display_date_time": "Monday"}], "errors": []}""".trimMargin()
+            |"age": 3600}], "errors": []}""".trimMargin()
         val response = OrderlyServerResponse(text, 200)
         val data = response.listData(GitCommit::class.java)
         assertThat(data[0].id).isEqualTo("12345")
         assertThat(data[0].dateTime).isEqualTo("2019-03-29 16:25:48")
-        assertThat(data[0].displayDateTime).isEqualTo("Monday")
+        assertThat(data[0].age).isEqualTo(3600)
     }
 
     private fun testTranslatedResponse(rawResponse: String, expectedTranslatedResponse: String)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/ListReportsTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/ListReportsTests.kt
@@ -1,0 +1,93 @@
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.Ignore
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.*
+import org.vaccineimpact.orderlyweb.controllers.web.ReportController
+import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
+import org.vaccineimpact.orderlyweb.models.ReportVersionWithDescLatest
+import java.time.Instant
+
+class ListReportsTests
+{
+    @Test
+    fun `can list all reports`()
+    {
+        val mockContext: ActionContext = mock()
+        val mockOrderlyServer: OrderlyServerAPI = mock {
+            on { get("/reports/source", mockContext) } doReturn
+                OrderlyServerResponse(
+                    Serializer.instance.toResult(
+                        listOf(
+                            "report1",
+                            "report2"
+                        )
+                    ), 200
+                )
+        }
+        val date1 = Instant.now()
+        val date2 = date1.minusSeconds(60)
+        val mockReportRepo: ReportRepository = mock {
+            on { this.getAllReportVersions() } doReturn
+                listOf(
+                    ReportVersionWithDescLatest("report1", null, "ID", false, date1, "VERSION", null),
+                    ReportVersionWithDescLatest("report2", null, "ID", false, date2, "VERSION", null)
+                )
+        }
+        val sut = ReportController(mockContext, mock(), mockOrderlyServer, mockReportRepo, mock())
+        val result = sut.getListReports()
+        assertThat(result).isEqualTo(
+            listOf(
+                mapOf("name" to "report1", "date" to date1),
+                mapOf("name" to "report2", "date" to date2)
+            )
+        )
+    }
+
+    @Test
+    fun `can list reports for branch and commit`()
+    {
+        val mockContext: ActionContext = mock {
+            on { queryParams("branch") } doReturn "branch1"
+            on { queryParams("commit") } doReturn "abcdef1"
+        }
+        val mockOrderlyServer: OrderlyServerAPI = mock {
+            on { get("/reports/source", mockContext) } doReturn
+                OrderlyServerResponse(
+                    Serializer.instance.toResult(
+                        listOf(
+                            "report_that_has_been_run",
+                            "report_that_has_not_been_run"
+                        )
+                    ), 200
+                )
+        }
+        val now = Instant.now()
+        val mockReportRepo: ReportRepository = mock {
+            on { this.getAllReportVersions() } doReturn
+                listOf(
+                    ReportVersionWithDescLatest(
+                        "report_that_has_been_run",
+                        null,
+                        "ID",
+                        false,
+                        now,
+                        "VERSION",
+                        null
+                    )
+                )
+        }
+        val sut = ReportController(mockContext, mock(), mockOrderlyServer, mockReportRepo, mock())
+        val result = sut.getListReports()
+        assertThat(result).isEqualTo(
+            listOf(
+                mapOf("name" to "report_that_has_been_run", "date" to now),
+                mapOf("name" to "report_that_has_not_been_run", "date" to null)
+            )
+        )
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunnableReportsTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunnableReportsTests.kt
@@ -1,49 +1,44 @@
 package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
 
-import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.controllers.web.ReportController
 import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
-import org.vaccineimpact.orderlyweb.models.ReportVersionWithDescLatest
+import org.vaccineimpact.orderlyweb.models.ReportWithDate
 import java.time.Instant
 
-class ListReportsTests
+class RunnableReportsTests
 {
     @Test
     fun `can list all reports`()
     {
         val mockContext: ActionContext = mock()
+        val reports = listOf(
+            "report1",
+            "report2"
+        )
         val mockOrderlyServer: OrderlyServerAPI = mock {
             on { get("/reports/source", mockContext) } doReturn
-                OrderlyServerResponse(
-                    Serializer.instance.toResult(
-                        listOf(
-                            "report1",
-                            "report2"
-                        )
-                    ), 200
-                )
+                OrderlyServerResponse(Serializer.instance.toResult(reports), 200)
         }
         val date1 = Instant.now()
         val date2 = date1.minusSeconds(60)
         val mockReportRepo: ReportRepository = mock {
-            on { this.getAllReportVersions() } doReturn
+            on { getLatestReportVersions(reports) } doReturn
                 listOf(
-                    ReportVersionWithDescLatest("report1", null, "ID", false, date1, "VERSION", null),
-                    ReportVersionWithDescLatest("report2", null, "ID", false, date2, "VERSION", null)
+                    ReportWithDate("report1", date1),
+                    ReportWithDate("report2", date2)
                 )
         }
         val sut = ReportController(mockContext, mock(), mockOrderlyServer, mockReportRepo, mock())
-        val result = sut.getListReports()
+        val result = sut.getRunnableReports()
         assertThat(result).isEqualTo(
             listOf(
-                mapOf("name" to "report1", "date" to date1),
-                mapOf("name" to "report2", "date" to date2)
+                ReportWithDate("report1", date1),
+                ReportWithDate("report2", date2)
             )
         )
     }
@@ -55,38 +50,27 @@ class ListReportsTests
             on { queryParams("branch") } doReturn "branch1"
             on { queryParams("commit") } doReturn "abcdef1"
         }
+        val reports = listOf(
+            "report_that_has_been_run",
+            "report_that_has_not_been_run"
+        )
         val mockOrderlyServer: OrderlyServerAPI = mock {
             on { get("/reports/source", mockContext) } doReturn
-                OrderlyServerResponse(
-                    Serializer.instance.toResult(
-                        listOf(
-                            "report_that_has_been_run",
-                            "report_that_has_not_been_run"
-                        )
-                    ), 200
-                )
+                OrderlyServerResponse(Serializer.instance.toResult(reports), 200)
         }
         val now = Instant.now()
         val mockReportRepo: ReportRepository = mock {
-            on { this.getAllReportVersions() } doReturn
+            on { getLatestReportVersions(reports) } doReturn
                 listOf(
-                    ReportVersionWithDescLatest(
-                        "report_that_has_been_run",
-                        null,
-                        "ID",
-                        false,
-                        now,
-                        "VERSION",
-                        null
-                    )
+                    ReportWithDate("report_that_has_been_run", now)
                 )
         }
         val sut = ReportController(mockContext, mock(), mockOrderlyServer, mockReportRepo, mock())
-        val result = sut.getListReports()
+        val result = sut.getRunnableReports()
         assertThat(result).isEqualTo(
             listOf(
-                mapOf("name" to "report_that_has_been_run", "date" to now),
-                mapOf("name" to "report_that_has_not_been_run", "date" to null)
+                ReportWithDate("report_that_has_been_run", now),
+                ReportWithDate("report_that_has_not_been_run", null)
             )
         )
     }

--- a/src/config/detekt/baseline-main.yml
+++ b/src/config/detekt/baseline-main.yml
@@ -19,7 +19,7 @@
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:23</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.db.TokenStore.kt:5</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.db.repositories.AuthorizationRepository.kt:244</ID>
-    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:122</ID>
+    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:124</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.security.authentication.GithubOAuthAuthenticator.kt:25</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.security.authentication.GithubOAuthProfileCreator.kt:31</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.security.authentication.GithubOAuthProfileCreator.kt:34</ID>
@@ -2414,10 +2414,10 @@
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.AuthorizationRepository.kt:238</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.AuthorizationRepository.kt:298</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.AuthorizationRepository.kt:33</ID>
-    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:205</ID>
-    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:283</ID>
-    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:369</ID>
-    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:55</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:207</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:285</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:371</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:57</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.db.repositories.RoleRepository.kt:22</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError.kt:6</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.errors.OrderlyWebError.kt:8</ID>
@@ -2454,10 +2454,10 @@
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:42</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.PermissionMapper.kt:17</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.PermissionMapper.kt:19</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:425</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:427</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:431</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:433</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:442</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:444</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:448</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:450</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.security.AllowedOriginsFilter.kt:18</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.security.providers.GithubApiClientAuthHelper.kt:75</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.security.providers.OkHttpMontaguAPIClient.kt:45</ID>
@@ -2569,8 +2569,8 @@
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.AuthorizationRepository.kt:256</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.AuthorizationRepository.kt:311</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.DocumentRepository.kt:17</ID>
-    <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:284</ID>
-    <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:47</ID>
+    <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:286</ID>
+    <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:49</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.RoleRepository.kt:106</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.SettingsRespository.kt:31</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.UserRepository.kt:140</ID>
@@ -2887,9 +2887,9 @@
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.DocumentRepository.kt:58</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.DocumentRepository.kt:59</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.DocumentRepository.kt:60</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:50</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:51</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:52</ID>
+    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:53</ID>
+    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:54</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.RoleRepository.kt:21</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.db.repositories.RoleRepository.kt:22</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.errors.OrderlyWebError.kt:4</ID>

--- a/src/config/detekt/baseline-main.yml
+++ b/src/config/detekt/baseline-main.yml
@@ -2454,10 +2454,10 @@
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:42</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.PermissionMapper.kt:17</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.PermissionMapper.kt:19</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:442</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:444</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:448</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:450</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:441</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:443</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:447</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:449</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.security.AllowedOriginsFilter.kt:18</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.security.providers.GithubApiClientAuthHelper.kt:75</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.security.providers.OkHttpMontaguAPIClient.kt:45</ID>


### PR DESCRIPTION
Adds new `/list-reports/` endpoint. It retrieves the list of available reports from orderly.server and uses the orderly database to annotate them with details of the "last run" date for those that have previously been executed. It accepts optional `branch` and `commit` query parameters where the relevant orderly store has `git_supported` (i.e. when there is a `.git` folder and `master_only` isn't true). This endpoint has been configured to require the `reports.run` permission because it has been added as part of the implementation of the new `/run-report` page (mrc-1595).

Notes:

- When "joining" the full list of reports from orderly.server with the list of report versions from the database we first retrieve every version of every report. This is a single query but could conceivably result in a lot of data being returned/materialised. A (more complex) alternative might be to do either a single large `IN` query or N small queries to retrieve the latest version date for the relevant reports.
- The code directly constructs JSON rather than using a web model (which is what we tend to do when using Freemarker templates - which we're not here). There isn't a model that could be immediately re-used but we could readily create an appropriate dataclass if necessary.