### PR TITLE
mrc-1607 Run report page: user can set changelog message and type

### DIFF
--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -33,6 +33,24 @@
                     </select>
                 </div>
             </div>
+          <div v-if="showChangelog">
+          <div id="changelog-message" class="form-group row">
+            <label for="changelogMessage" class="col-sm-2 col-form-label text-right">Changelog Message</label>
+            <div class="col-sm-6">
+              <textarea class="form-control" id="changelogMessage" rows="2"></textarea>
+            </div>
+          </div>
+          <div id="changelog-type" class="form-group row">
+            <label for="changelogType" class="col-sm-2 col-form-label text-right">Changelog Type</label>
+            <div class="col-sm-6">
+              <select class="form-control" :id="changelogType">
+                <option v-for="option in metadata.changelog_types" :value="option">
+                  {{ option }}
+                </option>
+              </select>
+            </div>
+          </div>
+          </div>
         </form>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>
     </div>
@@ -59,6 +77,9 @@
         computed: {
             showCommits: function () {
                 return this.gitCommits && this.gitCommits.length;
+            },
+            showChangelog: function () {
+              return this.showCommits
             }
         },
         methods: {

--- a/src/app/static/src/tests/components/runReport/runReport.test.js
+++ b/src/app/static/src/tests/components/runReport/runReport.test.js
@@ -189,11 +189,6 @@ describe("reportTags", () => {
                     changelog_types: changelogTypes
                 },
                 gitBranches
-            },
-            data() {
-                return {
-                    gitCommits: ""
-                }
             }
         });
         expect(wrapper.find("#changelog-message").exists()).toBe(false);

--- a/src/app/static/src/tests/components/runReport/runReport.test.js
+++ b/src/app/static/src/tests/components/runReport/runReport.test.js
@@ -156,4 +156,48 @@ describe("reportTags", () => {
         expect(wrapper.find("#another").exists()).toBe(false);
     });
 
+    it("it does render changelog message and type correctly if commits control exists", () => {
+        const changelogTypes =  ["internal", "public"]
+        const wrapper = mount(RunReport, {
+            propsData: {
+                metadata: {
+                    git_supported: true,
+                    changelog_types: changelogTypes
+                },
+                gitBranches
+            },
+            data() {
+                return {
+                    gitCommits: mockCommits
+                }
+            }
+        });
+
+        expect(wrapper.find("#changelog-message").exists()).toBe(true);
+        const options = wrapper.find("#changelog-type").find("select")
+            .findAll("option")
+        expect(options.at(0).text()).toBe(changelogTypes[0]);
+        expect(options.at(1).text()).toBe(changelogTypes[1]);
+    });
+
+    it("it does not render changelog message and type if commits control doesnt exists", () => {
+        const changelogTypes =  ["internal", "public"]
+        const wrapper = mount(RunReport, {
+            propsData: {
+                metadata: {
+                    git_supported: false,
+                    changelog_types: changelogTypes
+                },
+                gitBranches
+            },
+            data() {
+                return {
+                    gitCommits: ""
+                }
+            }
+        });
+        expect(wrapper.find("#changelog-message").exists()).toBe(false);
+        expect(wrapper.find("#changelog-type").exists()).toBe(false);
+    });
+
 });


### PR DESCRIPTION
This PR creates form controls for message and type changelog. Nothing has been persisted yet.