### PR TITLE
mrc-1606 Add run report button and temporary status check

### DIFF
--- a/src/app/static/src/js/components/runReport/reportList.vue
+++ b/src/app/static/src/js/components/runReport/reportList.vue
@@ -9,7 +9,7 @@
     >
         <template slot="append">
             <button class="btn btn-outline-secondary" v-on:click.prevent="clear" v-if="query">
-                🗙
+                ×
             </button>
         </template>
         <template slot="suggestion" slot-scope="{ data, htmlText }">

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -46,9 +46,9 @@
                     </button>
                     <div id="run-report-status" v-if="runningStatus" class="text-secondary mt-2">
                         {{runningStatus}}
-                <a @click.prevent="checkStatus" href="#">Check status</a>
-            </div>
-    </div>
+                        <a @click.prevent="checkStatus" href="#">Check status</a>
+                    </div>
+                 </div>
             </div>
         </form>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -140,13 +140,14 @@
                 };
                 api.post(`/report/${this.selectedReport}/actions/run/`, {}, {params})
                     .then(({data}) => {
-                        this.error = "";
                         this.runningKey = data.data.key;
                         this.runningStatus = "Run started";
+                        this.error = "";
+                        this.defaultMessage = "";
                     })
                     .catch((error) => {
                         this.error = error;
-                        this.defaultMessage = "Error when running report";
+                        this.defaultMessage = "An error occurred when running report";
                     });
             },
             checkStatus() {

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -37,10 +37,10 @@
                     </div>
                 </div>
             </template>
-            <div id="run-form-group" class="form-group row">
+            <div v-if="showRunButton" id="run-form-group" class="form-group row">
                 <div class="col-sm-2"></div>
                 <div class="col-sm-6">
-                    <button v-if="showRunButton" @click.prevent="runReport" class="btn" type="submit">Run report</button>
+                    <button @click.prevent="runReport" class="btn" type="submit">Run report</button>
                     <div id="run-report-status" v-if="runningStatus" class="text-secondary mt-2">
                         {{runningStatus}}
                         <a @click.prevent="checkStatus" href="#">Check status</a>

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -137,11 +137,21 @@
             runReport() {
                 //TODO: Include parameters and changelog message when implemented
                 //TODO: Add link to running report log on response, when implemented
-                //TODO: confirm instances format and provide instance(s) - orderly web server expects a single string,
-                //      but our metadata suggests should be returning a map. Check which we've settled on.
+
+                //Orderly server currently only accepts a single instance value, although the metadata endpoint supports
+                //multiple instances - until multiple are accepted, send the selected instance value for instance with
+                //greatest number of options
+                let instance = "";
+                if (this.metadata.instances_supported && this.metadata.instances &&
+                        Object.keys(this.metadata.instances).length > 0) {
+                    const instances = this.metadata.instances;
+                    const instanceName = Object.keys(instances).sort((a, b) => instances[a] < instances[b] ? 1 : -1)[0];
+                    instance = this.selectedInstances[instanceName]
+                }
+
                 const params = {
                     ref: this.selectedCommitId,
-                    instance: ""
+                    instance
                 };
                 api.post(`/report/${this.selectedReport}/actions/run/`, {}, {params})
                     .then(({data}) => {

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -156,10 +156,12 @@
                 api.get(`/report/${this.selectedReport}/actions/status/${this.runningKey}/`)
                     .then(({data}) => {
                         this.runningStatus = `Running status: ${data.data.status}`;
+                        this.error = "";
+                        this.defaultMessage = "";
                     })
                     .catch((error) => {
                         this.error = error;
-                        this.defaultMessage = "Error when fetching report status";
+                        this.defaultMessage = "An error occurred when fetching report status";
                     });
             }
         },

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -29,8 +29,9 @@
                 <div v-for="(options, name) in metadata.instances" v-if="options.length > 1" class="form-group row">
                     <label :for="name" class="col-sm-2 col-form-label text-right">Database "{{ name }}"</label>
                     <div class="col-sm-6">
-                        <select class="form-control" :id="name" v-model="selectedInstances[name]">
-                            <option v-for="option in options" :value="option">
+                        <select class="form-control" :id="name" :ref="`instance-${name}`" @change="changeInstance(name)">
+                            <option v-for="option in options" :value="option"
+                                    :selected="option === selectedInstances[name] ? 'selected' : undefined">
                                 {{ option }}
                             </option>
                         </select>
@@ -43,13 +44,14 @@
                     <button @click.prevent="runReport" class="btn" type="submit">Run report</button>
                     <div id="run-report-status" v-if="runningStatus" class="text-secondary mt-2">
                         {{runningStatus}}
-                        <a @click.prevent="checkStatus" href="#">Check status</a>
-                    </div>
-                </div>
+                <a @click.prevent="checkStatus" href="#">Check status</a>
+            </div>
+    </div>
             </div>
         </form>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>
     </div>
+
 </template>
 
 <script>
@@ -115,6 +117,11 @@
             changedCommit() {
                 this.updateReports();
             },
+            changeInstance(name) {
+                const value = this.$refs[`instance-${name}`][0].value;
+                this.selectedInstances[name] = value;
+                this.runningStatus = "";
+            },
             updateReports() {
                 this.reports = [];
                 const query = this.metadata.git_supported ? `?branch=${this.selectedBranch}&commit=${this.selectedCommitId}` : '';
@@ -172,6 +179,7 @@
             } else {
                 this.updateReports();
             }
+
             if (this.metadata.instances_supported) {
                 const instances = this.metadata.instances;
                 for (const key in instances) {
@@ -184,12 +192,6 @@
         watch: {
             selectedReport() {
                 this.runningStatus = "";
-            },
-            selectedInstances: {
-                handler() {
-                    this.runningStatus = "";
-                },
-                deep: true
             }
         }
     }

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -132,8 +132,8 @@
             runReport() {
                 //TODO: Include parameters and changelog message when implemented
                 //TODO: Add link to running report log on response, when implemented
-                //TODO: confirm instances format - orderly web server expects a single string, but our metadata
-                //      suggests should be returning a map. Check which we've settled on.
+                //TODO: confirm instances format and provide instance(s) - orderly web server expects a single string,
+                //      but our metadata suggests should be returning a map. Check which we've settled on.
                 const params = {
                     ref: this.selectedCommitId,
                     instance: ""
@@ -176,6 +176,14 @@
                         this.selectedInstances[key] = instances[key][0]
                     }
                 }
+            }
+        },
+        watch: {
+            selectedReport() {
+                this.runningStatus = "";
+            },
+            selectedInstances() {
+                this.runningStatus = "";
             }
         }
     }

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -40,8 +40,7 @@
             <div v-if="showRunButton" id="run-form-group" class="form-group row">
                 <div class="col-sm-2"></div>
                 <div class="col-sm-6">
-                    <button @click.prevent="runReport" class="btn" type="submit"
-                            :disabled="disableRun ? 'disabled' : undefined">
+                    <button @click.prevent="runReport" class="btn" type="submit" :disabled="disableRun">
                         Run report
                     </button>
                     <div id="run-report-status" v-if="runningStatus" class="text-secondary mt-2">

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -185,8 +185,11 @@
             selectedReport() {
                 this.runningStatus = "";
             },
-            selectedInstances() {
-                this.runningStatus = "";
+            selectedInstances: {
+                handler() {
+                    this.runningStatus = "";
+                },
+                deep: true
             }
         }
     }

--- a/src/app/static/src/tests/components/runReport/runReport.test.js
+++ b/src/app/static/src/tests/components/runReport/runReport.test.js
@@ -371,7 +371,7 @@ describe("runReport", () => {
         expect(wrapper.find("#run-form-group button").attributes("disabled")).toBeUndefined();
     });
 
-    it("changing a selected instance updates data and resets runningStatus", async () => {
+    it("changing a selected instance updates data and resets runningStatus and disabledRun", async () => {
         const wrapper = shallowMount(RunReport, {
             propsData: {
                 metadata: {
@@ -386,10 +386,11 @@ describe("runReport", () => {
         });
         wrapper.setData({selectedReport: "test-report"});
         await Vue.nextTick();
-        wrapper.setData({runningStatus: "test-status"});
+        wrapper.setData({runningStatus: "test-status", disableRun: true});
         await Vue.nextTick();
         expect(wrapper.vm.runningStatus).toBe("test-status");
         expect(wrapper.vm.selectedInstances).toStrictEqual({source: "prod"});
+        expect(wrapper.find("#run-form-group button").attributes("disabled")).toBe("disabled");
 
         const select = wrapper.find("#source");
         select.setValue("uat");
@@ -397,5 +398,6 @@ describe("runReport", () => {
 
         expect(wrapper.vm.selectedInstances).toStrictEqual({source: "uat"});
         expect(wrapper.vm.runningStatus).toBe("");
+        expect(wrapper.find("#run-form-group button").attributes("disabled")).toBeUndefined();
     });
 });

--- a/src/app/static/src/tests/components/runReport/runReport.test.js
+++ b/src/app/static/src/tests/components/runReport/runReport.test.js
@@ -361,18 +361,31 @@ describe("runReport", () => {
         expect(wrapper.vm.runningStatus).toBe("");
     });
 
-    it("changing selectedInstances resets runningStatus", async () => {
-        const wrapper = getWrapper();
-        const selectedInstances = {source: "uat"};
-        wrapper.setData({selectedInstances});
+    it("changing a selected instance updates data and resets runningStatus", async () => {
+        const wrapper = shallowMount(RunReport, {
+            propsData: {
+                metadata: {
+                    git_supported: true,
+                    instances_supported: true,
+                    instances: {
+                        source: ["prod", "uat"],
+                    }
+                },
+                gitBranches
+            }
+        });
+        wrapper.setData({selectedReport: "test-report"});
         await Vue.nextTick();
-
         wrapper.setData({runningStatus: "test-status"});
         await Vue.nextTick();
         expect(wrapper.vm.runningStatus).toBe("test-status");
+        expect(wrapper.vm.selectedInstances).toStrictEqual({source: "prod"});
 
-        wrapper.vm.selectedInstances.source = "science";
+        const select = wrapper.find("#source");
+        select.setValue("uat");
         await Vue.nextTick();
+
+        expect(wrapper.vm.selectedInstances).toStrictEqual({source: "uat"});
         expect(wrapper.vm.runningStatus).toBe("");
     });
 });

--- a/src/app/static/src/tests/components/runReport/runReport.test.js
+++ b/src/app/static/src/tests/components/runReport/runReport.test.js
@@ -363,11 +363,15 @@ describe("runReport", () => {
 
     it("changing selectedInstances resets runningStatus", async () => {
         const wrapper = getWrapper();
+        const selectedInstances = {source: "uat"};
+        wrapper.setData({selectedInstances});
+        await Vue.nextTick();
+
         wrapper.setData({runningStatus: "test-status"});
         await Vue.nextTick();
         expect(wrapper.vm.runningStatus).toBe("test-status");
 
-        wrapper.setData({selectedInstances: {source: "uat"}});
+        wrapper.vm.selectedInstances.source = "science";
         await Vue.nextTick();
         expect(wrapper.vm.runningStatus).toBe("");
     });

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -59,6 +59,27 @@ class RunReportPageTests : SeleniumTest()
     }
 
     @Test
+    fun `can run a report and check status`()
+    {
+        val typeahead = driver.findElement(By.id("report"))
+        val input = typeahead.findElement(By.tagName("input"))
+        input.sendKeys("min")
+        val matches = typeahead.findElements(By.tagName("a"))
+        matches[0].click()
+
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("run-form-group")))
+
+        val button = driver.findElement(By.cssSelector("#run-form-group button"))
+        button.click()
+
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("run-report-status")))
+        assertThat(driver.findElement(By.id("run-report-status")).text).startsWith("Run started")
+
+        driver.findElement(By.cssSelector("#run-report-status a")).click()
+        wait.until(ExpectedConditions.textToBePresentInElementLocated(By.id("run-report-status"), "Running status:"))
+    }
+
+    @Test
     fun `can view logs tab`()
     {
         driver.findElement(By.id("logs-link")).click()


### PR DESCRIPTION
It may be a bit premature to put this in, as a couple of other tickets/clarifications need to be resolved which will require modification of the `run` request - but it's probably good to get something in early to actually get reports running. 

Please note:
- There were no changes required to the backend as the existing run endpoint, simply passes through the request to orderly server
- I am confused about instances - we have our metadata and vue set up to assume there can be multiple instances, however the interface for orderly server only accepts a single instance. I've asked Rob to clarify, will check with him when I get back from leave. Since we seem to be getting a map of metadata instances from OS, I think its run endpoint just needs to be updated. 
- To run up the page with runnable reports locally, you must use 'git mode' - however, the report will not run to completion successfully in the local demo system because of unclean git status when attempting to switch to requested git ref. 
- So I have deployed this branch to UAT (https://support.montagu.dide.ic.ac.uk:10443/reports/run-report), where reports are runnable. Login with your montagu credentials. Try running `paper-first-public-app` on master with uat source database. The status will change to 'success' after a minute or so, and you should be able to see your new report version in the main reports page.
- I have put in a temporary 'Check status' link as a testing convenience - this can be replaced with the 'View log' link as per the mockup once the logging page is done
- The running status message is reset if the user selects a new report or a new database instance after a previous run has begun, since changing these values indicates embarking on a new run. It is automatically reset on select new git branch or commit, since both of these reset the selected report. In the course of implementing this, I discovered that `v-model` was not working for the multiple instance selects, so I've replaced it with a method triggered by `change` event. 