### PR TITLE
mrc-2024 Remove final usages of khttp

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -47,13 +47,12 @@ dependencies {
 
     compile "org.eclipse.mylyn.github:org.eclipse.egit.github.core:2.1.5"
 
-    compile "khttp:khttp:0.1.0"
-    compile "com.squareup.okhttp3:okhttp:4.0.0-RC1"
+    compile "org.json:json:20201115"
+    compile "com.squareup.okhttp3:okhttp:4.8.1"
 
     compile "org.ocpsoft.prettytime:prettytime:4.0.5.Final"
 
     testCompile "org.slf4j:slf4j-simple:1.7.21"
-    testCompile "khttp:khttp:0.1.0"
     testCompile "com.beust:klaxon:0.31"
     testCompile "com.opencsv:opencsv:3.9"
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -17,7 +17,12 @@ import org.vaccineimpact.orderlyweb.errors.OrderlyServerError
 interface OrderlyServerAPI
 {
     @Throws(OrderlyServerError::class)
-    fun post(url: String, context: ActionContext, rawRequest: Boolean = false, transformResponse: Boolean = true): OrderlyServerResponse
+    fun post(
+        url: String,
+        context: ActionContext,
+        rawRequest: Boolean = false,
+        transformResponse: Boolean = true
+    ): OrderlyServerResponse
 
     @Throws(OrderlyServerError::class)
     fun get(url: String, context: ActionContext): OrderlyServerResponse
@@ -54,16 +59,14 @@ class OrderlyServerResponse(val bytes: ByteArray, val statusCode: Int)
     }
 }
 
-class OrderlyServer(config: Config,
-                    private val client: OkHttpClient = OkHttpClient()
+class OrderlyServer(
+    config: Config,
+    private val client: OkHttpClient = OkHttpClient()
 ) : OrderlyServerAPI
 {
     private var throwOnError = false
 
-    private val standardHeaders = mapOf(
-            "Accept" to ContentTypes.json,
-            "Accept-Encoding" to "gzip"
-    )
+    private val standardHeaders = mapOf("Accept" to ContentTypes.json)
 
     private val urlBase: String = config["orderly.server"]
 
@@ -77,9 +80,9 @@ class OrderlyServer(config: Config,
     override fun get(url: String, context: ActionContext): OrderlyServerResponse
     {
         val request = Request.Builder()
-                .url(buildFullUrl(url, context.queryString()))
-                .headers(standardHeaders.toHeaders())
-                .build()
+            .url(buildFullUrl(url, context.queryString()))
+            .headers(standardHeaders.toHeaders())
+            .build()
         val response = client.newCall(request).execute()
         if (!response.isSuccessful && throwOnError)
         {
@@ -88,7 +91,12 @@ class OrderlyServer(config: Config,
         return transformResponse(response.code, response.body!!.string())
     }
 
-    override fun post(url: String, context: ActionContext, rawRequest: Boolean, transformResponse: Boolean): OrderlyServerResponse
+    override fun post(
+        url: String,
+        context: ActionContext,
+        rawRequest: Boolean,
+        transformResponse: Boolean
+    ): OrderlyServerResponse
     {
         val body = if (rawRequest)
         {
@@ -115,10 +123,10 @@ class OrderlyServer(config: Config,
             emptyMap()
         }
         val request = Request.Builder()
-                .url(buildFullUrl(url, context.queryString()))
-                .headers(headers.toHeaders())
-                .post(body)
-                .build()
+            .url(buildFullUrl(url, context.queryString()))
+            .headers(headers.toHeaders())
+            .post(body)
+            .build()
         val response = client.newCall(request).execute()
         if (!response.isSuccessful && throwOnError)
         {
@@ -137,10 +145,10 @@ class OrderlyServer(config: Config,
     override fun delete(url: String, context: ActionContext): OrderlyServerResponse
     {
         val request = Request.Builder()
-                .url(buildFullUrl(url, context.queryString()))
-                .headers(standardHeaders.toHeaders())
-                .delete()
-                .build()
+            .url(buildFullUrl(url, context.queryString()))
+            .headers(standardHeaders.toHeaders())
+            .delete()
+            .build()
         val response = client.newCall(request).execute()
         if (!response.isSuccessful && throwOnError)
         {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/PermissionChecker.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/PermissionChecker.kt
@@ -1,11 +1,11 @@
 package org.vaccineimpact.orderlyweb.tests
 
 
-import khttp.responses.Response
 import org.assertj.core.api.Assertions
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.test_helpers.removePermission
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.RequestHelper

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/APIPermissionChecker.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/APIPermissionChecker.kt
@@ -1,9 +1,9 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests
 
-import khttp.responses.Response
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.errors.InvalidOperationError
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
 import org.vaccineimpact.orderlyweb.tests.PermissionChecker
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.APIRequestHelper
 import spark.route.HttpMethod

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/WebPermissionChecker.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/WebPermissionChecker.kt
@@ -1,8 +1,8 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests
 
-import khttp.responses.Response
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
 import org.vaccineimpact.orderlyweb.tests.PermissionChecker
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.WebRequestHelper
 import spark.route.HttpMethod

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/APIRequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/APIRequestHelper.kt
@@ -2,7 +2,6 @@ package org.vaccineimpact.orderlyweb.tests.integration_tests.helpers
 
 import com.github.salomonbrys.kotson.get
 import com.google.gson.JsonParser
-import khttp.responses.Response
 import org.assertj.core.api.Assertions
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.db.AppConfig
@@ -12,6 +11,8 @@ import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.UserSource
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.security.WebTokenHelper
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
+import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.giveUserGroupPermission
 import org.vaccineimpact.orderlyweb.tests.insertUser
@@ -63,7 +64,7 @@ class APIRequestHelper : RequestHelper()
     {
         val token = generateToken(userEmail)
         val headers = standardHeaders(contentType).withAuthorizationHeader(token)
-        return get(baseUrl + url, headers)
+        return HttpClient.get(baseUrl + url, headers)
     }
 
     fun delete(url: String, contentType: String = ContentTypes.json,
@@ -71,7 +72,7 @@ class APIRequestHelper : RequestHelper()
     {
         val token = generateToken(userEmail)
         val headers = standardHeaders(contentType).withAuthorizationHeader(token)
-        return khttp.delete(baseUrl + url, headers)
+        return HttpClient.delete(baseUrl + url, headers)
     }
 
     fun post(url: String, body: Map<String, Any>?, contentType: String = ContentTypes.json,
@@ -79,7 +80,7 @@ class APIRequestHelper : RequestHelper()
     {
         val token = generateToken(userEmail)
         val headers = standardHeaders(contentType).withAuthorizationHeader(token)
-        return khttp.post(baseUrl + url, headers, json = body)
+        return HttpClient.post(baseUrl + url, headers, json = body)
     }
 
     fun generateOnetimeToken(url: String, userEmail: String = fakeGlobalReportReader()): String
@@ -97,25 +98,25 @@ class APIRequestHelper : RequestHelper()
     {
         val token = "faketoken"
         val headers = standardHeaders(contentType).withAuthorizationHeader(token)
-        return get(baseUrl + url, headers)
+        return HttpClient.get(baseUrl + url, headers)
     }
 
     fun getWithToken(url: String, bearerToken: String): Response
     {
         val headers = standardHeaders(ContentTypes.json).withAuthorizationHeader(bearerToken)
-        return get(baseUrl + url, headers)
+        return HttpClient.get(baseUrl + url, headers)
     }
 
     fun getWrongPermissions(url: String, contentType: String = ContentTypes.json): Response
     {
         val token = generateToken("bademail@gmail.com")
         val headers = standardHeaders(contentType).withAuthorizationHeader(token)
-        return get(baseUrl + url, headers)
+        return HttpClient.get(baseUrl + url, headers)
     }
 
     fun getNoAuth(url: String, contentType: String = ContentTypes.json): Response
     {
-        return get(baseUrl + url, standardHeaders(contentType))
+        return HttpClient.get(baseUrl + url, standardHeaders(contentType))
     }
 
     private fun Map<String, String>.withAuthorizationHeader(token: String) = this +

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/RequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/RequestHelper.kt
@@ -2,8 +2,9 @@ package org.vaccineimpact.orderlyweb.tests.integration_tests.helpers
 
 import com.beust.klaxon.JsonObject
 import com.beust.klaxon.Parser
-import khttp.structures.authorization.BasicAuthorization
 import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.test_helpers.http.BasicAuthorization
+import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
 
 abstract class RequestHelper
 {
@@ -16,21 +17,13 @@ abstract class RequestHelper
 
     val MontaguTestUser = "test.user@example.com"
 
-    protected fun get(url: String, headers: Map<String, String>) = khttp.get(url, headers)
-
-    protected fun standardHeaders(contentType: String): Map<String, String>
-    {
-        return mapOf(
-                "Accept" to contentType,
-                "Accept-Encoding" to "gzip"
-        )
-    }
+    protected fun standardHeaders(contentType: String) = mapOf("Accept" to contentType)
 
     fun loginWithMontagu(): JsonObject
     {
         // these user login details are set up in ./dev/run-dependencies.sh
         val auth = BasicAuthorization(MontaguTestUser, "password")
-        val response = khttp.post("${AppConfig()["montagu.api_url"]}/authenticate/",
+        val response = HttpClient.post("${AppConfig()["montagu.api_url"]}/authenticate/",
                 data = mapOf("grant_type" to "client_credentials"),
                 auth = auth
         )

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/WebRequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/WebRequestHelper.kt
@@ -5,13 +5,14 @@ import com.beust.klaxon.json
 import com.github.salomonbrys.kotson.fromJson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
-import khttp.responses.Response
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyAuthorizationRepository
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyUserRepository
 import org.vaccineimpact.orderlyweb.models.UserSource
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.security.clients.MontaguIndirectClient
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
+import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
 import spark.route.HttpMethod
 
 class WebRequestHelper : RequestHelper()
@@ -26,7 +27,7 @@ class WebRequestHelper : RequestHelper()
     ): Response
     {
         val headers = standardHeaders(contentType)
-        return get(baseUrl + url, headers)
+        return HttpClient.get(baseUrl + url, headers, true)
     }
 
     fun loginWithMontaguAndMakeRequest(url: String,
@@ -59,7 +60,7 @@ class WebRequestHelper : RequestHelper()
         val cookieName = MontaguIndirectClient.cookie
         val headers = standardHeaders(contentType) +
                 mapOf("Cookie" to "$cookieName=$montaguToken")
-        return khttp.get(baseUrl + url, headers, allowRedirects = allowRedirects)
+        return HttpClient.get(baseUrl + url, headers, allowRedirects = allowRedirects)
     }
 
     fun webLoginWithMontagu(withPermissions: Set<ReifiedPermission> = setOf()): String
@@ -70,7 +71,7 @@ class WebRequestHelper : RequestHelper()
         }
         val montaguToken = loginWithMontagu()["access_token"] as String
         val loginResponse = getWithMontaguCookie("/login/", montaguToken)
-        return loginResponse.headers["Set-Cookie"].toString()
+        return loginResponse.headers["set-cookie"].toString()
     }
 
     fun requestWithSessionCookie(url: String,
@@ -99,9 +100,9 @@ class WebRequestHelper : RequestHelper()
         }
         return when (method)
         {
-            HttpMethod.get -> khttp.get(fullUrl, headers)
-            HttpMethod.post -> khttp.post(fullUrl, headers, data = data)
-            HttpMethod.delete -> khttp.delete(fullUrl, headers)
+            HttpMethod.get -> HttpClient.get(fullUrl, headers)
+            HttpMethod.post -> HttpClient.post(fullUrl, headers, data = data)
+            HttpMethod.delete -> HttpClient.delete(fullUrl, headers)
             else -> throw IllegalArgumentException("Method not supported")
         }
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/IntegrationTest.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/IntegrationTest.kt
@@ -1,6 +1,5 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests
 
-import khttp.responses.Response
 import org.assertj.core.api.Assertions
 import org.junit.After
 import org.junit.Before
@@ -10,6 +9,7 @@ import org.vaccineimpact.orderlyweb.app_start.main
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.test_helpers.JSONValidator
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
 import org.vaccineimpact.orderlyweb.tests.integration_tests.APIPermissionChecker
 import org.vaccineimpact.orderlyweb.tests.integration_tests.WebPermissionChecker
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.APIRequestHelper
@@ -62,8 +62,6 @@ abstract class IntegrationTest
     {
         Assertions.assertThat(response.statusCode)
                 .isEqualTo(200)
-
-        Assertions.assertThat(response.headers["Content-Encoding"]).isEqualTo("gzip")
     }
 
     protected fun assertSuccessfulWithResponseText(response: Response)
@@ -71,8 +69,6 @@ abstract class IntegrationTest
         Assertions.assertThat(response.statusCode)
                 .withFailMessage(response.text)
                 .isEqualTo(200)
-
-        Assertions.assertThat(response.headers["Content-Encoding"]).isEqualTo("gzip")
     }
 
     protected fun assertUnauthorized(response: Response, reportName: String)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/BundleTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/BundleTests.kt
@@ -13,6 +13,7 @@ import org.vaccineimpact.orderlyweb.db.getResource
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.security.WebTokenHelper
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReviewer
 import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
 import spark.route.HttpMethod
@@ -44,7 +45,7 @@ class BundlePackTests : IntegrationTest()
                 ContentTypes.zip, HttpMethod.post)
     }
 
-    private fun getZipEntries(response: khttp.responses.Response): MutableList<String>
+    private fun getZipEntries(response: Response): MutableList<String>
     {
         val entries = mutableListOf<String>()
         ZipInputStream(ByteArrayInputStream(response.content)).use { zis ->

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ZipTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ZipTests.kt
@@ -9,6 +9,7 @@ import org.vaccineimpact.orderlyweb.db.fromJoinPath
 import org.vaccineimpact.orderlyweb.db.joinPath
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.createArchiveFolder
 import org.vaccineimpact.orderlyweb.tests.deleteArchiveFolder
@@ -127,7 +128,7 @@ class ZipTests : IntegrationTest()
                 "$version/README.md")
     }
 
-    private fun getZipEntries(response: khttp.responses.Response): MutableList<String>
+    private fun getZipEntries(response: Response): MutableList<String>
     {
         val entries = mutableListOf<String>()
         ZipInputStream(ByteArrayInputStream(response.content)).use {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/MontaguAuthenticationTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/MontaguAuthenticationTests.kt
@@ -1,8 +1,7 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.api.auth
 
 import com.github.fge.jackson.JsonLoader
-import khttp.options
-import khttp.post
+import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.test_helpers.TestTokenHeader
@@ -14,7 +13,7 @@ class MontaguAuthenticationTests : IntegrationTest()
     @Test
     fun `authentication fails without Auth header`()
     {
-        val result = post(url)
+        val result = HttpClient.post(url)
         assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(result.text,
                 expectedErrorCode = "montagu-token-invalid",
@@ -24,7 +23,7 @@ class MontaguAuthenticationTests : IntegrationTest()
     @Test
     fun `authentication fails with malformed Auth header`()
     {
-        val result = post(url, auth = TestTokenHeader("token", "wrongprefix"))
+        val result = HttpClient.post(url, auth = TestTokenHeader("token", "wrongprefix"))
         assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(result.text,
                 expectedErrorCode = "montagu-token-invalid",
@@ -34,7 +33,7 @@ class MontaguAuthenticationTests : IntegrationTest()
     @Test
     fun `authentication fails with invalid token`()
     {
-        val result = post(url, auth = TestTokenHeader("badtoken"))
+        val result = HttpClient.post(url, auth = TestTokenHeader("badtoken"))
         assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(result.text,
                 expectedErrorCode = "montagu-token-invalid",
@@ -46,7 +45,7 @@ class MontaguAuthenticationTests : IntegrationTest()
     {
         val token = APIRequestHelper().loginWithMontagu()["access_token"].toString()
 
-        val result = post(url, auth = TestTokenHeader(token))
+        val result = HttpClient.post(url, auth = TestTokenHeader(token))
 
         assertSuccessful(result)
 
@@ -59,7 +58,7 @@ class MontaguAuthenticationTests : IntegrationTest()
     @Test
     fun `can get OPTIONS for authentication endpoint`()
     {
-        val result = options(url)
+        val result = HttpClient.options(url)
         assertThat(result.statusCode).isEqualTo(200)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/DirectActionContextTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/DirectActionContextTests.kt
@@ -135,7 +135,6 @@ class DirectActionContextTests
         sut.addDefaultResponseHeaders("testContentType")
 
         verify(rawResponse).setContentType("testContentType")
-        verify(rawResponse).addHeader("Content-Encoding", "gzip")
         verify(rawResponse).addHeader("Access-Control-Allow-Credentials", "true")
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
@@ -21,10 +21,7 @@ class OrderlyServerTests
         on { this["orderly.server"] } doReturn "http://orderly"
     }
 
-    private val standardHeaders = mapOf(
-            "Accept" to ContentTypes.json,
-            "Accept-Encoding" to "gzip"
-    )
+    private val standardHeaders = mapOf("Accept" to ContentTypes.json)
 
     @Test
     fun `passes through query string to GET`()

--- a/src/config/detekt/baseline-main.yml
+++ b/src/config/detekt/baseline-main.yml
@@ -240,79 +240,6 @@
     <ID>Indentation:org.vaccineimpact.orderlyweb.Helpers.kt:29</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.Helpers.kt:30</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.Helpers.kt:31</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:100</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:101</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:102</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:103</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:104</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:105</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:106</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:107</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:108</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:110</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:111</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:112</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:114</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:115</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:116</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:118</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:119</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:120</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:121</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:124</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:125</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:126</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:128</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:129</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:130</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:132</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:133</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:134</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:140</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:141</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:142</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:143</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:146</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:147</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:148</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:162</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:163</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:164</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:165</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:166</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:167</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:168</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:169</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:170</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:171</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:172</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:173</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:174</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:175</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:176</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:177</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:178</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:179</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:180</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:182</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:183</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:184</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:185</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:57</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:58</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:64</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:65</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:80</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:81</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:82</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:85</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:86</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:87</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:94</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:95</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:96</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:98</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:99</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.Serializer.kt:26</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.Serializer.kt:27</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.Serializer.kt:28</ID>
@@ -2367,8 +2294,6 @@
     <ID>MaxLineLength:Orderly.kt$Orderly$private</ID>
     <ID>MaxLineLength:Orderly.kt$Orderly$val reportRepository: ReportRepository = OrderlyReportRepository(isReviewer, isGlobalReader, reportReadingScopes)</ID>
     <ID>MaxLineLength:OrderlyAuthorizationGenerator.kt$OrderlyAuthorizationGenerator&lt;T : CommonProfile&gt; : AuthorizationGenerator</ID>
-    <ID>MaxLineLength:OrderlyServerAPI.kt$OrderlyServer$override</ID>
-    <ID>MaxLineLength:OrderlyServerAPI.kt$OrderlyServerAPI$@Throws(OrderlyServerError::class) fun post(url: String, context: ActionContext, rawRequest: Boolean = false, transformResponse: Boolean = true): OrderlyServerResponse</ID>
     <ID>MaxLineLength:OrderlyWebAuthenticationConfig.kt$OrderlyWebAuthenticationConfig$val settingsRepo: SettingsRepository = OrderlySettingsRepository()</ID>
     <ID>MaxLineLength:OrderlyWebAuthenticationConfig.kt$UnknownAuthenticationProvider : Exception</ID>
     <ID>MaxLineLength:OrderlyWebError.kt$OrderlyWebError$open fun asResult()</ID>
@@ -2394,8 +2319,6 @@
     <ID>MaxLineLength:UnableToConnectToDatabaseError.kt$UnableToConnectToDatabaseError$org.vaccineimpact.orderlyweb.models.ErrorInfo("database-connection-error", "Unable to establish connection to the database at $url")</ID>
     <ID>MaxLineLength:UnknownObjectError.kt$UnknownObjectError$org.vaccineimpact.orderlyweb.models.ErrorInfo("unknown-${mangleTypeName(typeName)}", "Unknown ${mangleTypeName(typeName)} : '$id'")</ID>
     <ID>MaxLineLength:VersionRouteConfig.kt$VersionRouteConfig$APIEndpoint("/reports/:name/versions/:version/changelog/", versionController, "getChangelogByNameAndVersion")</ID>
-    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:20</ID>
-    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:91</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.SparkWrapper.kt:35</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.app_start.ErrorHandler.kt:65</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.app_start.routing.api.VersionRouteConfig.kt:45</ID>
@@ -2620,11 +2543,6 @@
     <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.DirectActionContext.kt:105</ID>
     <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.DirectActionContext.kt:73</ID>
     <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.Files.kt:99</ID>
-    <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:105</ID>
-    <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:114</ID>
-    <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:132</ID>
-    <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:175</ID>
-    <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:98</ID>
     <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.Serializer.kt:50</ID>
     <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.WebEndpoint.kt:58</ID>
     <ID>NoLineBreakAfterElse:org.vaccineimpact.orderlyweb.app_start.ActionResolver.kt:37</ID>
@@ -2774,8 +2692,6 @@
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.Helpers.kt:128</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.Helpers.kt:22</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.Helpers.kt:23</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:57</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:58</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.SparkWrapper.kt:12</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.SparkWrapper.kt:13</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.SparkWrapper.kt:35</ID>
@@ -3252,34 +3168,6 @@
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.Helpers.kt:85</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.Helpers.kt:93</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.Helpers.kt:97</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:101</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:105</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:110</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:114</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:124</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:128</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:132</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:138</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:146</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:153</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:162</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:165</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:167</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:169</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:171</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:175</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:18</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:32</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:38</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:44</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:51</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:60</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:71</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:78</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:85</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:92</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:94</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:98</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.Serializer.kt:12</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.Serializer.kt:14</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.Serializer.kt:41</ID>
@@ -3999,11 +3887,6 @@
     <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.DirectActionContext.kt:104</ID>
     <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.DirectActionContext.kt:72</ID>
     <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.Files.kt:98</ID>
-    <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:104</ID>
-    <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:113</ID>
-    <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:131</ID>
-    <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:174</ID>
-    <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:97</ID>
     <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.Serializer.kt:49</ID>
     <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.WebEndpoint.kt:57</ID>
     <ID>SpacingAroundKeyword:org.vaccineimpact.orderlyweb.app_start.ActionResolver.kt:36</ID>
@@ -4066,7 +3949,6 @@
     <ID>SpacingAroundOperators:org.vaccineimpact.orderlyweb.DirectActionContext.kt:96</ID>
     <ID>SpacingAroundOperators:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:15</ID>
     <ID>SpacingAroundOperators:org.vaccineimpact.orderlyweb.security.providers.GithubApiClientAuthHelper.kt:99</ID>
-    <ID>StringTemplate:org.vaccineimpact.orderlyweb.OrderlyServerAPI.kt:191</ID>
     <ID>StringTemplate:org.vaccineimpact.orderlyweb.controllers.web.GitController.kt:18</ID>
     <ID>StringTemplate:org.vaccineimpact.orderlyweb.viewmodels.ReportFileViewModelBuilder.kt:14</ID>
     <ID>StringTemplate:org.vaccineimpact.orderlyweb.viewmodels.ReportFileViewModelBuilder.kt:34</ID>

--- a/src/customConfigTests/build.gradle
+++ b/src/customConfigTests/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     testCompile "org.slf4j:slf4j-simple:1.7.21"
-    testCompile "khttp:khttp:0.1.0"
     testCompile "com.beust:klaxon:0.31"
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:2.+"

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
@@ -1,12 +1,12 @@
 package org.vaccineimpact.orderlyweb.customConfigTests
 
-import khttp.responses.Response
 import org.assertj.core.api.Assertions
 import org.junit.After
 import org.junit.Before
 import org.vaccineimpact.orderlyweb.app_start.main
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.getResource
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
 import java.io.File
 import java.net.BindException
 import java.net.ServerSocket
@@ -62,8 +62,6 @@ abstract class CustomConfigTests
     {
         Assertions.assertThat(response.statusCode)
                 .isEqualTo(200)
-
-        Assertions.assertThat(response.headers["Content-Encoding"]).isEqualTo("gzip")
     }
 
     protected fun assertHtmlContentType(response: Response)

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
@@ -1,12 +1,12 @@
 package org.vaccineimpact.orderlyweb.customConfigTests
 
 import com.github.fge.jackson.JsonLoader
-import khttp.post
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.test_helpers.TestTokenHeader
+import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
 
 class FineGrainedPermissionTests : CustomConfigTests()
 {
@@ -19,7 +19,7 @@ class FineGrainedPermissionTests : CustomConfigTests()
         startApp("auth.fine_grained=false")
 
         val token = RequestHelper().loginWithMontagu()["access_token"].toString()
-        val result = post(url, auth = TestTokenHeader(token))
+        val result = HttpClient.post(url, auth = TestTokenHeader(token))
 
         assertSuccessful(result)
 
@@ -53,7 +53,7 @@ class FineGrainedPermissionTests : CustomConfigTests()
 
         val token = RequestHelper().loginWithMontagu()["access_token"].toString()
 
-        val result = post(url, auth = TestTokenHeader(token))
+        val result = HttpClient.post(url, auth = TestTokenHeader(token))
 
         assertSuccessful(result)
 

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubAuthenticationTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubAuthenticationTests.kt
@@ -1,13 +1,12 @@
 package org.vaccineimpact.orderlyweb.customConfigTests
 
 import com.github.fge.jackson.JsonLoader
-import khttp.options
-import khttp.post
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.test_helpers.JSONValidator
 import org.vaccineimpact.orderlyweb.test_helpers.TestTokenHeader
+import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
 
 class GithubAuthenticationTests : CustomConfigTests()
 {
@@ -21,7 +20,7 @@ class GithubAuthenticationTests : CustomConfigTests()
     @Test
     fun `authentication fails without Auth header`()
     {
-        val result = post(url)
+        val result = HttpClient.post(url)
         assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(result.text,
                 expectedErrorCode = "github-token-invalid",
@@ -31,7 +30,7 @@ class GithubAuthenticationTests : CustomConfigTests()
     @Test
     fun `authentication fails with malformed Auth header`()
     {
-        val result = post(url, auth = TestTokenHeader("token", "bearer"))
+        val result = HttpClient.post(url, auth = TestTokenHeader("token", "bearer"))
         assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(result.text,
                 expectedErrorCode = "github-token-invalid",
@@ -41,7 +40,7 @@ class GithubAuthenticationTests : CustomConfigTests()
     @Test
     fun `authentication fails with invalid github token`()
     {
-        val result = post(url, auth = TestTokenHeader("badtoken"))
+        val result = HttpClient.post(url, auth = TestTokenHeader("badtoken"))
         assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(result.text,
                 expectedErrorCode = "github-token-invalid",
@@ -55,7 +54,7 @@ class GithubAuthenticationTests : CustomConfigTests()
         // reversed so GitHub doesn't spot it and invalidate it
         val token = "fcef1c6821f7561259ce45d4840965642607e5a4".reversed()
 
-        val result = post(url, auth = TestTokenHeader(token))
+        val result = HttpClient.post(url, auth = TestTokenHeader(token))
 
         assertSuccessful(result)
 
@@ -72,7 +71,7 @@ class GithubAuthenticationTests : CustomConfigTests()
         // reversed so GitHub doesn't spot it and invalidate it
         val tokenWithoutEmailReadingScope = "e0182507b0c6ad077a3036fd181a6260c0376e1c".reversed()
 
-        val result = post(url, auth = TestTokenHeader(tokenWithoutEmailReadingScope))
+        val result = HttpClient.post(url, auth = TestTokenHeader(tokenWithoutEmailReadingScope))
 
         JSONValidator.validateError(result.text,
                 expectedErrorCode = "github-token-invalid",
@@ -87,7 +86,7 @@ class GithubAuthenticationTests : CustomConfigTests()
         // reversed so GitHub doesn't spot it and invalidate it
         val tokenWithoutUserReadingScope = "285d9b1b6620ab4dfd6c403b29451d52aa38a158".reversed()
 
-        val result = post(url, auth = TestTokenHeader(tokenWithoutUserReadingScope))
+        val result = HttpClient.post(url, auth = TestTokenHeader(tokenWithoutUserReadingScope))
 
         JSONValidator.validateError(result.text,
                 expectedErrorCode = "github-token-invalid",
@@ -98,7 +97,7 @@ class GithubAuthenticationTests : CustomConfigTests()
     @Test
     fun `can get OPTIONS for authentication endpoint`()
     {
-        val result = options(url)
+        val result = HttpClient.options(url)
         assertThat(result.statusCode).isEqualTo(200)
     }
 

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RequestHelper.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RequestHelper.kt
@@ -2,11 +2,12 @@ package org.vaccineimpact.orderlyweb.customConfigTests
 
 import com.beust.klaxon.JsonObject
 import com.beust.klaxon.Parser
-import khttp.responses.Response
-import khttp.structures.authorization.BasicAuthorization
 import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.security.WebTokenHelper
+import org.vaccineimpact.orderlyweb.test_helpers.http.BasicAuthorization
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
+import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
 
 class RequestHelper
 {
@@ -28,7 +29,7 @@ class RequestHelper
     {
         // these user login details are set up in ./dev/run-dependencies.sh
         val auth = BasicAuthorization("test.user@example.com", "password")
-        val response = khttp.post("${AppConfig()["montagu.api_url"]}/authenticate/",
+        val response = HttpClient.post("${AppConfig()["montagu.api_url"]}/authenticate/",
                 data = mapOf("grant_type" to "client_credentials"),
                 auth = auth
         )
@@ -37,18 +38,12 @@ class RequestHelper
         return Parser().parse(StringBuilder(text)) as JsonObject
     }
 
-    private fun standardHeaders(contentType: String): Map<String, String>
-    {
-        return mapOf(
-                "Accept" to contentType,
-                "Accept-Encoding" to "gzip"
-        )
-    }
+    private fun standardHeaders(contentType: String) = mapOf("Accept" to contentType)
 
     private fun Map<String, String>.withAuthorizationHeader(token: String) = this +
             mapOf("Authorization" to "Bearer $token")
 
-    private fun get(url: String, headers: Map<String, String>) = khttp.get(url, headers)
+    private fun get(url: String, headers: Map<String, String>) = HttpClient.get(url, headers)
 
     private fun generateToken(emailAddress: String) =
             WebTokenHelper.instance.issuer.generateBearerToken(emailAddress)

--- a/src/testHelpers/build.gradle
+++ b/src/testHelpers/build.gradle
@@ -2,7 +2,9 @@ dependencies {
     compile "junit:junit:4.12"
     compile "org.jooq:jooq:3.9.1"
     compile "org.jooq:jooq-meta:3.9.1"
-    compile "khttp:khttp:0.1.0"
+    compile "org.json:json:20201115"
+    compile "com.squareup.okhttp3:okhttp:4.8.1"
+    compile "com.squareup.okhttp3:okhttp-urlconnection:4.8.1"
     compile "org.assertj:assertj-core:3.6.2"
     compile "com.github.fge:json-schema-validator:2.2.6"
 

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/RequestHelpers.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/RequestHelpers.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.orderlyweb.test_helpers
-import khttp.structures.authorization.Authorization
+
+import org.vaccineimpact.orderlyweb.test_helpers.http.Authorization
 
 data class TestTokenHeader(val token: String, val prefix: String = "token") : Authorization
 {

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/http/HttpClient.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/http/HttpClient.kt
@@ -1,0 +1,113 @@
+package org.vaccineimpact.orderlyweb.test_helpers.http
+
+import okhttp3.FormBody
+import okhttp3.Headers.Companion.toHeaders
+import okhttp3.JavaNetCookieJar
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.net.CookieManager
+import java.util.*
+
+object HttpClient
+{
+    fun get(url: String, headers: Map<String, String>, allowRedirects: Boolean = false): Response
+    {
+        val client = OkHttpClient.Builder()
+            .followRedirects(allowRedirects)
+            .apply {
+                if (allowRedirects)
+                {
+                    cookieJar(JavaNetCookieJar(CookieManager()))
+                }
+            }
+            .build()
+        val request = Request.Builder()
+            .url(url)
+            .headers(headers.toHeaders())
+            .build()
+        return Response(client.newCall(request).execute())
+    }
+
+    fun post(url: String, data: Map<String, String>, auth: Authorization): Response
+    {
+        val request = Request.Builder()
+            .url(url)
+            .header(auth.header.first, auth.header.second)
+            .post(
+                FormBody.Builder().apply {
+                    data.forEach { (t, u) -> add(t, u) }
+                }.build()
+            )
+            .build()
+        return Response(OkHttpClient().newCall(request).execute())
+    }
+
+    fun post(url: String, headers: Map<String, String>, json: Map<String, Any>?): Response
+    {
+        val request = Request.Builder()
+            .url(url)
+            .headers(headers.toHeaders())
+            .post((if (json == null) "" else JSONObject(json).toString()).toRequestBody("application/json".toMediaType()))
+            .build()
+        return Response(OkHttpClient().newCall(request).execute())
+    }
+
+    fun post(url: String) = post(url, emptyMap(), "")
+    fun post(url: String, auth: Authorization) = post(url, emptyMap(), auth)
+    fun post(url: String, headers: Map<String, String>, data: String?): Response
+    {
+        val request = Request.Builder()
+            .url(url)
+            .headers(headers.toHeaders())
+            .post((data ?: "").toRequestBody())
+            .build()
+        return Response(OkHttpClient().newCall(request).execute())
+    }
+
+    fun delete(url: String, headers: Map<String, String>): Response
+    {
+        val request = Request.Builder()
+            .url(url)
+            .headers(headers.toHeaders())
+            .delete()
+            .build()
+        return Response(OkHttpClient().newCall(request).execute())
+    }
+
+    fun options(url: String): Response
+    {
+        val request = Request.Builder()
+            .url(url)
+            .method("OPTIONS", null)
+            .build()
+        return Response(OkHttpClient().newCall(request).execute())
+    }
+}
+
+interface Authorization
+{
+    val header: Pair<String, String>
+}
+
+data class BasicAuthorization(val user: String, val password: String) : Authorization
+{
+    override val header: Pair<String, String>
+        get()
+        {
+            val b64 = Base64.getEncoder().encode("${this.user}:${this.password}".toByteArray()).toString(Charsets.UTF_8)
+            return "Authorization" to "Basic $b64"
+        }
+}
+
+class Response(private val okHttpResponse: okhttp3.Response)
+{
+    val content: ByteArray by lazy(okHttpResponse.body!!::bytes)
+    val headers: Map<String, String>
+        get() = okHttpResponse.headers.toMap().mapKeys { it.key.toLowerCase() }
+    val statusCode: Int
+        get() = okHttpResponse.code
+    val text: String by lazy(okHttpResponse.body!!::string)
+}


### PR DESCRIPTION
We currently use both OkHttp and khttp for HTTP requests. khttp is unmaintained. This changeset removes our dependency on it by introducing a new HttpClient class which broadly presents the same API in order to minimise code churn.

Implementation notes:
- Unlike khttp, OkHttp does transparent gzip - but only if you _don’t_ specify a Accept-Encoding on requests (even if this encoding is gzip!). So we remove this header where specified explicitly.
- Unlike khttp, OkHttp doesn’t automatically store cookies. These are only needed by our tests when redirection takes place - so this feature is enabled only where necessary.
- OkHttp is updated to the latest version compatible with the version of Kotlin that we're using (1.3)
- A direct dependency on org.json is added (it was previously transitive via khttp)

Observations:
- We use three different JSON codecs in relation to HTTP requests (GSON, klaxon and org.json) - we should consolidate these at some point.
- The de facto standard HTTP client for Kotlin is likely to become ktor-client. This PR would make switching to it easier as the new HttpClient is implementation-agnostic.