### PR TITLE
orderly.server won't start if orderly root is not version controlled

### DIFF
--- a/config/orderly_server_version
+++ b/config/orderly_server_version
@@ -1,1 +1,1 @@
-master
+vimc-4594


### PR DESCRIPTION
This is to test that https://github.com/vimc/orderly.server/pull/55 won't break orderly-web tests