### PR TITLE
Add row to orderlyweb_runningreport when run a report

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -198,7 +198,16 @@ Starts a new Orderly run of a report named `:name`.
 
 Required permissions: `reports.run`.
 
-Accepts as `POST` body json that will be passed directly through to the report.  This is required when the report requires parameters and is not allowed for reports that do not allow parameters.
+Accepts optional arguments as the JSON encoded body of a `POST` request:
+```json
+{
+  "instances": {"database": "instance", …},
+  "params": {"name": "value", …},
+  "gitBranch": "main",
+  "gitCommit": "abc1234"
+}
+```
+`params` will be passed directly through to the report.  This is required when the report requires parameters and is not allowed for reports that do not allow parameters.
 
 Accepts the query parameter `ref`, to try running the report against a particular git reference (e.g., a branch or a commit).  This is not yet actually supported.
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -201,8 +201,8 @@ Required permissions: `reports.run`.
 Accepts optional arguments as the JSON encoded body of a `POST` request:
 ```json
 {
-  "instances": {"database": "instance", …},
-  "params": {"name": "value", …},
+  "instances": {"source": "production"},
+  "params": {"name1": "value1", "name2": "value2"},
   "gitBranch": "main",
   "gitCommit": "abc1234"
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -27,8 +27,8 @@ interface OrderlyServerAPI
 
     fun post(
         url: String,
-        data: String,
-        params: Map<String, String?>
+        bodyJson: String,
+        queryParams: Map<String, String?>
     ): OrderlyServerResponse
 
     @Throws(OrderlyServerError::class)
@@ -149,19 +149,19 @@ class OrderlyServer(
         }
     }
 
-    override fun post(url: String, data: String, params: Map<String, String?>): OrderlyServerResponse
+    override fun post(url: String, bodyJson: String, queryParams: Map<String, String?>): OrderlyServerResponse
     {
         val httpUrl = urlBase.toHttpUrl().newBuilder()
             .addPathSegments(url.trimStart('/'))
             .apply {
-                params.forEach { (key, value) ->
+                queryParams.forEach { (key, value) ->
                     addQueryParameter(key, value)
                 }
             }.build()
         val request = Request.Builder()
             .url(httpUrl)
             .headers(standardHeaders.toHeaders())
-            .post(data.toRequestBody(ContentTypes.json.toMediaType()))
+            .post(bodyJson.toRequestBody(ContentTypes.json.toMediaType()))
             .build()
         val response = client.newCall(request).execute()
         if (!response.isSuccessful && throwOnError)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -25,6 +25,7 @@ interface OrderlyServerAPI
         transformResponse: Boolean = true
     ): OrderlyServerResponse
 
+    @Throws(OrderlyServerError::class)
     fun post(
         url: String,
         bodyJson: String,

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/ReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/api/ReportRouteConfig.kt
@@ -3,42 +3,41 @@ package org.vaccineimpact.orderlyweb.app_start.routing.api
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.app_start.RouteConfig
 import org.vaccineimpact.orderlyweb.controllers.api.ReportController
+import org.vaccineimpact.orderlyweb.controllers.api.ReportRunController
 import spark.route.HttpMethod
 
 object ReportRouteConfig : RouteConfig
 {
     private val runReports = setOf("*/reports.run")
     private val readReports = setOf("report:<name>/reports.read")
-    private val controller = ReportController::class
 
     override val endpoints: List<EndpointDefinition> = listOf(
 
-            APIEndpoint("/reports/", controller, "getAllReports")
-
+            APIEndpoint("/reports/", ReportController::class, "getAllReports")
                     .json()
                     .transform()
                     // more specific permission checking in the controller action
                     .secure(),
 
-            APIEndpoint("/reports/:name/", controller, "getVersionsByName")
+            APIEndpoint("/reports/:name/", ReportController::class, "getVersionsByName")
                     .json()
                     .transform()
                     .secure(readReports),
 
-            APIEndpoint("/reports/:name/run/", controller, "run",
+            APIEndpoint("/reports/:name/run/", ReportRunController::class, "run",
                     method = HttpMethod.post)
                     .json()
                     .secure(runReports),
 
-            APIEndpoint("/reports/:key/status/", controller, "status")
+            APIEndpoint("/reports/:key/status/", ReportRunController::class, "status")
                     .json()
                     .secure(runReports),
-            APIEndpoint("/reports/:key/kill/", controller, "kill",
+            APIEndpoint("/reports/:key/kill/", ReportRunController::class, "kill",
                     method = HttpMethod.delete)
                     .json()
                     .secure(runReports),
 
-            APIEndpoint("/reports/:name/latest/changelog/", controller, "getLatestChangelogByName")
+            APIEndpoint("/reports/:name/latest/changelog/", ReportController::class, "getLatestChangelogByName")
                     .json()
                     .transform()
                     .secure(readReports)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.orderlyweb.app_start.routing.web
 
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.app_start.RouteConfig
+import org.vaccineimpact.orderlyweb.controllers.api.ReportRunController
 import org.vaccineimpact.orderlyweb.controllers.web.IndexController
 import org.vaccineimpact.orderlyweb.controllers.web.ReportController
 import spark.route.HttpMethod
@@ -27,12 +28,12 @@ object WebReportRouteConfig : RouteConfig
                     ReportController::class, "getByNameAndVersion")
                     .secure(readReports),
             WebEndpoint("/report/:name/actions/run/",
-                    org.vaccineimpact.orderlyweb.controllers.api.ReportController::class, "run",
+                    ReportRunController::class, "run",
                     method = HttpMethod.post)
                     .json()
                     .secure(runReports),
             WebEndpoint("/report/:name/actions/status/:key/",
-                    org.vaccineimpact.orderlyweb.controllers.api.ReportController::class, "status")
+                    ReportRunController::class, "status")
                     .json()
                     .secure(runReports),
             WebEndpoint(

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportController.kt
@@ -1,10 +1,6 @@
 package org.vaccineimpact.orderlyweb.controllers.api
 
-import org.vaccineimpact.orderlyweb.models.Changelog
-import org.vaccineimpact.orderlyweb.models.Report
-import org.vaccineimpact.orderlyweb.models.ReportVersionWithDescCustomFieldsLatestParamsTags
-import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
-import org.vaccineimpact.orderlyweb.*
+import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.Controller
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config
@@ -13,46 +9,29 @@ import org.vaccineimpact.orderlyweb.db.OrderlyClient
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyReportRepository
 import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
 import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
+import org.vaccineimpact.orderlyweb.models.Changelog
+import org.vaccineimpact.orderlyweb.models.Report
+import org.vaccineimpact.orderlyweb.models.ReportVersionWithDescCustomFieldsLatestParamsTags
+import org.vaccineimpact.orderlyweb.models.permissions.PermissionSet
 
-class ReportController(context: ActionContext,
-                       private val orderly: OrderlyClient,
-                       private val reportRepository: ReportRepository,
-                       private val orderlyServerAPI: OrderlyServerAPI,
-                       config: Config) : Controller(context, config)
+class ReportController(
+    context: ActionContext,
+    private val orderly: OrderlyClient,
+    private val reportRepository: ReportRepository,
+    config: Config
+) : Controller(context, config)
 {
     constructor(context: ActionContext) :
             this(context,
                     Orderly(context),
                     OrderlyReportRepository(context),
-                    OrderlyServer(AppConfig()),
                     AppConfig())
-
-    fun run(): String
-    {
-        val name = context.params(":name")
-        val response = orderlyServerAPI.post("/v1/reports/$name/run/", context)
-        return passThroughResponse(response)
-    }
 
     fun publish(): Boolean
     {
         val name = context.params(":name")
         val version = context.params(":version")
         return reportRepository.togglePublishStatus(name, version)
-    }
-
-    fun status(): String
-    {
-        val key = context.params(":key")
-        val response = orderlyServerAPI.get("/v1/reports/$key/status/", context)
-        return passThroughResponse(response)
-    }
-
-    fun kill(): String
-    {
-        val key = context.params(":key")
-        val response = orderlyServerAPI.delete("/v1/reports/$key/kill/", context)
-        return passThroughResponse(response)
     }
 
     fun getAllReports(): List<Report>
@@ -81,11 +60,9 @@ class ReportController(context: ActionContext,
         return reportRepository.getReportsByName(name)
     }
 
-
     fun getLatestChangelogByName(): List<Changelog>
     {
         val name = context.params(":name")
         return orderly.getLatestChangelogByName(name)
     }
-
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
@@ -41,15 +41,11 @@ class ReportRunController(
             orderlyServerAPI.post(
                 "/v1/reports/$name/run/",
                 Gson().toJson(params),
-                mapOf(
+                listOf(
                     "ref" to gitCommit,
                     // TODO remove this in favour of passing instances itself to orderly.server - see VIMC-4561
-                    "instance" to when (instances.isEmpty())
-                    {
-                        true -> ""
-                        false -> instances.values.iterator().next()
-                    }
-                )
+                    "instance" to instances.values.elementAtOrNull(0)
+                ).mapNotNull { p -> p.second?.let { p } }.toMap()
             )
         val reportRun = response.data(ReportRun::class.java)
         reportRunRepository.addReportRun(

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
@@ -52,9 +52,9 @@ class ReportRunController(
                 )
             )
         val reportRun = response.data(ReportRun::class.java)
-        @Suppress("UnsafeCallOnNullableType")
         reportRunRepository.addReportRun(
             reportRun.key,
+            @Suppress("UnsafeCallOnNullableType")
             context.userProfile!!.id,
             Instant.now(),
             reportRun.name,

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
@@ -44,7 +44,7 @@ class ReportRunController(
                     "ref" to gitCommit,
                     // TODO remove this in favour of passing instances itself to orderly.server - see VIMC-4561
                     "instance" to instances.values.elementAtOrNull(0)
-                ).mapNotNull { p -> p.second?.let { p } }.toMap()
+                ).filter { it.second != null }.toMap()
             )
         val reportRun = response.data(ReportRun::class.java)
         reportRunRepository.addReportRun(

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
@@ -32,10 +32,10 @@ class ReportRunController(
     {
         val name = context.params(":name")
 
-        val instances: Map<String, String> = context.postData("instances")
-        val params: Map<String, String> = context.postData("params")
-        val gitBranch: String = context.postData("gitBranch")
-        val gitCommit: String = context.postData("gitCommit")
+        val instances = context.postData<Map<String, String>>()["instances"] ?: emptyMap()
+        val params = context.postData<Map<String, String>>()["params"] ?: emptyMap()
+        val gitBranch = context.postData<String>()["gitBranch"]
+        val gitCommit = context.postData<String>()["gitCommit"]
 
         val response =
             orderlyServerAPI.post(

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
@@ -1,0 +1,82 @@
+package org.vaccineimpact.orderlyweb.controllers.api
+
+import com.google.gson.Gson
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.OrderlyServer
+import org.vaccineimpact.orderlyweb.OrderlyServerAPI
+import org.vaccineimpact.orderlyweb.controllers.Controller
+import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.db.Config
+import org.vaccineimpact.orderlyweb.db.repositories.OrderlyWebReportRunRepository
+import org.vaccineimpact.orderlyweb.db.repositories.ReportRunRepository
+import java.time.Instant
+
+data class ReportRun(val name: String, val key: String, val path: String)
+
+class ReportRunController(
+    context: ActionContext,
+    private val reportRunRepository: ReportRunRepository,
+    private val orderlyServerAPI: OrderlyServerAPI,
+    config: Config
+) : Controller(context, config)
+{
+    constructor(context: ActionContext) :
+            this(
+                context,
+                OrderlyWebReportRunRepository(),
+                OrderlyServer(AppConfig()),
+                AppConfig()
+            )
+
+    fun run(): String
+    {
+        val name = context.params(":name")
+
+        val instances: Map<String, String> = context.postData("instances")
+        val params: Map<String, String> = context.postData("params")
+        val gitBranch: String = context.postData("gitBranch")
+        val gitCommit: String = context.postData("gitCommit")
+
+        val response =
+            orderlyServerAPI.post(
+                "/v1/reports/$name/run/",
+                Gson().toJson(params),
+                mapOf(
+                    "ref" to gitCommit,
+                    // TODO remove this in favour of passing instances itself to orderly.server - see VIMC-4561
+                    "instance" to when (instances.isEmpty())
+                    {
+                        true -> ""
+                        false -> instances.values.iterator().next()
+                    }
+                )
+            )
+        val reportRun = response.data(ReportRun::class.java)
+        @Suppress("UnsafeCallOnNullableType")
+        reportRunRepository.addReportRun(
+            reportRun.key,
+            context.userProfile!!.id,
+            Instant.now(),
+            reportRun.name,
+            instances,
+            params,
+            gitBranch,
+            gitCommit
+        )
+        return passThroughResponse(response)
+    }
+
+    fun status(): String
+    {
+        val key = context.params(":key")
+        val response = orderlyServerAPI.get("/v1/reports/$key/status/", context)
+        return passThroughResponse(response)
+    }
+
+    fun kill(): String
+    {
+        val key = context.params(":key")
+        val response = orderlyServerAPI.delete("/v1/reports/$key/kill/", context)
+        return passThroughResponse(response)
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
@@ -9,9 +9,8 @@ import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyWebReportRunRepository
 import org.vaccineimpact.orderlyweb.db.repositories.ReportRunRepository
+import org.vaccineimpact.orderlyweb.models.ReportRun
 import java.time.Instant
-
-data class ReportRun(val name: String, val key: String, val path: String)
 
 class ReportRunController(
     context: ActionContext,

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/ReportRunController.kt
@@ -24,7 +24,7 @@ class ReportRunController(
             this(
                 context,
                 OrderlyWebReportRunRepository(),
-                OrderlyServer(AppConfig()),
+                OrderlyServer(AppConfig()).throwOnError(),
                 AppConfig()
             )
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRunRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRunRepository.kt
@@ -1,0 +1,48 @@
+package org.vaccineimpact.orderlyweb.db.repositories
+
+import com.google.gson.Gson
+import org.vaccineimpact.orderlyweb.db.*
+import java.sql.Timestamp
+import java.time.Instant
+
+interface ReportRunRepository
+{
+    fun addReportRun(
+        key: String,
+        user: String,
+        date: Instant,
+        report: String,
+        instances: Map<String, String>,
+        params: Map<String, String>,
+        gitBranch: String?,
+        gitCommit: String?
+    )
+}
+
+class OrderlyWebReportRunRepository : ReportRunRepository
+{
+    override fun addReportRun(
+        key: String,
+        user: String,
+        date: Instant,
+        report: String,
+        instances: Map<String, String>,
+        params: Map<String, String>,
+        gitBranch: String?,
+        gitCommit: String?
+    )
+    {
+        JooqContext().use {
+            it.dsl.insertInto(Tables.ORDERLYWEB_REPORT_RUN)
+                .set(Tables.ORDERLYWEB_REPORT_RUN.KEY, key)
+                .set(Tables.ORDERLYWEB_REPORT_RUN.EMAIL, user)
+                .set(Tables.ORDERLYWEB_REPORT_RUN.DATE, Timestamp.from(date))
+                .set(Tables.ORDERLYWEB_REPORT_RUN.REPORT, report)
+                .set(Tables.ORDERLYWEB_REPORT_RUN.INSTANCES, Gson().toJson(instances))
+                .set(Tables.ORDERLYWEB_REPORT_RUN.PARAMS, Gson().toJson(params))
+                .set(Tables.ORDERLYWEB_REPORT_RUN.GIT_BRANCH, gitBranch)
+                .set(Tables.ORDERLYWEB_REPORT_RUN.GIT_COMMIT, gitCommit)
+                .execute()
+        }
+    }
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportRun.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportRun.kt
@@ -1,0 +1,3 @@
+package org.vaccineimpact.orderlyweb.models
+
+data class ReportRun(val name: String, val key: String, val path: String)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRunRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRunRepositoryTests.kt
@@ -25,8 +25,8 @@ class ReportRunRepositoryTests : CleanDatabaseTests()
             "user@email.com",
             now,
             "report1",
-            """{"instance1": "pre-staging"}""",
-            """{"parameter1": "value1"}""",
+            mapOf("instance1" to "pre-staging"),
+            mapOf("parameter1" to "value1"),
             "branch1",
             "commit1"
         )
@@ -35,8 +35,8 @@ class ReportRunRepositoryTests : CleanDatabaseTests()
             "user@email.com",
             now,
             "report2",
-            """{"instance2": "post-staging"}""",
-            """{"parameter2": "value2"}""",
+            mapOf("instance2" to "post-staging"),
+            mapOf("parameter2" to "value2"),
             "branch1",
             "commit2"
         )
@@ -50,8 +50,8 @@ class ReportRunRepositoryTests : CleanDatabaseTests()
             assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.EMAIL]).isEqualTo("user@email.com")
             assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.DATE].toInstant()).isEqualTo(now)
             assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.REPORT]).isEqualTo("report1")
-            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.INSTANCES]).isEqualTo("""{"instance1": "pre-staging"}""")
-            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.PARAMS]).isEqualTo("""{"parameter1": "value1"}""")
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.INSTANCES]).isEqualTo("""{"instance1":"pre-staging"}""")
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.PARAMS]).isEqualTo("""{"parameter1":"value1"}""")
             assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.GIT_BRANCH]).isEqualTo("branch1")
             assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.GIT_COMMIT]).isEqualTo("commit1")
 
@@ -69,8 +69,8 @@ class ReportRunRepositoryTests : CleanDatabaseTests()
                 "test.user@example.com",
                 Instant.now(),
                 "report2",
-                """{"instance2": "post-staging"}""",
-                """{"parameter2": "value2"}""",
+                mapOf("instance2" to "post-staging"),
+                mapOf("parameter2" to "value2"),
                 "branch1",
                 "commit2"
             )

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRunRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRunRepositoryTests.kt
@@ -1,0 +1,79 @@
+package org.vaccineimpact.orderlyweb.tests.database_tests
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.vaccineimpact.orderlyweb.db.JooqContext
+import org.vaccineimpact.orderlyweb.db.Tables
+import org.vaccineimpact.orderlyweb.db.repositories.OrderlyWebReportRunRepository
+import org.vaccineimpact.orderlyweb.test_helpers.CleanDatabaseTests
+import org.vaccineimpact.orderlyweb.tests.insertUser
+import java.time.Instant
+
+class ReportRunRepositoryTests : CleanDatabaseTests()
+{
+    @Test
+    fun `can add report run`()
+    {
+        insertUser("user@email.com", "user.name")
+
+        val now = Instant.now()
+
+        val sut = OrderlyWebReportRunRepository()
+        sut.addReportRun(
+            "adventurous_aardvark",
+            "user@email.com",
+            now,
+            "report1",
+            """{"instance1": "pre-staging"}""",
+            """{"parameter1": "value1"}""",
+            "branch1",
+            "commit1"
+        )
+        sut.addReportRun(
+            "benevolent_badger",
+            "user@email.com",
+            now,
+            "report2",
+            """{"instance2": "post-staging"}""",
+            """{"parameter2": "value2"}""",
+            "branch1",
+            "commit2"
+        )
+        JooqContext().use {
+            val result = it.dsl.selectFrom(Tables.ORDERLYWEB_REPORT_RUN).fetch()
+
+            assertThat(result.count()).isEqualTo(2)
+
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.ID]).isEqualTo(1)
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.KEY]).isEqualTo("adventurous_aardvark")
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.EMAIL]).isEqualTo("user@email.com")
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.DATE].toInstant()).isEqualTo(now)
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.REPORT]).isEqualTo("report1")
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.INSTANCES]).isEqualTo("""{"instance1": "pre-staging"}""")
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.PARAMS]).isEqualTo("""{"parameter1": "value1"}""")
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.GIT_BRANCH]).isEqualTo("branch1")
+            assertThat(result[0][Tables.ORDERLYWEB_REPORT_RUN.GIT_COMMIT]).isEqualTo("commit1")
+
+            assertThat(result[1][Tables.ORDERLYWEB_REPORT_RUN.ID]).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `cannot add report for non-existent user`()
+    {
+        val sut = OrderlyWebReportRunRepository()
+        assertThatThrownBy {
+            sut.addReportRun(
+                "adventurous_aardvark",
+                "test.user@example.com",
+                Instant.now(),
+                "report2",
+                """{"instance2": "post-staging"}""",
+                """{"parameter2": "value2"}""",
+                "branch1",
+                "commit2"
+            )
+        }.hasMessageContaining("FOREIGN KEY constraint failed")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ReportTests.kt
@@ -8,6 +8,7 @@ import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.integration_tests.APIPermissionChecker
+import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReader
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReviewer
 import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
 import spark.route.HttpMethod

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ReportTests.kt
@@ -8,7 +8,6 @@ import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
 import org.vaccineimpact.orderlyweb.tests.integration_tests.APIPermissionChecker
-import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReader
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReviewer
 import org.vaccineimpact.orderlyweb.tests.integration_tests.tests.IntegrationTest
 import spark.route.HttpMethod

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportControllerTests.kt
@@ -1,6 +1,5 @@
 package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.api
 
-import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
@@ -8,8 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ActionContext
-import org.vaccineimpact.orderlyweb.OrderlyServerAPI
-import org.vaccineimpact.orderlyweb.OrderlyServerResponse
 import org.vaccineimpact.orderlyweb.controllers.api.ReportController
 import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.db.OrderlyClient
@@ -52,53 +49,13 @@ class ReportControllerTests : ControllerTest()
     }
 
     @Test
-    fun `runs a report`()
-    {
-        val actionContext = mock<ActionContext> {
-            on { this.params(":name") } doReturn reportName
-            on { this.permissions } doReturn PermissionSet()
-        }
-
-        val mockAPIResponse = OrderlyServerResponse("okayresponse", 200)
-
-        val apiClient = mock<OrderlyServerAPI>() {
-            on { this.post(any(), any(), any(), any()) } doReturn mockAPIResponse
-        }
-
-        val sut = ReportController(actionContext, mock(), mockReportRepo, apiClient, mockConfig)
-
-        val result = sut.run()
-
-        assertThat(result).isEqualTo("okayresponse")
-    }
-
-    @Test
-    fun `kills a report`()
-    {
-        val actionContext = mock<ActionContext> {
-            on { this.params(":key") } doReturn reportKey
-        }
-
-        val mockAPIResponse = OrderlyServerResponse("okayresponse", 200)
-
-        val apiClient = mock<OrderlyServerAPI>() {
-            on { this.delete("/v1/reports/$reportKey/kill/", actionContext) } doReturn mockAPIResponse
-        }
-
-        val sut = ReportController(actionContext, mock(), mockReportRepo, apiClient, mockConfig)
-        val result = sut.kill()
-
-        assertThat(result).isEqualTo("okayresponse")
-    }
-
-    @Test
     fun `getAllReports throws MissingRequiredPermission error if user has no report reading permissions`()
     {
         val mockContext = mock<ActionContext> {
             on { it.permissions } doReturn PermissionSet()
         }
 
-        val sut = ReportController(mockContext, mockOrderly, mockReportRepo, mock(), mockConfig)
+        val sut = ReportController(mockContext, mockOrderly, mockReportRepo, mockConfig)
 
         assertThatThrownBy { sut.getAllReports() }
                 .isInstanceOf(MissingRequiredPermissionError::class.java)
@@ -112,7 +69,7 @@ class ReportControllerTests : ControllerTest()
             on { it.permissions } doReturn PermissionSet()
         }
 
-        val sut = ReportController(mockContext, mock(), mock(), mock(), mockConfig)
+        val sut = ReportController(mockContext, mock(), mock(), mockConfig)
 
         assertThatThrownBy { sut.getAllVersions() }
                 .isInstanceOf(MissingRequiredPermissionError::class.java)
@@ -133,7 +90,7 @@ class ReportControllerTests : ControllerTest()
             on { it.params(":name") } doReturn reportName
         }
 
-        val sut = ReportController(mockContext, mock(), mockReportRepo, mock(), mockConfig)
+        val sut = ReportController(mockContext, mock(), mockReportRepo, mockConfig)
 
         assertThat(sut.getVersionsByName()).isEqualTo(reportVersions)
     }
@@ -157,7 +114,7 @@ class ReportControllerTests : ControllerTest()
             on { this.params(":name") } doReturn reportName
         }
 
-        val sut = ReportController(mockContext, orderly, mockReportRepo, mock(), mockConfig)
+        val sut = ReportController(mockContext, orderly, mockReportRepo, mockConfig)
 
         val result = sut.getLatestChangelogByName()
         assertThat(result.count()).isEqualTo(changelogs.count())
@@ -181,7 +138,7 @@ class ReportControllerTests : ControllerTest()
             on { this.params(":name") } doReturn name
         }
 
-        val sut = ReportController(mockContext, mock(), mockReportRepo, mock(), mockConfig)
+        val sut = ReportController(mockContext, mock(), mockReportRepo, mockConfig)
 
         val result = sut.publish()
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportRunControllerTests.kt
@@ -58,6 +58,41 @@ class ReportRunControllerTests : ControllerTest()
     }
 
     @Test
+    fun `runs a report without arguments`()
+    {
+        val actionContext: ActionContext = mock {
+            on { params(":name") } doReturn reportName
+            on { userProfile } doReturn CommonProfile().apply { id = "a@b.com" }
+        }
+
+        val mockAPIResponseText =
+            """{"data": {"name": "$reportName", "key": $reportKey, "path": "/status/$reportKey"}}"""
+
+        val mockAPIResponse = OrderlyServerResponse(mockAPIResponseText, 200)
+
+        val apiClient: OrderlyServerAPI = mock {
+            on { post("/v1/reports/$reportName/run/","{}", mapOf()) } doReturn mockAPIResponse
+        }
+
+        val mockReportRunRepo: ReportRunRepository = mock()
+
+        val sut = ReportRunController(actionContext, mockReportRunRepo, apiClient, mock())
+        val result = sut.run()
+
+        assertThat(result).isEqualTo(mockAPIResponseText)
+        verify(mockReportRunRepo).addReportRun(
+            eq(reportKey),
+            eq("a@b.com"),
+            any<Instant>(),
+            eq(reportName),
+            eq(mapOf()),
+            eq(mapOf()),
+            eq(null),
+            eq(null)
+        )
+    }
+
+    @Test
     fun `gets report status`()
     {
         val actionContext: ActionContext = mock {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportRunControllerTests.kt
@@ -1,0 +1,95 @@
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.api
+
+import com.nhaarman.mockito_kotlin.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.pac4j.core.profile.CommonProfile
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.OrderlyServerAPI
+import org.vaccineimpact.orderlyweb.OrderlyServerResponse
+import org.vaccineimpact.orderlyweb.controllers.api.ReportRunController
+import org.vaccineimpact.orderlyweb.db.repositories.ReportRunRepository
+import java.time.Instant
+
+class ReportRunControllerTests : ControllerTest()
+{
+    private val reportName = "report1"
+    private val reportKey = "123"
+
+    @Test
+    fun `runs a report`()
+    {
+        val actionContext: ActionContext = mock {
+            on { params(":name") } doReturn reportName
+            on { queryParams("instance") } doReturn """{"instance": "i1"}"""
+            on { queryParams("params") } doReturn """{"param": "p1"}"""
+            on { queryParams("TODO") } doReturn "branch1"
+            on { queryParams("ref") } doReturn "abc123"
+            on { userProfile } doReturn CommonProfile().apply { id = "a@b.com" }
+        }
+
+        val mockAPIResponseText =
+            """{"data": {"name": "$reportName", "key": $reportKey, "path": "/status/$reportKey"}}"""
+
+        val mockAPIResponse = OrderlyServerResponse(mockAPIResponseText, 200)
+
+        val apiClient: OrderlyServerAPI = mock {
+            on { post(any(), any(), any(), any()) } doReturn mockAPIResponse
+        }
+
+        val mockReportRunRepo: ReportRunRepository = mock()
+
+        val sut = ReportRunController(actionContext, mockReportRunRepo, apiClient, mock())
+        val result = sut.run()
+
+        assertThat(result).isEqualTo(mockAPIResponseText)
+        verify(mockReportRunRepo).addReportRun(
+            eq(reportKey),
+            eq("a@b.com"),
+            any<Instant>(),
+            eq(reportName),
+            eq("""{"instance": "i1"}"""),
+            eq("""{"param": "p1"}"""),
+            eq("branch1"),
+            eq("abc123")
+        )
+    }
+
+    @Test
+    fun `gets report status`()
+    {
+        val actionContext: ActionContext = mock {
+            on { params(":key") } doReturn reportKey
+        }
+
+        val mockAPIResponse = OrderlyServerResponse("""{"status": "running"}""", 200)
+
+        val apiClient: OrderlyServerAPI = mock {
+            on { get("/v1/reports/$reportKey/status/", actionContext) } doReturn mockAPIResponse
+        }
+
+        val sut = ReportRunController(actionContext, mock(), apiClient, mock())
+        val result = sut.status()
+
+        assertThat(result).isEqualTo("""{"status": "running"}""")
+    }
+
+    @Test
+    fun `kills a report`()
+    {
+        val actionContext: ActionContext = mock {
+            on { params(":key") } doReturn reportKey
+        }
+
+        val mockAPIResponse = OrderlyServerResponse("okayresponse", 200)
+
+        val apiClient: OrderlyServerAPI = mock {
+            on { delete("/v1/reports/$reportKey/kill/", actionContext) } doReturn mockAPIResponse
+        }
+
+        val sut = ReportRunController(actionContext, mock(), apiClient, mock())
+        val result = sut.kill()
+
+        assertThat(result).isEqualTo("okayresponse")
+    }
+}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportRunControllerTests.kt
@@ -21,10 +21,12 @@ class ReportRunControllerTests : ControllerTest()
     {
         val actionContext: ActionContext = mock {
             on { params(":name") } doReturn reportName
-            on { queryParams("instance") } doReturn """{"instance": "i1"}"""
-            on { queryParams("params") } doReturn """{"param": "p1"}"""
-            on { queryParams("TODO") } doReturn "branch1"
-            on { queryParams("ref") } doReturn "abc123"
+            on { postData<Any>() } doReturn mapOf(
+                "instances" to mapOf("instance" to "i1"),
+                "params" to mapOf("param" to "p1"),
+                "gitBranch" to "branch1",
+                "gitCommit" to "abc123"
+            )
             on { userProfile } doReturn CommonProfile().apply { id = "a@b.com" }
         }
 
@@ -34,7 +36,7 @@ class ReportRunControllerTests : ControllerTest()
         val mockAPIResponse = OrderlyServerResponse(mockAPIResponseText, 200)
 
         val apiClient: OrderlyServerAPI = mock {
-            on { post(any(), any(), any(), any()) } doReturn mockAPIResponse
+            on { post(any<String>(), any<String>(), any<Map<String, String?>>()) } doReturn mockAPIResponse
         }
 
         val mockReportRunRepo: ReportRunRepository = mock()
@@ -48,8 +50,8 @@ class ReportRunControllerTests : ControllerTest()
             eq("a@b.com"),
             any<Instant>(),
             eq(reportName),
-            eq("""{"instance": "i1"}"""),
-            eq("""{"param": "p1"}"""),
+            eq(mapOf("instance" to "i1")),
+            eq(mapOf("param" to "p1")),
             eq("branch1"),
             eq("abc123")
         )

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -139,20 +139,21 @@
 
                 //Orderly server currently only accepts a single instance value, although the metadata endpoint supports
                 //multiple instances - until multiple are accepted, send the selected instance value for instance with
-                //greatest number of options
-                let instance = "";
+                //greatest number of options. See VIMC-4561.
+                let instances = {};
                 if (this.metadata.instances_supported && this.metadata.instances &&
-                        Object.keys(this.metadata.instances).length > 0) {
-                    const instances = this.metadata.instances;
-                    const instanceName = Object.keys(instances).sort((a, b) => instances[a] < instances[b] ? 1 : -1)[0];
-                    instance = this.selectedInstances[instanceName]
+                    Object.keys(this.metadata.instances).length > 0) {
+                    const instanceName = Object.keys(this.metadata.instances).sort((a, b) => this.metadata.instances[b].length - this.metadata.instances[a].length)[0];
+                    const instance = this.selectedInstances[instanceName];
+                    instances = Object.keys(this.metadata.instances).reduce((a, e) => ({[e]: instance, ...a}), {});
                 }
 
-                const params = {
-                    ref: this.selectedCommitId,
-                    instance
-                };
-                api.post(`/report/${this.selectedReport}/actions/run/`, {}, {params})
+                api.post(`/report/${this.selectedReport}/actions/run/`, {
+                    instances: instances,
+                    params: {}, //TODO mrc-2167
+                    gitBranch: this.selectedBranch,
+                    gitCommit: this.selectedCommitId,
+                })
                     .then(({data}) => {
                         this.disableRun = true;
                         this.runningKey = data.data.key;

--- a/src/app/static/src/tests/components/runReport/runReport.test.js
+++ b/src/app/static/src/tests/components/runReport/runReport.test.js
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import {shallowMount, mount} from "@vue/test-utils";
+import {mount, shallowMount} from "@vue/test-utils";
 import RunReport from "../../../js/components/runReport/runReport.vue";
 import ReportList from "../../../js/components/runReport/reportList.vue";
 import ErrorInfo from "../../../js/components/errorInfo";
@@ -230,7 +230,7 @@ describe("runReport", () => {
 
     it("clicking run button sends run request and displays status on success", async (done) => {
         const url = 'http://app/report/test-report/actions/run/';
-        mockAxios.onPost(url, {})
+        mockAxios.onPost(url)
             .reply(200, {data: {key: "test-key"}});
 
         const propsData =  {
@@ -261,7 +261,17 @@ describe("runReport", () => {
             setTimeout(() => {
                 expect(mockAxios.history.post.length).toBe(1);
                 expect(mockAxios.history.post[0].url).toBe(url);
-                expect(mockAxios.history.post[0].params).toStrictEqual({ref: "test-commit", instance: "science"});
+                expect(mockAxios.history.post[0].data).toBe(JSON.stringify(
+                    {
+                        "instances": {
+                            "source": "science",
+                            "annexe": "science"
+                        },
+                        "params": {},
+                        "gitBranch": "master",
+                        "gitCommit": "test-commit"
+                    }
+                ));
                 expect(wrapper.find("#run-report-status").text()).toContain("Run started");
                 expect(wrapper.find("#run-report-status a").text()).toBe("Check status");
                 expect(wrapper.find("#run-form-group button").attributes("disabled")).toBe("disabled");
@@ -275,7 +285,7 @@ describe("runReport", () => {
 
     it("clicking run button sends run request and sets error", async (done) => {
         const url = 'http://app/report/test-report/actions/run/';
-        mockAxios.onPost(url, {})
+        mockAxios.onPost(url)
             .reply(500, "TEST ERROR");
         const wrapper = getWrapper();
 

--- a/src/config/detekt/baseline-main.yml
+++ b/src/config/detekt/baseline-main.yml
@@ -763,22 +763,6 @@
     <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.OnetimeTokenController.kt:10</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.OnetimeTokenController.kt:11</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.OnetimeTokenController.kt:18</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:17</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:18</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:19</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:20</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:21</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:24</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:25</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:26</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:27</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:28</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:61</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:62</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:63</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:71</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:72</ID>
-    <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:73</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:13</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:14</ID>
     <ID>Indentation:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:15</ID>
@@ -2481,7 +2465,6 @@
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.app_start.routing.web.WebDocumentRouteConfig.kt:28</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.app_start.routing.web.WebVersionRouteConfig.kt:45</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.api.ArtefactController.kt:67</ID>
-    <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:90</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:52</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.api.VersionController.kt:101</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.web.AdminController.kt:20</ID>
@@ -2523,7 +2506,6 @@
     <ID>NoConsecutiveBlankLines:org.vaccineimpact.orderlyweb.app_start.RouteConfig.kt:45</ID>
     <ID>NoConsecutiveBlankLines:org.vaccineimpact.orderlyweb.app_start.Router.kt:15</ID>
     <ID>NoConsecutiveBlankLines:org.vaccineimpact.orderlyweb.app_start.SparkApp.kt:18</ID>
-    <ID>NoConsecutiveBlankLines:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:84</ID>
     <ID>NoConsecutiveBlankLines:org.vaccineimpact.orderlyweb.db.Extensions.kt:3</ID>
     <ID>NoConsecutiveBlankLines:org.vaccineimpact.orderlyweb.db.JoinPath.kt:97</ID>
     <ID>NoConsecutiveBlankLines:org.vaccineimpact.orderlyweb.db.MappingHelpers.kt:12</ID>
@@ -2734,11 +2716,6 @@
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.GitController.kt:9</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.OnetimeTokenController.kt:10</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.OnetimeTokenController.kt:11</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:17</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:18</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:19</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:20</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:21</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:13</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:14</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:15</ID>
@@ -3304,17 +3281,6 @@
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.HomeController.kt:12</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.OnetimeTokenController.kt:12</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.OnetimeTokenController.kt:16</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:22</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:31</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:38</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:45</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:52</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:59</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:61</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:69</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:71</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:79</ID>
-    <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ReportController.kt:86</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:17</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:25</ID>
     <ID>SpacingAroundCurly:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:30</ID>


### PR DESCRIPTION
This is a fair amount of code to do something quite simple: add a row to the database when a report is run. It doesn't cover updating the row as the job progresses, or retrieving rows from the table - they are the subject of subsequent tickets.

Summary of code changes:
- Enable requests to orderly.server from OrderlyWeb backend, rather than only passing through requests from front-end
  - POST only for now
  - Passed-through responses should probably be refactored to re-use new logic (i.e. old `post` method calls new `post` method)
- Split `ReportController`, creating a `ReportRunController` (URLs remain unchanged)
- Log report runs to database, using new `OrderlyWebReportRunRepository` class
- Modify front-end to send a dict of instances rather than just a string (where the values in the map are the string that was previously sent)