### PR TITLE
mrc-1603 Run report page: user can select report to run

### DIFF
--- a/src/app/static/jest.config.js
+++ b/src/app/static/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
         "appUrl": "http://app"
     },
     "transformIgnorePatterns": [
-        "node_modules/(?!(vue-bootstrap-typeahead)/)"
+        "node_modules/(?!(vue-typeahead-bootstrap)/)",
     ],
     "moduleFileExtensions": [
         "js",

--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -11169,6 +11169,12 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -13493,6 +13499,25 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue-typeahead-bootstrap": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/vue-typeahead-bootstrap/-/vue-typeahead-bootstrap-2.7.2.tgz",
+      "integrity": "sha512-iUrpK5s0e4/NC0891KFmNpgaVLYtk10K3wViljdhTw6vmIrMiMmhHQaB83K3frJSDGSgTvdh22RW+ojQpl2VKQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.20",
+        "resize-observer-polyfill": "^1.5.0",
+        "vue": "^2.5.17"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.1",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -47,6 +47,7 @@
     "vue-jest": "^3.0.5",
     "vue-loader": "^15.8.3",
     "vue-template-compiler": "^2.6.11",
+    "vue-typeahead-bootstrap": "^2.7.2",
     "webpack": "^4.41.5",
     "webpack-node-externals": "^1.7.2",
     "webpack-stream": "^5.2.1"

--- a/src/app/static/src/js/components/runReport/reportList.vue
+++ b/src/app/static/src/js/components/runReport/reportList.vue
@@ -1,0 +1,57 @@
+<template>
+    <vue-typeahead-bootstrap
+        :data="sortedReports"
+        :serializer="e => e.name"
+        v-model="query"
+        showOnFocus
+        placeholder="Choose a report"
+        @hit="$emit('update:report', $event.name)"
+    >
+        <template slot="append">
+            <button class="btn btn-outline-secondary" v-on:click.prevent="clear" v-if="query">
+                🗙
+            </button>
+        </template>
+        <template slot="suggestion" slot-scope="{ data, htmlText }">
+            <div>
+                <span v-html="htmlText"></span>
+                <span class="text-muted pl-3">Last run: {{ data.date ? new Intl.DateTimeFormat(undefined, {weekday: "short", month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "numeric"}).format(new Date(data.date)) : 'never' }}</span>
+            </div>
+        </template>
+    </vue-typeahead-bootstrap>
+</template>
+
+<script>
+    import VueTypeaheadBootstrap from "vue-typeahead-bootstrap";
+
+    export default {
+        name: "reportList",
+        props: {
+            "reports": Array,
+            "report": String
+        },
+        components: {
+            VueTypeaheadBootstrap
+        },
+        methods: {
+            clear() {
+                this.query = "";
+                this.$emit("update:report", "");
+            }
+        },
+        data() {
+            return {
+                query: ""
+            }
+        },
+        computed: {
+            sortedReports() {
+                return this.reports.sort((a, b) => a.name.localeCompare(b.name));
+            }
+        },
+        beforeDestroy() {
+            this.$emit('update:report', "")
+        }
+    }
+
+</script>

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -1,38 +1,42 @@
 <template>
     <div>
         <form class="mt-3">
-            <div v-if="metadata.git_supported">
-                <div id="git-branch-form-group" class="form-group row">
-                    <label for="git-branch" class="col-sm-2 col-form-label text-right">Git branch</label>
-                    <div class="col-sm-6">
-                        <select class="form-control" id="git-branch" v-model="selectedBranch" @change="changedBranch">
-                            <option v-for="branch in gitBranches" :value="branch">{{ branch }}</option>
-                        </select>
-                    </div>
-                </div>
-                <div v-if="showCommits" id="git-commit-form-group" class="form-group row">
-                    <label for="git-commit" class="col-sm-2 col-form-label text-right">Git commit</label>
-                    <div class="col-sm-6">
-                        <select class="form-control" id="git-commit" v-model="selectedCommitId">
-                            <option v-for="commit in gitCommits" :value="commit.id">
-                                {{ commit.id }} ({{ commit.date_time }})
-                            </option>
-                        </select>
-                    </div>
+            <div v-if="metadata.git_supported" id="git-branch-form-group" class="form-group row">
+                <label for="git-branch" class="col-sm-2 col-form-label text-right">Git branch</label>
+                <div class="col-sm-6">
+                    <select class="form-control" id="git-branch" v-model="selectedBranch" @change="changedBranch">
+                        <option v-for="branch in gitBranches" :value="branch">{{ branch }}</option>
+                    </select>
                 </div>
             </div>
-            <div v-for="(options, name) in metadata.instances"
-                 v-if="metadata.instances_supported && options.length > 1"
-                 class="form-group row">
-                <label :for="name" class="col-sm-2 col-form-label text-right">Database "{{ name }}"</label>
+            <div v-if="showCommits" id="git-commit-form-group" class="form-group row">
+                <label for="git-commit" class="col-sm-2 col-form-label text-right">Git commit</label>
                 <div class="col-sm-6">
-                    <select class="form-control" :id="name" v-model="selectedInstances[name]">
-                        <option v-for="option in options" :value="option">
-                            {{ option }}
+                    <select class="form-control" id="git-commit" v-model="selectedCommitId" @change="changedCommit">
+                        <option v-for="commit in gitCommits" :value="commit.id">
+                            {{ commit.id }} ({{ commit.date_time }})
                         </option>
                     </select>
                 </div>
             </div>
+            <div v-if="showReports" id="report-form-group" class="form-group row">
+                <label for="report" class="col-sm-2 col-form-label text-right">Report</label>
+                <div class="col-sm-6">
+                    <report-list id="report" :reports="reports" :report.sync="selectedReport"/>
+                </div>
+            </div>
+            <template v-if="showInstances">
+                <div v-for="(options, name) in metadata.instances" v-if="options.length > 1" class="form-group row">
+                    <label :for="name" class="col-sm-2 col-form-label text-right">Database "{{ name }}"</label>
+                    <div class="col-sm-6">
+                        <select class="form-control" :id="name" v-model="selectedInstances[name]">
+                            <option v-for="option in options" :value="option">
+                                {{ option }}
+                            </option>
+                        </select>
+                    </div>
+                </div>
+            </template>
         </form>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>
     </div>
@@ -41,49 +45,82 @@
 <script>
     import {api} from "../../utils/api";
     import ErrorInfo from "../errorInfo";
+    import ReportList from "./reportList";
 
     export default {
         name: "runReport",
-        props: ['metadata', 'gitBranches'],
-        components: {ErrorInfo},
+        props: [
+            "metadata",
+            "gitBranches",
+        ],
+        components: {
+            ErrorInfo,
+            ReportList
+        },
         data: () => {
             return {
                 gitCommits: [],
+                reports: [],
                 selectedBranch: "",
                 selectedCommitId: "",
+                selectedReport: "",
+                selectedInstances: {},
                 error: "",
                 defaultMessage: "",
-                selectedInstances: {}
             }
         },
         computed: {
-            showCommits: function () {
+            showCommits() {
                 return this.gitCommits && this.gitCommits.length;
+            },
+            showReports() {
+                return this.reports && this.reports.length;
+            },
+            showInstances() {
+                return this.metadata.instances_supported && this.selectedReport;
             }
         },
         methods: {
-            changedBranch: function () {
-                if (this.selectedBranch) {
-                    api.get(`/git/branch/${this.selectedBranch}/commits/`)
-                        .then(({data}) => {
-                            this.gitCommits = data.data;
-                            if (this.gitCommits.length) {
-                                this.selectedCommitId = this.gitCommits[0].id;
-                            }
-                            this.error = "";
-                            this.defaultMessage = "";
-                        })
-                        .catch((error) => {
-                            this.error = error;
-                            this.defaultMessage = "An error occurred fetching Git commits";
-                        });
-                }
+            changedBranch() {
+                api.get(`/git/branch/${this.selectedBranch}/commits/`)
+                    .then(({data}) => {
+                        this.gitCommits = data.data;
+                        if (this.gitCommits.length) {
+                            this.selectedCommitId = this.gitCommits[0].id;
+                            this.changedCommit();
+                        }
+                        this.error = "";
+                        this.defaultMessage = "";
+                    })
+                    .catch((error) => {
+                        this.error = error;
+                        this.defaultMessage = "An error occurred fetching Git commits";
+                    });
+            },
+            changedCommit() {
+                this.updateReports();
+            },
+            updateReports() {
+                this.reports = [];
+                const query = this.metadata.git_supported ? `?branch=${this.selectedBranch}&commit=${this.selectedCommitId}` : '';
+                api.get(`/reports/runnable/${query}`)
+                    .then(({data}) => {
+                        this.reports = data.data;
+                        this.error = "";
+                        this.defaultMessage = "";
+                    })
+                    .catch((error) => {
+                        this.error = error;
+                        this.defaultMessage = "An error occurred fetching reports";
+                    });
             }
         },
         mounted() {
             if (this.metadata.git_supported) {
                 this.selectedBranch = this.gitBranches[0];
                 this.changedBranch();
+            } else {
+                this.updateReports();
             }
             if (this.metadata.instances_supported) {
                 const instances = this.metadata.instances;

--- a/src/app/static/src/tests/components/runReport/reportList.test.js
+++ b/src/app/static/src/tests/components/runReport/reportList.test.js
@@ -1,0 +1,46 @@
+import Vue from "vue";
+import {mount} from "@vue/test-utils";
+import ReportList from "../../../js/components/runReport/reportList.vue";
+
+function getWrapper() {
+    return mount(ReportList, {
+        propsData: {
+            reports: [
+                {name: "report2", date: null},
+                {name: "report1", date: new Date().toISOString()}
+            ]
+        }
+    });
+}
+
+describe("reportList", () => {
+
+    it("renders typeahead correctly and fires event on selection", (done) => {
+        const wrapper = getWrapper();
+
+        const reportSuggestions = wrapper.findAll("a div.sr-only");
+        expect(reportSuggestions.length).toBe(2);
+        expect(reportSuggestions.at(0).text()).toBe("report1");
+        expect(reportSuggestions.at(1).text()).toBe("report2");
+        reportSuggestions.at(1).trigger("click");
+        expect(wrapper.emitted()["update:report"].length).toBe(1);
+        expect(wrapper.emitted()["update:report"][0]).toEqual(["report2"]);
+
+        done();
+    });
+
+    it("typeahead filters list correctly", async (done) => {
+        const wrapper = getWrapper();
+
+        wrapper.find("input").setValue("rt2");
+
+        await Vue.nextTick();
+
+        const reportSuggestions = wrapper.findAll("a div.sr-only");
+        expect(reportSuggestions.length).toBe(1);
+        expect(reportSuggestions.at(0).text()).toBe("report2");
+
+        done();
+    });
+
+});

--- a/src/app/static/src/tests/components/runReport/runReport.test.js
+++ b/src/app/static/src/tests/components/runReport/runReport.test.js
@@ -1,22 +1,43 @@
 import Vue from "vue";
 import {shallowMount, mount} from "@vue/test-utils";
 import RunReport from "../../../js/components/runReport/runReport.vue";
+import ReportList from "../../../js/components/runReport/reportList.vue";
 import ErrorInfo from "../../../js/components/errorInfo";
 import {mockAxios} from "../../mockAxios";
 
-describe("reportTags", () => {
+describe("runReport", () => {
     beforeEach(() => {
         mockAxios.reset();
         mockAxios.onGet('http://app/git/branch/master/commits/')
-            .reply(200, {"data": mockCommits});
+            .reply(200, {"data": gitCommits});
     });
 
-    const mockCommits = [
+    const gitCommits = [
         {id: "abcdef", date_time: "Mon Jun 08, 12:01"},
         {id: "abc123", date_time: "Tue Jun 09, 13:11"}
     ];
 
     const gitBranches = ["master", "dev"];
+
+    const reports = [
+        {name: "report1", date: new Date().toISOString()},
+        {name: "report2", date: null}
+    ];
+
+    const getWrapper = (reports) => {
+        mockAxios.onGet('http://app/reports/runnable/?branch=master&commit=abcdef')
+            .reply(200, {"data": reports});
+
+        return mount(RunReport, {
+            propsData: {
+                metadata: {
+                    git_supported: true,
+                    instances_supported: false
+                },
+                gitBranches
+            }
+        });
+    }
 
     it("renders git branch drop down and fetches commits if git supported", (done) => {
 
@@ -56,14 +77,16 @@ describe("reportTags", () => {
         });
 
         await Vue.nextTick();
-        expect(mockAxios.history.get.length).toBe(0);
+        expect(mockAxios.history.get.length).toBe(1);
         expect(wrapper.find("#git-branch-form-group").exists()).toBe(false);
         expect(wrapper.find("#git-commit-form-group").exists()).toBe(false);
     });
 
     it("calls api to get commits when branch changes and updates commits drop down", (done) => {
         mockAxios.onGet('http://app/git/branch/dev/commits/')
-            .reply(200, {"data": mockCommits});
+            .reply(200, {"data": gitCommits});
+        mockAxios.onGet('http://app/reports/runnable/?branch=dev&commit=abcdef')
+            .reply(200, {"data": []});
 
         const wrapper = mount(RunReport, {
             propsData: {
@@ -90,7 +113,7 @@ describe("reportTags", () => {
         })
     });
 
-    it("show error message if error getting git commits", () => {
+    it("show error message if error getting git commits", (done) => {
         mockAxios.onGet('http://app/git/branch/master/commits/')
             .reply(500, "TEST ERROR");
 
@@ -108,6 +131,31 @@ describe("reportTags", () => {
         })
     });
 
+    it("updates reports dropdown by calling api when commit changes", (done) => {
+        const wrapper = getWrapper(reports);
+
+        setTimeout(() => {
+            expect(mockAxios.history.get.length).toBe(2);
+            expect(wrapper.find(ErrorInfo).props("apiError")).toBe("");
+            expect(wrapper.find(ErrorInfo).props("defaultMessage")).toBe("");
+            expect(wrapper.find(ReportList).props("reports")).toEqual(expect.arrayContaining(reports));
+            done();
+        });
+    });
+
+    it("displays report list in order and allows selection and reset", (done) => {
+        const wrapper = getWrapper(reports);
+
+        setTimeout(async () => {
+            wrapper.find(ReportList).find("a:last-of-type").trigger("click");
+            expect(wrapper.vm.$data["selectedReport"]).toBe("report2");
+            await Vue.nextTick();
+            wrapper.find(ReportList).find("button").trigger("click");
+            expect(wrapper.vm.$data["selectedReport"]).toBe("");
+            done();
+        });
+    });
+
     it("shows instances if instances supported", () => {
         const wrapper = shallowMount(RunReport, {
             propsData: {
@@ -121,6 +169,11 @@ describe("reportTags", () => {
                     }
                 },
                 gitBranches
+            },
+            data() {
+                return {
+                    selectedReport: "report1"
+                }
             }
         });
 

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -41,9 +41,21 @@ class RunReportPageTests : SeleniumTest()
     @Test
     fun `can view git commits`()
     {
-        wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("git-commit")))
         val commitsSelect = Select(driver.findElement(By.id("git-commit")))
         assertThat(commitsSelect.options.size).isEqualTo(2)
+        assertThat(commitsSelect.options).allMatch { it.text.contains(Regex("[0-9a-f]{7}")) }
+    }
+
+    @Test
+    fun `can view and select reports`()
+    {
+        val typeahead = driver.findElement(By.id("report"))
+        assertThat(typeahead.findElements(By.tagName("a")).size).isEqualTo(2)
+        val input = typeahead.findElement(By.tagName("input"))
+        input.sendKeys("min")
+        val matches = typeahead.findElements(By.tagName("a"))
+        assertThat(matches.size).isEqualTo(1)
+        assertThat(matches[0].text).startsWith("minimal")
     }
 
     @Test


### PR DESCRIPTION
This builds on #283 to expand support for running reports via OrderlyWeb to report selection itself:

* Re-orders the form and makes it slightly more wizard-like: moving "Database instance" below "Report" (as it is effectively a runtime parameter) and conditionally displaying each form input based on the previous
* It supports orderly stores with git enabled and disabled. In the latter case the git branch and commit selectors are hidden.
* It uses the vanilla [vue-typeahead-bootstrap](https://github.com/alexurquhart/vue-bootstrap-typeahead) component. We have an old version of a related (unmaintained) project in our source tree but it enforces some constraints that aren't applicable here. This isn't ideal - it could be updated/amended but I'm wary of collateral damage.
* Given the wizard-like nature of the form and that each step isn't (currently) a separate Vue component, there is some coupling between each step and its predecessor. For example, when testing the form as a whole, it's necessary to set the current commit ID before the report selector is usable.
* mrc-2152 will provide the ability to refresh the list of git commits/branches at the orderly.server end

For testing:
* Ensure that you're using the `git` model rather than `demo` - you need to use a version controlled store until VIMC-4539 is resolved (no further code changes will be necessary here)
* Ensure that you've run `add-test-users.sh`
* Visit http://localhost:8888/run-report/ (there's no link to this page yet)