### PR TITLE
mrc-2116 Include user CLI build in buildkite scripts

### DIFF
--- a/buildkite/build-cli.sh
+++ b/buildkite/build-cli.sh
@@ -20,7 +20,10 @@ docker build --tag orderly-web-cli-build \
     .
 
 # Migrate the test db
-./scripts/migrate-test.sh
+#. $here/migrate-test.sh
+
+# Generate orderly data and migrate for orderly web tables
+$here/make-db.sh
 
 # Run the created image
 docker run --rm \

--- a/buildkite/build-cli.sh
+++ b/buildkite/build-cli.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -ex
+
+HERE=$(dirname $0)
+. $HERE/common
+
+# This is the path for teamcity agents. If running locally, pass in your own docker config location
+# i.e. /home/{user}/.docker/config.json
+#docker_auth_path=${1:-/opt/teamcity-agent/.docker/config.json}
+
+# Make the build environment image that is shared between multiple build targets
+./scripts/make-build-env.sh
+
+# Create an image based on the shared build env that compiles and dockerises
+# the CLI, and pushes the image
+docker build --tag orderly-web-cli-build \
+    --build-arg git_id=$GIT_ID \
+    --build-arg git_branch=$GIT_BRANCH \
+    -f cli.Dockerfile \
+    .
+
+# TODO test?
+
+# Migrate the test db
+#./scripts/migrate-test.sh
+
+# Run the created image
+#docker run --rm \
+#    -v /var/run/docker.sock:/var/run/docker.sock \
+#    -v $docker_auth_path:/root/.docker/config.json \
+#    -v $PWD/demo:/api/src/userCLI/demo \
+#    --network=host \
+#    orderly-web-cli-build
+

--- a/buildkite/build-cli.sh
+++ b/buildkite/build-cli.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
-HERE=$(dirname $0)
-. $HERE/common
+here=$(dirname $0)
+. $here/common
 
 # This is the path for teamcity agents. If running locally, pass in your own docker config location
 # i.e. /home/{user}/.docker/config.json
@@ -19,16 +19,14 @@ docker build --tag orderly-web-cli-build \
     -f cli.Dockerfile \
     .
 
-# TODO test?
-
 # Migrate the test db
-#./scripts/migrate-test.sh
+./scripts/migrate-test.sh
 
 # Run the created image
-#docker run --rm \
-#    -v /var/run/docker.sock:/var/run/docker.sock \
-#    -v $docker_auth_path:/root/.docker/config.json \
-#    -v $PWD/demo:/api/src/userCLI/demo \
-#    --network=host \
-#    orderly-web-cli-build
+docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $BUILDKITE_DOCKER_AUTH_PATH:/root/.docker/config.json \
+    -v $PWD/demo:/api/src/userCLI/demo \
+    --network=host \
+    orderly-web-cli-build
 

--- a/buildkite/common
+++ b/buildkite/common
@@ -31,6 +31,8 @@ export MONTAGU_ORDERLY_PATH=$PWD/git
 export ORDERLY_SERVER_USER_ID=$UID
 
 function cleardocker() {
+  echo here is
+  echo $here
   $here/../scripts/clear-docker.sh
 }
 trap cleardocker EXIT

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -20,6 +20,9 @@ steps:
 
     - wait
 
+    - label: ":construction_worker: Make user CLI"
+      command: buildkite/build-cli.sh
+
     - label: ":mag: Run smoke test"
       command: buildkite/run-smoke-test.sh
 

--- a/src/config/detekt/baseline-userCLI.xml
+++ b/src/config/detekt/baseline-userCLI.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>FinalNewline:org.vaccineimpact.orderlyweb.userCLI.App.kt:1</ID>
+    <ID>FinalNewline:org.vaccineimpact.orderlyweb.userCLI.tests.AddMembersTests.kt:1</ID>
+    <ID>FinalNewline:org.vaccineimpact.orderlyweb.userCLI.tests.AddPermissionTests.kt:1</ID>
+    <ID>FinalNewline:org.vaccineimpact.orderlyweb.userCLI.tests.AddUserGroupTests.kt:1</ID>
+    <ID>FinalNewline:org.vaccineimpact.orderlyweb.userCLI.tests.AddUserTests.kt:1</ID>
+    <ID>MaxLineLength:AddPermissionTests.kt$AddPermissionTests$grantPermissions(mapOf("&lt;group&gt;" to "[test.user@email.com]", "&lt;permission&gt;" to listOf("[*/permission.read]")))</ID>
+    <ID>MaxLineLength:AddPermissionTests.kt$AddPermissionTests$grantPermissions(mapOf("&lt;group&gt;" to "[test.user@email.com]", "&lt;permission&gt;" to listOf("[badlyformatted/reports.read]")))</ID>
+    <ID>MaxLineLength:AddPermissionTests.kt$AddPermissionTests$val result = grantPermissions(mapOf("&lt;group&gt;" to "[test.user@email.com]", "&lt;permission&gt;" to listOf("[*/reports.read]", "[report:testreport/reports.review]")))</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.userCLI.tests.AddPermissionTests.kt:20</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.userCLI.tests.AddPermissionTests.kt:54</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.userCLI.tests.AddPermissionTests.kt:58</ID>
+    <ID>NewLineAtEndOfFile:AddMembersTests.kt$org.vaccineimpact.orderlyweb.userCLI.tests.AddMembersTests.kt</ID>
+    <ID>NewLineAtEndOfFile:AddPermissionTests.kt$org.vaccineimpact.orderlyweb.userCLI.tests.AddPermissionTests.kt</ID>
+    <ID>NewLineAtEndOfFile:AddUserGroupTests.kt$org.vaccineimpact.orderlyweb.userCLI.tests.AddUserGroupTests.kt</ID>
+    <ID>NewLineAtEndOfFile:AddUserTests.kt$org.vaccineimpact.orderlyweb.userCLI.tests.AddUserTests.kt</ID>
+    <ID>NewLineAtEndOfFile:App.kt$org.vaccineimpact.orderlyweb.userCLI.App.kt</ID>
+    <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.userCLI.GrantPermission.kt:17</ID>
+    <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.userCLI.tests.AddPermissionTests.kt:40</ID>
+    <ID>NoConsecutiveBlankLines:org.vaccineimpact.orderlyweb.userCLI.AddMembers.kt:19</ID>
+    <ID>NoConsecutiveBlankLines:org.vaccineimpact.orderlyweb.userCLI.tests.AddPermissionTests.kt:47</ID>
+    <ID>SpacingAroundComma:org.vaccineimpact.orderlyweb.userCLI.App.kt:45</ID>
+    <ID>TooGenericExceptionCaught:App.kt$e: Exception</ID>
+    <ID>TopLevelPropertyNaming:App.kt$const val doc = """ OrderlyWeb User CLI Usage: app add-users &lt;email&gt;... app add-groups &lt;name&gt;... app add-members &lt;group&gt; &lt;email&gt;... app grant &lt;group&gt; &lt;permission&gt;... """</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/src/userCLI/build.gradle
+++ b/src/userCLI/build.gradle
@@ -42,6 +42,12 @@ distDocker {
     tagVersion = cli_docker_version
 }
 
+detekt {
+    config = files("$rootDir/config/detekt/detekt.yml")
+    buildUponDefaultConfig = true
+    baseline = file("$rootDir/config/detekt/baseline-userCLI.xml")
+}
+
 task copyDemo(type: Copy) {
     from '../app/demo'
     include '*'


### PR DESCRIPTION
Building the user CLI was missing from the buildkite build, so this PR:
- Adds a build step to build and run the build environment container which tests and pushes the CLI image
- Adds detekt baseline and gradle task for user CLI code - the above step includes checking detekt