### PR TITLE
Implement basic live-reload for front-end code

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ rm -r app/demo && rm -r app/git && ./gradlew :app:generateTestData
 ./gradlew :generateDatabaseInterface
 ```
 
+### Automatic rebuilding of UI code
+
+Running `npm run watch --prefix src/app/static` starts a process that will rebuild the UI whenever a `.js`, `.ts` or
+`.vue` file changes. If you're just making front-end changes this avoids having to restart the whole application
+(recompiling the Kotlin code etc).
+
 ## Docker build
 The app is dockerised by running the `./buildkite/build-app.sh` script, which does the following:
 1. Calls `./buildkite/make-build-env.sh` which builds a docker image based on the `Dockerfile` which contains all the

--- a/src/app/static/gulpfile.js
+++ b/src/app/static/gulpfile.js
@@ -40,3 +40,7 @@ gulp.task('js', function () {
 });
 
 gulp.task('build', gulp.parallel('sass', 'js', 'webpack'));
+
+gulp.task(function watch() {
+    gulp.watch(['src/js/**/*.@(js|ts|vue)'], gulp.series('webpack'));
+})

--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -13411,7 +13411,7 @@
       "integrity": "sha512-tcbhmjLyWb+2s2gdiSmROEoD/OQPFeKC9xBnKgs0H+umY8CaVrVPGFdr1y1qovm7HxUbdk/BKqi94GQDc5XB3A==",
       "dev": true,
       "requires": {
-        "buble": "buble@github:pemrouz/buble",
+        "buble": "github:pemrouz/buble",
         "express": "^4.14.0",
         "lru_map": "^0.3.3",
         "platform": "^1.3.4",
@@ -13426,8 +13426,8 @@
           "dev": true
         },
         "buble": {
-          "version": "git+ssh://git@github.com/pemrouz/buble.git#4e639aeeb64712ac95dc30a52750d1ee4432c9c8",
-          "from": "buble@github:pemrouz/buble",
+          "version": "github:pemrouz/buble#4e639aeeb64712ac95dc30a52750d1ee4432c9c8",
+          "from": "github:pemrouz/buble",
           "dev": true,
           "requires": {
             "acorn": "^5.1.2",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -5,6 +5,7 @@
   "main": "gulpfile.js",
   "scripts": {
     "build": "NODE_ENV=production gulp build",
+    "watch": "NODE_ENV=production gulp watch",
     "js": "NODE_ENV=development gulp js",
     "test": "jest -c jest.config.js"
   },


### PR DESCRIPTION
Adds a `watch` task to our Gulp config that can be invoked as follows:
```sh
npm run watch --prefix src/app/static
```
This will watch the front-end code and rebuild it as necessary. Note that it doesn't watch the css files or our external JavaScript dependencies - this could be added but these change much less frequently.

Also apply a neutral fix to `package-lock.json` to fix a mysterious dependency resolution problem that is preventing me from doing a clean `npm install`.