### PR TITLE
mrc-2174 Show start time and elapsed on metadata tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ The app will now be available on your local machine at http://127.0.0.1:8888 and
    To achieve this, make the following changes before running `/dev/run-dependencies.sh` and the app:
    - In `/dev/cli.sh'` replace `docker run -v $PWD/src/app/demo:/orderly $image "$@"` with `docker run -v $PWD/src/app/git:/orderly $image "$@"`
    - In `/config/default.properties` replace `orderly_root=demo/` with `orderly_root=git/`
-   - In `/dev/run-dependencies.sh` replace `export MONTAGU_ORDERLY_PATH=$(realpath $here/../src/customConfigTests/git` with `export MONTAGU_ORDERLY_PATH=$(realpath $here/../src/app/git)`    
-
+   
 See [auth.md](/docs/auth.md) for further details about web authentication.
 
 ### Generate test data.  

--- a/buildkite/make-db.sh
+++ b/buildkite/make-db.sh
@@ -1,3 +1,5 @@
+set -ex
+
 ORDERLY_IMAGE=$ORG/orderly:master
 MIGRATE_IMAGE=$ORG/orderlyweb-migrate:$GIT_ID
 
@@ -10,7 +12,7 @@ docker run --rm \
     -u $UID \
     -v $PWD:/orderly \
     -w "/orderly" \
-    --env "HOME=/tmp"
+    --env "HOME=/tmp" \
     $ORDERLY_IMAGE \
     "."
 

--- a/buildkite/make-db.sh
+++ b/buildkite/make-db.sh
@@ -10,6 +10,7 @@ docker run --rm \
     -u $UID \
     -v $PWD:/orderly \
     -w "/orderly" \
+    --env "HOME=/tmp"
     $ORDERLY_IMAGE \
     "."
 

--- a/dev/run-dependencies.sh
+++ b/dev/run-dependencies.sh
@@ -13,7 +13,8 @@ here=$(dirname $0)
 
 $here/migrate-local-test.sh
 
-export MONTAGU_ORDERLY_PATH=$(realpath $here/../src/customConfigTests/git)
+export MONTAGU_ORDERLY_PATH=$(realpath $here/../src/app/git)
+
 export ORDERLY_SERVER_USER_ID=$UID
 $here/../scripts/run-dependencies.sh
 

--- a/src/.idea/codeStyles/Project.xml
+++ b/src/.idea/codeStyles/Project.xml
@@ -3,18 +3,9 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="java.util" withSubpackages="false" static="false" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="io.ktor" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="LBRACE_ON_NEXT_LINE" value="true" />

--- a/src/.idea/codeStyles/Project.xml
+++ b/src/.idea/codeStyles/Project.xml
@@ -3,9 +3,18 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="java.util" withSubpackages="false" static="false" />
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
-          <package name="io.ktor" withSubpackages="true" static="false" />
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="LBRACE_ON_NEXT_LINE" value="true" />

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -86,14 +86,11 @@ distDocker {
 // creates folder at app/demo with up to date orderly test data
 task generateTestData() {
     doLast {
-        String image = "vimc/orderly:create_demo_script_git"
+        String image = "vimc/orderly:master"
         def username = System.properties['user.name']
         def uid = ["id", "-u", username].execute().text.trim()
-        //def gid = ["id", "-g", username].execute().text.trim()
-        //def user_str = "{}:{}".format(uid, gid)
 
         println("Pulling " + image)
-        println("USER STRING: " + uid)
 
         exec {
             commandLine 'docker', 'pull', image

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -86,17 +86,20 @@ distDocker {
 // creates folder at app/demo with up to date orderly test data
 task generateTestData() {
     doLast {
-        String image = "vimc/orderly:master"
+        String image = "vimc/orderly:create_demo_script_git"
         def username = System.properties['user.name']
         def uid = ["id", "-u", username].execute().text.trim()
+        //def gid = ["id", "-g", username].execute().text.trim()
+        //def user_str = "{}:{}".format(uid, gid)
 
         println("Pulling " + image)
+        println("USER STRING: " + uid)
 
         exec {
             commandLine 'docker', 'pull', image
         }
         exec {
-            commandLine 'docker', 'run', '--rm', '--entrypoint', 'create_orderly_demo.sh', '-u', uid, '-v', "$projectDir:/orderly", '-w', "/orderly", image, "."
+            commandLine 'docker', 'run', '--rm', '--entrypoint', 'create_orderly_demo.sh', '--user', uid, '--env', 'HOME=/tmp', '-v', "$projectDir:/orderly", '-w', "/orderly", image, "."
         }
         
         String owMigrateImage = "vimc/orderlyweb-migrate:master"

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compile "com.github.salomonbrys.kotson:kotson:2.5.0"
     compile "com.opencsv:opencsv:3.9"
 
+    compile "org.apache.commons:commons-lang3:3.12.0"
     compile "org.postgresql:postgresql:9.4.1212.jre7"
     compile "org.jooq:jooq:3.9.1"
     compile "org.jooq:jooq-meta:3.9.1"

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/ReportRepository.kt
@@ -21,7 +21,7 @@ interface ReportRepository
     fun togglePublishStatus(name: String, version: String): Boolean
 
     @Throws(UnknownObjectError::class)
-    fun getReportVersion(name: String, version: String): ReportVersionWithDescLatest
+    fun getReportVersion(name: String, version: String): ReportVersionWithDescLatestElapsed
 
     fun getAllReportVersions(): List<ReportVersionWithDescLatest>
 
@@ -119,7 +119,7 @@ class OrderlyReportRepository(val isReviewer: Boolean,
         }
     }
 
-    override fun getReportVersion(name: String, version: String): ReportVersionWithDescLatest
+    override fun getReportVersion(name: String, version: String): ReportVersionWithDescLatestElapsed
     {
         //raise exception if version does not belong to named report, or version does not exist
         JooqContext().use {
@@ -381,7 +381,7 @@ class OrderlyReportRepository(val isReviewer: Boolean,
                 .mapValues { it.value.associate { r -> r[PARAMETERS.NAME] to r[PARAMETERS.VALUE] } }
     }
 
-    private fun getReportVersion(name: String, version: String, ctx: JooqContext): ReportVersionWithDescLatest
+    private fun getReportVersion(name: String, version: String, ctx: JooqContext): ReportVersionWithDescLatestElapsed
     {
         val latestVersionForEachReport = getLatestVersionsForReports(ctx)
 
@@ -392,7 +392,8 @@ class OrderlyReportRepository(val isReviewer: Boolean,
                         ORDERLYWEB_REPORT_VERSION_FULL.PUBLISHED,
                         ORDERLYWEB_REPORT_VERSION_FULL.DATE,
                         latestVersionForEachReport.field<String>("latestVersion"),
-                        ORDERLYWEB_REPORT_VERSION_FULL.DESCRIPTION)
+                        ORDERLYWEB_REPORT_VERSION_FULL.DESCRIPTION,
+                        ORDERLYWEB_REPORT_VERSION_FULL.ELAPSED)
                 .from(ORDERLYWEB_REPORT_VERSION_FULL)
                 .join(latestVersionForEachReport.tableName)
                 .on(ORDERLYWEB_REPORT_VERSION_FULL.REPORT.eq(latestVersionForEachReport.field("report")))
@@ -400,7 +401,7 @@ class OrderlyReportRepository(val isReviewer: Boolean,
                 .and(ORDERLYWEB_REPORT_VERSION_FULL.ID.eq(version))
                 .and(shouldIncludeReportVersion)
                 .singleOrNull()
-                ?.into(ReportVersionWithDescLatest::class.java)
+                ?.into(ReportVersionWithDescLatestElapsed::class.java)
                 ?: throw UnknownObjectError("$name-$version", "reportVersion")
     }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionWithArtefactsDataDescParamsResources.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionWithArtefactsDataDescParamsResources.kt
@@ -2,7 +2,7 @@ package org.vaccineimpact.orderlyweb.models
 
 import java.time.Instant
 
-data class ReportVersionWithArtefactsDataDescParamsResources(@Transient val basicReportVersion: ReportVersionWithDescLatest,
+data class ReportVersionWithArtefactsDataDescParamsResources(@Transient val basicReportVersion: ReportVersionWithDescLatestElapsed,
                                                              val artefacts: List<Artefact>,
                                                              val resources: List<FileInfo>,
                                                              val dataInfo: List<DataInfo>,

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionWithDescLatestElapsed.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionWithDescLatestElapsed.kt
@@ -5,11 +5,13 @@ import java.time.Instant
 
 data class ReportVersionWithDescLatestElapsed
 @ConstructorProperties("name", "displayname", "id", "published", "date", "latestVersion", "description", "elapsed")
-constructor(override val name: String,
-            override val displayName: String?,
-            override val id: String,
-            override val published: Boolean,
-            override val date: Instant,
-            val latestVersion: String,
-            val description: String?,
-            val elapsed: Double): ReportVersion
+constructor(
+    override val name: String,
+    override val displayName: String?,
+    override val id: String,
+    override val published: Boolean,
+    override val date: Instant,
+    val latestVersion: String,
+    val description: String?,
+    val elapsed: Double
+) : ReportVersion

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionWithDescLatestElapsed.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/ReportVersionWithDescLatestElapsed.kt
@@ -1,0 +1,15 @@
+package org.vaccineimpact.orderlyweb.models
+
+import java.beans.ConstructorProperties
+import java.time.Instant
+
+data class ReportVersionWithDescLatestElapsed
+@ConstructorProperties("name", "displayname", "id", "published", "date", "latestVersion", "description", "elapsed")
+constructor(override val name: String,
+            override val displayName: String?,
+            override val id: String,
+            override val published: Boolean,
+            override val date: Instant,
+            val latestVersion: String,
+            val description: String?,
+            val elapsed: Double): ReportVersion

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -8,27 +8,30 @@ import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import kotlin.math.roundToLong
 
-data class ReportVersionPageViewModel(@Serialise("reportJson") val report: ReportVersionWithDescLatestElapsed,
-                                      val focalArtefactUrl: String?,
-                                      val isRunner: Boolean,
-                                      val artefacts: List<ArtefactViewModel>,
-                                      val dataLinks: List<InputDataViewModel>,
-                                      val resources: List<DownloadableFileViewModel>,
-                                      val zipFile: DownloadableFileViewModel,
-                                      val versions: List<VersionPickerViewModel>,
-                                      val changelog: List<ChangelogViewModel>,
-                                      val parameterValues: String?,
-                                      val startTimeString: String,
-                                      val elapsedString: String,
-                                      val appViewModel: AppViewModel) :
-        AppViewModel by appViewModel
+data class ReportVersionPageViewModel(
+    @Serialise("reportJson") val report: ReportVersionWithDescLatestElapsed,
+    val focalArtefactUrl: String?,
+    val isRunner: Boolean,
+    val artefacts: List<ArtefactViewModel>,
+    val dataLinks: List<InputDataViewModel>,
+    val resources: List<DownloadableFileViewModel>,
+    val zipFile: DownloadableFileViewModel,
+    val versions: List<VersionPickerViewModel>,
+    val changelog: List<ChangelogViewModel>,
+    val parameterValues: String?,
+    val startTimeString: String,
+    val elapsedString: String,
+    val appViewModel: AppViewModel
+) : AppViewModel by appViewModel
 {
     companion object
     {
-        fun build(report: ReportVersionWithArtefactsDataDescParamsResources,
-                  versions: List<String>,
-                  changelog: List<Changelog>,
-                  context: ActionContext): ReportVersionPageViewModel
+        fun build(
+            report: ReportVersionWithArtefactsDataDescParamsResources,
+            versions: List<String>,
+            changelog: List<Changelog>,
+            context: ActionContext
+        ): ReportVersionPageViewModel
         {
             val fileViewModelBuilder = ReportFileViewModelBuilder(report.name, report.id)
 
@@ -76,6 +79,7 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
             val date = getDateStringFromVersionId(report.id)
             val startTimeString = getFriendlyDateTime(date)
 
+            @Suppress("MagicNumber")
             val elapsedMillis = (report.basicReportVersion.elapsed * 1000).roundToLong()
             val elapsedString = DurationFormatUtils.formatDurationWords(elapsedMillis, true, true)
 
@@ -166,13 +170,17 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
 
 data class VersionPickerViewModel(val url: String, val date: String, val selected: Boolean)
 
-data class ArtefactViewModel(val artefact: Artefact,
-                             val files: List<DownloadableFileViewModel>,
-                             val inlineArtefactFigure: String?)
+data class ArtefactViewModel(
+    val artefact: Artefact,
+    val files: List<DownloadableFileViewModel>,
+    val inlineArtefactFigure: String?
+)
 
-data class InputDataViewModel(val key: String,
-                              val csv: DownloadableFileViewModel,
-                              val rds: DownloadableFileViewModel)
+data class InputDataViewModel(
+    val key: String,
+    val csv: DownloadableFileViewModel,
+    val rds: DownloadableFileViewModel
+)
 
 data class DownloadableFileViewModel(val name: String, val url: String, val size: Long?)
 {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/viewmodels/ReportVersionViewModel.kt
@@ -1,13 +1,14 @@
 package org.vaccineimpact.orderlyweb.viewmodels
 
+import org.apache.commons.lang3.time.DurationFormatUtils
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.controllers.web.Serialise
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
-import java.time.format.DateTimeFormatter
+import kotlin.math.roundToLong
 
-data class ReportVersionPageViewModel(@Serialise("reportJson") val report: ReportVersionWithDescLatest,
+data class ReportVersionPageViewModel(@Serialise("reportJson") val report: ReportVersionWithDescLatestElapsed,
                                       val focalArtefactUrl: String?,
                                       val isRunner: Boolean,
                                       val artefacts: List<ArtefactViewModel>,
@@ -17,6 +18,8 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                                       val versions: List<VersionPickerViewModel>,
                                       val changelog: List<ChangelogViewModel>,
                                       val parameterValues: String?,
+                                      val startTimeString: String,
+                                      val elapsedString: String,
                                       val appViewModel: AppViewModel) :
         AppViewModel by appViewModel
 {
@@ -70,6 +73,12 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                 null
             }
 
+            val date = getDateStringFromVersionId(report.id)
+            val startTimeString = getFriendlyDateTime(date)
+
+            val elapsedMillis = (report.basicReportVersion.elapsed * 1000).roundToLong()
+            val elapsedString = DurationFormatUtils.formatDurationWords(elapsedMillis, true, true)
+
             return ReportVersionPageViewModel(
                     report.basicReportVersion.copy(displayName = displayName),
                     focalArtefactUrl,
@@ -81,6 +90,8 @@ data class ReportVersionPageViewModel(@Serialise("reportJson") val report: Repor
                     versions.sortedByDescending { it }.map { buildVersionPickerViewModel(report.name, report.id, it) },
                     changelogViewModel,
                     parameterValues,
+                    startTimeString,
+                    elapsedString,
                     DefaultViewModel(context, IndexViewModel.breadcrumb, breadcrumb))
         }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/OrderlyTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/OrderlyTests.kt
@@ -35,8 +35,19 @@ class OrderlyTests : CleanDatabaseTests()
                     "vz",
                     "descripion")
 
+    private val basicReportVersionElapsed =
+            ReportVersionWithDescLatestElapsed(
+                    "test",
+                    "display name",
+                    "v1",
+                    true,
+                    now,
+                    "vz",
+                    "descripion",
+                    1.5)
+
     private val mockReportRepo = mock<ReportRepository> {
-        on { getReportVersion("test", "v1") } doReturn basicReportVersion
+        on { getReportVersion("test", "v1") } doReturn basicReportVersionElapsed
         on { getAllReportVersions() } doReturn listOf(basicReportVersion, basicReportVersion.copy(id = "v2"))
         on { getParametersForVersions(listOf("v1")) } doReturn mapOf("v1" to mapOf("p1" to "param1", "p2" to "param2"))
         on { getLatestVersion("test") } doReturn basicReportVersion.copy(id = "latest", date = now.minusSeconds(100))

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/VersionTests.kt
@@ -90,7 +90,7 @@ class VersionTests : CleanDatabaseTests()
     @Test
     fun `reviewer can get version details for report with no publish record`()
     {
-        insertReport("test", "version1", addOrderlyWebReportVersion = false)
+        insertReport("test", "version1", elapsed=4.3, addOrderlyWebReportVersion = false)
 
         val sut = createSut(isReviewer = true)
 
@@ -99,12 +99,13 @@ class VersionTests : CleanDatabaseTests()
         assertThat(result.name).isEqualTo("test")
         assertThat(result.id).isEqualTo("version1")
         assertThat(result.published).isFalse()
+        assertThat(result.elapsed).isEqualTo(4.3)
     }
 
     @Test
     fun `reviewer can get unpublished version details`()
     {
-        insertReport("test", "version1", published = false)
+        insertReport("test", "version1", published = false, elapsed=4.3)
 
         val sut = createSut(isReviewer = true)
 
@@ -113,6 +114,7 @@ class VersionTests : CleanDatabaseTests()
         assertThat(result.name).isEqualTo("test")
         assertThat(result.id).isEqualTo("version1")
         assertThat(result.published).isFalse()
+        assertThat(result.elapsed).isEqualTo(4.3)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/TemplateObjectWrapperTests.kt
@@ -28,13 +28,14 @@ class TemplateObjectWrapperTests
     {
         val now = Instant.now()
         val artFiles = listOf(FileInfo("graph.png", 1234))
-        val report = ReportVersionWithArtefactsDataDescParamsResources(ReportVersionWithDescLatest("r1",
+        val report = ReportVersionWithArtefactsDataDescParamsResources(ReportVersionWithDescLatestElapsed("r1",
                 "first report",
                 "v1",
                 true,
                 now,
                 "v1",
-                "a fake report"),
+                "a fake report",
+                1.5),
                 listOf(Artefact(ArtefactFormat.DATA, "a graph", artFiles)),
                 listOf(),
                 listOf(DataInfo("hash", 1234, 2345)),

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
@@ -105,8 +105,9 @@ class VersionControllerTests : ControllerTest()
         val reportName = "reportName"
         val reportVersion = "reportVersion"
 
-        val report = ReportVersionWithArtefactsDataDescParamsResources(ReportVersionWithDescLatest(displayName = "displayName", id = "id", date = Instant.now(),
-                name = "name", published = true, description = "description", latestVersion = "v1"),
+        val report = ReportVersionWithArtefactsDataDescParamsResources(
+                ReportVersionWithDescLatestElapsed(displayName = "displayName", id = "id", date = Instant.now(),
+                name = "name", published = true, description = "description", latestVersion = "v1", elapsed = 1.5),
                 artefacts = listOf(),
                 resources = listOf(), dataInfo = listOf(), parameterValues = mapOf())
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/VersionControllerTests.kt
@@ -125,7 +125,19 @@ class VersionControllerTests : ControllerTest()
                 mock(),
                 mockConfig)
 
-        assertThat(sut.getByNameAndVersion()).isEqualTo(report)
+        val result = sut.getByNameAndVersion()
+        assertThat(result.basicReportVersion.date).isEqualTo(report.basicReportVersion.date)
+        assertThat(result.basicReportVersion.description).isEqualTo("description")
+        assertThat(result.basicReportVersion.displayName).isEqualTo("displayName")
+        assertThat(result.basicReportVersion.elapsed).isEqualTo(1.5)
+        assertThat(result.basicReportVersion.id).isEqualTo("id")
+        assertThat(result.basicReportVersion.latestVersion).isEqualTo("v1")
+        assertThat(result.basicReportVersion.name).isEqualTo("name")
+        assertThat(result.basicReportVersion.published).isEqualTo(true)
+        assertThat(result.artefacts.count()).isEqualTo(0)
+        assertThat(result.resources.count()).isEqualTo(0)
+        assertThat(result.dataInfo.count()).isEqualTo(0)
+        assertThat(result.parameterValues.keys.count()).isEqualTo(0)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/GetByNameAndVersionTests.kt
@@ -17,13 +17,15 @@ import java.time.Instant
 class GetByNameAndVersionTests
 {
     private val versionId = "20170103-143015-1234abcd"
-    private val mockReportDetails = ReportVersionWithArtefactsDataDescParamsResources(ReportVersionWithDescLatest("r1",
-            "a fake report",
-            versionId,
-            true,
-            Instant.now(),
-            "latest v",
-            "a fake report"),
+    private val mockReportDetails = ReportVersionWithArtefactsDataDescParamsResources(
+            ReportVersionWithDescLatestElapsed("r1",
+                "a fake report",
+                versionId,
+                true,
+                Instant.now(),
+                "latest v",
+                "a fake report",
+                3754.3),
             listOf(),
             listOf(),
             listOf(),
@@ -73,6 +75,16 @@ class GetByNameAndVersionTests
         val result = sut.getByNameAndVersion()
 
         assertThat(result.report.displayName).isEqualTo("r1")
+    }
+
+    @Test
+    fun `builds start time and elapsed time strings`()
+    {
+        val sut = ReportController(mockActionContext, mockOrderly, mock(), mockReportRepo, mock())
+        val result = sut.getByNameAndVersion()
+
+        assertThat(result.startTimeString).isEqualTo("Tue Jan 03 2017, 14:30")
+        assertThat(result.elapsedString).isEqualTo("1 hour 2 minutes 34 seconds")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPage/MetadataTabTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPage/MetadataTabTests.kt
@@ -18,6 +18,10 @@ class MetadataTabTests: BaseVersionPageTests()
     {
         val jsoupDoc = template.jsoupDocFor(VersionPageTestData.testModel)
         val content = jsoupDoc.select("#metadata-tab .container")
-        assertThat(content.text()).isEqualToIgnoringWhitespace("No relevant metadata")
+
+        assertThat(content.select("#started-label").text()).isEqualTo("Started:")
+        assertThat(content.select("#started-value").text()).isEqualTo("Mon 12 Jun 2020 14:23")
+        assertThat(content.select("#elapsed-label").text()).isEqualTo("Elapsed:")
+        assertThat(content.select("#elapsed-value").text()).isEqualTo("3 hours 2 minutes")
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPage/VersionPageTestData.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/templates/VersionPage/VersionPageTestData.kt
@@ -1,21 +1,19 @@
 package org.vaccineimpact.orderlyweb.tests.unit_tests.templates.VersionPage
 
-import org.vaccineimpact.orderlyweb.models.Artefact
-import org.vaccineimpact.orderlyweb.models.ArtefactFormat
-import org.vaccineimpact.orderlyweb.models.ReportVersionWithArtefactsDataDescParamsResources
-import org.vaccineimpact.orderlyweb.models.ReportVersionWithDescLatest
+import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.viewmodels.*
 import java.sql.Timestamp
 
 object VersionPageTestData
 {
-    val testBasicReportVersion = ReportVersionWithDescLatest(name = "r1",
+    val testBasicReportVersion = ReportVersionWithDescLatestElapsed(name = "r1",
             displayName = "r1 display",
             id = "r1-v1",
             published = true,
             date = Timestamp(System.currentTimeMillis()).toInstant(),
             latestVersion = "v1",
-            description = "r1 description")
+            description = "r1 description",
+            elapsed = 1.5)
 
     val testReport = ReportVersionWithArtefactsDataDescParamsResources(testBasicReportVersion,
             artefacts = listOf(),
@@ -72,5 +70,7 @@ object VersionPageTestData
                 listOf(),
                 listOf(),
                 "p1=v1, p2=v2",
+                "Mon 12 Jun 2020 14:23",
+                "3 hours 2 minutes",
                 testDefaultModel)
 }

--- a/src/app/templates/partials/metadata-tab.ftl
+++ b/src/app/templates/partials/metadata-tab.ftl
@@ -5,16 +5,16 @@
 <#include "report-title.ftl">
 <div class="container ml-0">
     <div class="row">
-        <div class="col-2 text-right">
+        <div id="started-label" class="col-2 text-right">
             Started:
         </div>
-        <div class="col-4">
+        <div id="started-value" class="col-4">
             ${startTimeString}
         </div>
-        <div class="col-2 text-right">
+        <div id="elapsed-label" class="col-2 text-right">
             Elapsed:
         </div>
-        <div class="col-4">
+        <div id="elapsed-value" class="col-4">
             ${elapsedString}
         </div>
     </div>

--- a/src/app/templates/partials/metadata-tab.ftl
+++ b/src/app/templates/partials/metadata-tab.ftl
@@ -1,6 +1,21 @@
 <#-- @ftlvariable name="report" type="org.vaccineimpact.orderlyweb.models.ReportVersionDetail" -->
+<#-- @ftlvariable name="startTimeString" type="String" -->
+<#-- @ftlvariable name="elapsedString" type="String" -->
 
 <#include "report-title.ftl">
 <div class="container ml-0">
-    No relevant metadata
+    <div class="row">
+        <div class="col-2 text-right">
+            Started:
+        </div>
+        <div class="col-4">
+            ${startTimeString}
+        </div>
+        <div class="col-2 text-right">
+            Elapsed:
+        </div>
+        <div class="col-4">
+            ${elapsedString}
+        </div>
+    </div>
 </div>

--- a/src/config/detekt/baseline-main.yml
+++ b/src/config/detekt/baseline-main.yml
@@ -27,8 +27,8 @@
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.security.clients.OrderlyWebIndirectClient.kt:44</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.security.clients.OrderlyWebIndirectClient.kt:45</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.security.providers.OkHttpMontaguAPIClient.kt:110</ID>
-    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:136</ID>
-    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:89</ID>
+    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:104</ID>
+    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:151</ID>
     <ID>EmptyDefaultConstructor:OrderlyWebIndirectClient.kt$OrderlyWebIndirectClient$()</ID>
     <ID>EmptyFunctionBlock:InMemoryTokenStore.kt$InMemoryTokenStore${ }</ID>
     <ID>EmptyFunctionBlock:OkHttpMontaguAPIClient.kt$LocalOkHttpMontaguApiClient.&lt;no name provided&gt;${ }</ID>
@@ -256,9 +256,9 @@
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.viewmodels.ReportDraftViewModel.kt:22</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.viewmodels.ReportDraftViewModel.kt:44</ID>
     <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.viewmodels.ReportDraftViewModel.kt:48</ID>
-    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:147</ID>
-    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:57</ID>
-    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:90</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:105</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:162</ID>
+    <ID>MaximumLineLength:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:63</ID>
     <ID>MayBeConst:ContentTypes.kt$ContentTypes$val binarydata = "application/octet-stream"</ID>
     <ID>MayBeConst:ContentTypes.kt$ContentTypes$val csv = "text/csv"</ID>
     <ID>MayBeConst:ContentTypes.kt$ContentTypes$val html = "text/html"</ID>
@@ -273,10 +273,10 @@
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:42</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.PermissionMapper.kt:17</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.PermissionMapper.kt:19</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:441</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:443</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:447</ID>
-    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:449</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:442</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:444</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:448</ID>
+    <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:450</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.security.AllowedOriginsFilter.kt:18</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.security.providers.GithubApiClientAuthHelper.kt:75</ID>
     <ID>MultiLineIfElse:org.vaccineimpact.orderlyweb.security.providers.OkHttpMontaguAPIClient.kt:45</ID>
@@ -460,7 +460,6 @@
     <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.security.authentication.OrderlyWebAuthenticationConfig.kt:6</ID>
     <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.security.clients.JWTHeaderClient.kt:5</ID>
     <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.security.providers.OkHttpMontaguAPIClient.kt:9</ID>
-    <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:8</ID>
     <ID>PackageName:org.vaccineimpact.orderlyweb.app_start.APIResponseErrorHandler.kt:1</ID>
     <ID>PackageName:org.vaccineimpact.orderlyweb.app_start.ActionResolver.kt:1</ID>
     <ID>PackageName:org.vaccineimpact.orderlyweb.app_start.AuthenticationRouteBuilder.kt:1</ID>
@@ -842,27 +841,6 @@
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportFileViewModelBuilder.kt:10</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportFileViewModelBuilder.kt:8</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportFileViewModelBuilder.kt:9</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:10</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:11</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:12</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:13</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:14</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:15</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:158</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:159</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:16</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:160</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:162</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:163</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:164</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:17</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:18</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:19</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:20</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:25</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:26</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:27</ID>
-    <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.ReportVersionViewModel.kt:28</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.RunReportViewModel.kt:10</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.RunReportViewModel.kt:11</ID>
     <ID>ParameterListWrapping:org.vaccineimpact.orderlyweb.viewmodels.RunReportViewModel.kt:9</ID>

--- a/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
+++ b/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
@@ -49,13 +49,17 @@
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
           } ],
+          "Accept-Language" : [ {
+            "matcher" : "exact",
+            "value" : "en-US"
+          } ],
           "Connection" : [ {
             "matcher" : "exact",
             "value" : "keep-alive"
           } ],
           "Referer" : [ {
             "matcher" : "glob",
-            "value" : "http://localhost:8888/weblogin*"
+            "value" : "http://localhost:8888/*"
           } ],
           "Upgrade-Insecure-Requests" : [ {
             "matcher" : "exact",
@@ -69,7 +73,7 @@
       },
       "response" : {
         "status" : 302,
-        "body" : "<html><body>You are being <a href=\"https://github.com/login?client_id=b9e2c4a9c3995ea43cd7&amp;return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3Db9e2c4a9c3995ea43cd7%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail\">redirected</a>.</body></html>",
+        "body" : "<html><body>You are being <a href=\"https://github.com/login?client_id=6f32ad91d57a254341cb&amp;return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3D6f32ad91d57a254341cb%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail\">redirected</a>.</body></html>",
         "encodedBody" : false,
         "templated" : false,
         "headers" : {
@@ -79,7 +83,7 @@
           "Date" : [ "Wed, 29 May 2019 15:52:37 GMT" ],
           "Expect-Ct" : [ "max-age=2592000, report-uri=\"https://api.github.com/_private/browser/errors\"" ],
           "Hoverfly" : [ "Was-Here" ],
-          "Location" : [ "https://github.com/login?client_id=b9e2c4a9c3995ea43cd7&return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3Db9e2c4a9c3995ea43cd7%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail" ],
+          "Location" : [ "https://github.com/login?client_id=6f32ad91d57a254341cb&return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3D6f32ad91d57a254341cb%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail" ],
           "Referrer-Policy" : [ "origin-when-cross-origin, strict-origin-when-cross-origin" ],
           "Server" : [ "GitHub.com" ],
           "Set-Cookie" : [ "has_recent_activity=1; path=/; expires=Wed, 29 May 2019 16:52:37 -0000", "ignored_unsupported_browser_notice=false; path=/", "_gh_sess=bGx0cmtZbHI0OGprQi9PbXZBTDhhS3pGb09vZ2dWWitydmFBRnprODBwVzZDbE41TWdSU2psdEIreER5MlE1K2JRUEpyRmU2NlNVYjFNN0RJQ1VOblBBOXBZSVdETlczK3dnNG44YkhKYUx5YzBMTnl0WE1UNGRrK0NpajVNWUVKYmw1dDNHb2pLeStpMW0ydHFrL29PS0d4N2wyeUt1cUVoWHpBYXNMN0M3Uk1nZElFMlVqaDJXWHJtQlAxYkxmc0tpbXdCbHdXcUpFWjBjM081VllqWGpDYURNeVhRNEdBbVpUOWl0S2VtdnROTnNXTEpxRmJFT05Bbmx2OWllNi0tcW5pdjZJWnlMR0Y4QXVYZ2NrbVcrUT09--31f056df0af59a3c7dff51455826cd1beec8dff6; path=/; secure; HttpOnly" ],
@@ -115,11 +119,11 @@
         "query" : {
           "client_id" : [ {
             "matcher" : "exact",
-            "value" : "b9e2c4a9c3995ea43cd7"
+            "value" : "6f32ad91d57a254341cb"
           } ],
           "return_to" : [ {
             "matcher" : "exact",
-            "value" : "/login/oauth/authorize?client_id=b9e2c4a9c3995ea43cd7&redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&response_type=code&scope=read:user read:org user:email"
+            "value" : "/login/oauth/authorize?client_id=6f32ad91d57a254341cb&redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&response_type=code&scope=read:user read:org user:email"
           } ]
         },
         "body" : [ {
@@ -844,7 +848,7 @@
           } ],
           "dimensions[page]" : [ {
             "matcher" : "exact",
-            "value" : "https://github.com/login?client_id=b9e2c4a9c3995ea43cd7&return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3Db9e2c4a9c3995ea43cd726redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail"
+            "value" : "https://github.com/login?client_id=6f32ad91d57a254341cb&return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3D6f32ad91d57a254341cb%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail"
           } ],
           "dimensions[pixel_ratio]" : [ {
             "matcher" : "exact",
@@ -1103,7 +1107,7 @@
       },
       "response" : {
         "status" : 302,
-        "body" : "<html><body>You are being <a href=\"https://github.com/login/oauth/authorize?client_id=b9e2c4a9c3995ea43cd7&amp;redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&amp;response_type=code&amp;scope=read%3Auser%20read%3Aorg%20user%3Aemail\">redirected</a>.</body></html>",
+        "body" : "<html><body>You are being <a href=\"https://github.com/login/oauth/authorize?client_id=6f32ad91d57a254341cb&amp;redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&amp;response_type=code&amp;scope=read%3Auser%20read%3Aorg%20user%3Aemail\">redirected</a>.</body></html>",
         "encodedBody" : false,
         "templated" : false,
         "headers" : {
@@ -1113,7 +1117,7 @@
           "Date" : [ "Wed, 29 May 2019 15:52:39 GMT" ],
           "Expect-Ct" : [ "max-age=2592000, report-uri=\"https://api.github.com/_private/browser/errors\"" ],
           "Hoverfly" : [ "Was-Here" ],
-          "Location" : [ "https://github.com/login/oauth/authorize?client_id=b9e2c4a9c3995ea43cd7&redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&response_type=code&scope=read%3Auser%20read%3Aorg%20user%3Aemail" ],
+          "Location" : [ "https://github.com/login/oauth/authorize?client_id=6f32ad91d57a254341cb&redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&response_type=code&scope=read%3Auser%20read%3Aorg%20user%3Aemail" ],
           "Referrer-Policy" : [ "origin-when-cross-origin, strict-origin-when-cross-origin" ],
           "Server" : [ "GitHub.com" ],
           "Set-Cookie" : [ "has_recent_activity=1; path=/; expires=Wed, 29 May 2019 16:52:39 -0000", "user_session=uLOGkpK2P3L8N_SPYYjaUjcaf8qR2UlTUjvKcGQCc6AqMnYl; path=/; expires=Wed, 12 Jun 2019 15:52:39 -0000; secure; HttpOnly", "__Host-user_session_same_site=uLOGkpK2P3L8N_SPYYjaUjcaf8qR2UlTUjvKcGQCc6AqMnYl; path=/; expires=Wed, 12 Jun 2019 15:52:39 -0000; secure; HttpOnly; SameSite=Strict", "logged_in=yes; domain=.github.com; path=/; expires=Sun, 29 May 2039 16:52:39 -0000; secure; HttpOnly", "dotcom_user=notarealuse; domain=.github.com; path=/; expires=Sun, 29 May 2039 16:52:39 -0000; secure; HttpOnly", "_gh_sess=N3JGang4V2lNclhpaEpvQ0JPQXgwaHJ0Ui9BaEFabnZLVmRSbWhmbVA0TkIyYy9zTElhSk80UHFNMXM3emUxK093Q3E1K29lbkxiUWpxclR3SFlNS1c4TFhtUEFWR3YrcThTem9JMXNnc3BEbkVBZmZvZ1dvRUsxUlRKVnpFc1pQVjEyWkpnZnI4UytzRXM4MzkzZ2FEREh0TzlnTjZ1bUxtK0FPM1hSMTFseXRkaHZGaFVldkxocWFWOUhTNlN6N3ZDS0VMeHgwU255WG80NzJaOTIxVmVTM3VnaXhIbG03YTN5OXA4VTNXdWpBMzNVcWhWaDNicFVvQjQ1RXBtWVU1YW9aSDNuNDk2UDVvVnFNcEo0cWJ3SWFnYnpOYXVRMGRqSjcrUkNCYmF5dUVzMkx6dFAzbXFHZ2hnU0E0ZWROZTYvdzdISlJQcVlTZHpOWXMxZmZYbXIvbys0dXd6Q0pTdnJyWWRFZ2JrPS0tL25CdURoMlVqZkxaTDNLalFMeFF5Zz09--61da5f0942d99841d2eba03ecaba6e0b1eecbcea; path=/; secure; HttpOnly" ],
@@ -1149,7 +1153,7 @@
         "query" : {
           "client_id" : [ {
             "matcher" : "exact",
-            "value" : "b9e2c4a9c3995ea43cd7"
+            "value" : "6f32ad91d57a254341cb"
           } ],
           "redirect_uri" : [ {
             "matcher" : "exact",
@@ -1455,7 +1459,7 @@
           "X-Frame-Options" : [ "deny" ],
           "X-Github-Media-Type" : [ "github.beta; format=json" ],
           "X-Github-Request-Id" : [ "C1CE:7278:5707:AC15:5CEEAAC7" ],
-          "X-Oauth-Client-Id" : [ "b9e2c4a9c3995ea43cd7" ],
+          "X-Oauth-Client-Id" : [ "6f32ad91d57a254341cb" ],
           "X-Oauth-Scopes" : [ "read:user, read:org, user:email" ],
           "X-Ratelimit-Limit" : [ "5000" ],
           "X-Ratelimit-Remaining" : [ "4995" ],
@@ -1539,7 +1543,7 @@
           "X-Frame-Options" : [ "deny" ],
           "X-Github-Media-Type" : [ "github.beta; format=json" ],
           "X-Github-Request-Id" : [ "C1CE:7278:572D:AD7C:5CEEAAC9" ],
-          "X-Oauth-Client-Id" : [ "b9e2c4a9c3995ea43cd7" ],
+          "X-Oauth-Client-Id" : [ "6f32ad91d57a254341cb" ],
           "X-Oauth-Scopes" : [ "read:user, read:org, user:email" ],
           "X-Ratelimit-Limit" : [ "5000" ],
           "X-Ratelimit-Remaining" : [ "4994" ],
@@ -1615,7 +1619,7 @@
           "X-Frame-Options" : [ "deny" ],
           "X-Github-Media-Type" : [ "unknown, github.v3" ],
           "X-Github-Request-Id" : [ "C1CE:7278:5744:ADAB:5CEEAAC9" ],
-          "X-Oauth-Client-Id" : [ "b9e2c4a9c3995ea43cd7" ],
+          "X-Oauth-Client-Id" : [ "6f32ad91d57a254341cb" ],
           "X-Oauth-Scopes" : [ "read:user, read:org, user:email" ],
           "X-Ratelimit-Limit" : [ "5000" ],
           "X-Ratelimit-Remaining" : [ "4993" ],

--- a/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
+++ b/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
@@ -69,7 +69,7 @@
       },
       "response" : {
         "status" : 302,
-        "body" : "<html><body>You are being <a href=\"https://github.com/login?client_id=6f32ad91d57a254341cb&amp;return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3D6f32ad91d57a254341cb%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail\">redirected</a>.</body></html>",
+        "body" : "<html><body>You are being <a href=\"https://github.com/login?client_id=b9e2c4a9c3995ea43cd7&amp;return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3Db9e2c4a9c3995ea43cd7%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail\">redirected</a>.</body></html>",
         "encodedBody" : false,
         "templated" : false,
         "headers" : {
@@ -79,7 +79,7 @@
           "Date" : [ "Wed, 29 May 2019 15:52:37 GMT" ],
           "Expect-Ct" : [ "max-age=2592000, report-uri=\"https://api.github.com/_private/browser/errors\"" ],
           "Hoverfly" : [ "Was-Here" ],
-          "Location" : [ "https://github.com/login?client_id=6f32ad91d57a254341cb&return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3D6f32ad91d57a254341cb%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail" ],
+          "Location" : [ "https://github.com/login?client_id=b9e2c4a9c3995ea43cd7&return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3Db9e2c4a9c3995ea43cd7%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail" ],
           "Referrer-Policy" : [ "origin-when-cross-origin, strict-origin-when-cross-origin" ],
           "Server" : [ "GitHub.com" ],
           "Set-Cookie" : [ "has_recent_activity=1; path=/; expires=Wed, 29 May 2019 16:52:37 -0000", "ignored_unsupported_browser_notice=false; path=/", "_gh_sess=bGx0cmtZbHI0OGprQi9PbXZBTDhhS3pGb09vZ2dWWitydmFBRnprODBwVzZDbE41TWdSU2psdEIreER5MlE1K2JRUEpyRmU2NlNVYjFNN0RJQ1VOblBBOXBZSVdETlczK3dnNG44YkhKYUx5YzBMTnl0WE1UNGRrK0NpajVNWUVKYmw1dDNHb2pLeStpMW0ydHFrL29PS0d4N2wyeUt1cUVoWHpBYXNMN0M3Uk1nZElFMlVqaDJXWHJtQlAxYkxmc0tpbXdCbHdXcUpFWjBjM081VllqWGpDYURNeVhRNEdBbVpUOWl0S2VtdnROTnNXTEpxRmJFT05Bbmx2OWllNi0tcW5pdjZJWnlMR0Y4QXVYZ2NrbVcrUT09--31f056df0af59a3c7dff51455826cd1beec8dff6; path=/; secure; HttpOnly" ],
@@ -115,11 +115,11 @@
         "query" : {
           "client_id" : [ {
             "matcher" : "exact",
-            "value" : "6f32ad91d57a254341cb"
+            "value" : "b9e2c4a9c3995ea43cd7"
           } ],
           "return_to" : [ {
             "matcher" : "exact",
-            "value" : "/login/oauth/authorize?client_id=6f32ad91d57a254341cb&redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&response_type=code&scope=read:user read:org user:email"
+            "value" : "/login/oauth/authorize?client_id=b9e2c4a9c3995ea43cd7&redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&response_type=code&scope=read:user read:org user:email"
           } ]
         },
         "body" : [ {
@@ -844,7 +844,7 @@
           } ],
           "dimensions[page]" : [ {
             "matcher" : "exact",
-            "value" : "https://github.com/login?client_id=6f32ad91d57a254341cb&return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3D6f32ad91d57a254341cb%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail"
+            "value" : "https://github.com/login?client_id=b9e2c4a9c3995ea43cd7&return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3Db9e2c4a9c3995ea43cd726redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A8888%252Flogin%253Fclient_name%253DGithubIndirectClient%26response_type%3Dcode%26scope%3Dread%3Auser%20read%3Aorg%20user%3Aemail"
           } ],
           "dimensions[pixel_ratio]" : [ {
             "matcher" : "exact",
@@ -1103,7 +1103,7 @@
       },
       "response" : {
         "status" : 302,
-        "body" : "<html><body>You are being <a href=\"https://github.com/login/oauth/authorize?client_id=6f32ad91d57a254341cb&amp;redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&amp;response_type=code&amp;scope=read%3Auser%20read%3Aorg%20user%3Aemail\">redirected</a>.</body></html>",
+        "body" : "<html><body>You are being <a href=\"https://github.com/login/oauth/authorize?client_id=b9e2c4a9c3995ea43cd7&amp;redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&amp;response_type=code&amp;scope=read%3Auser%20read%3Aorg%20user%3Aemail\">redirected</a>.</body></html>",
         "encodedBody" : false,
         "templated" : false,
         "headers" : {
@@ -1113,7 +1113,7 @@
           "Date" : [ "Wed, 29 May 2019 15:52:39 GMT" ],
           "Expect-Ct" : [ "max-age=2592000, report-uri=\"https://api.github.com/_private/browser/errors\"" ],
           "Hoverfly" : [ "Was-Here" ],
-          "Location" : [ "https://github.com/login/oauth/authorize?client_id=6f32ad91d57a254341cb&redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&response_type=code&scope=read%3Auser%20read%3Aorg%20user%3Aemail" ],
+          "Location" : [ "https://github.com/login/oauth/authorize?client_id=b9e2c4a9c3995ea43cd7&redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Flogin%3Fclient_name%3DGithubIndirectClient&response_type=code&scope=read%3Auser%20read%3Aorg%20user%3Aemail" ],
           "Referrer-Policy" : [ "origin-when-cross-origin, strict-origin-when-cross-origin" ],
           "Server" : [ "GitHub.com" ],
           "Set-Cookie" : [ "has_recent_activity=1; path=/; expires=Wed, 29 May 2019 16:52:39 -0000", "user_session=uLOGkpK2P3L8N_SPYYjaUjcaf8qR2UlTUjvKcGQCc6AqMnYl; path=/; expires=Wed, 12 Jun 2019 15:52:39 -0000; secure; HttpOnly", "__Host-user_session_same_site=uLOGkpK2P3L8N_SPYYjaUjcaf8qR2UlTUjvKcGQCc6AqMnYl; path=/; expires=Wed, 12 Jun 2019 15:52:39 -0000; secure; HttpOnly; SameSite=Strict", "logged_in=yes; domain=.github.com; path=/; expires=Sun, 29 May 2039 16:52:39 -0000; secure; HttpOnly", "dotcom_user=notarealuse; domain=.github.com; path=/; expires=Sun, 29 May 2039 16:52:39 -0000; secure; HttpOnly", "_gh_sess=N3JGang4V2lNclhpaEpvQ0JPQXgwaHJ0Ui9BaEFabnZLVmRSbWhmbVA0TkIyYy9zTElhSk80UHFNMXM3emUxK093Q3E1K29lbkxiUWpxclR3SFlNS1c4TFhtUEFWR3YrcThTem9JMXNnc3BEbkVBZmZvZ1dvRUsxUlRKVnpFc1pQVjEyWkpnZnI4UytzRXM4MzkzZ2FEREh0TzlnTjZ1bUxtK0FPM1hSMTFseXRkaHZGaFVldkxocWFWOUhTNlN6N3ZDS0VMeHgwU255WG80NzJaOTIxVmVTM3VnaXhIbG03YTN5OXA4VTNXdWpBMzNVcWhWaDNicFVvQjQ1RXBtWVU1YW9aSDNuNDk2UDVvVnFNcEo0cWJ3SWFnYnpOYXVRMGRqSjcrUkNCYmF5dUVzMkx6dFAzbXFHZ2hnU0E0ZWROZTYvdzdISlJQcVlTZHpOWXMxZmZYbXIvbys0dXd6Q0pTdnJyWWRFZ2JrPS0tL25CdURoMlVqZkxaTDNLalFMeFF5Zz09--61da5f0942d99841d2eba03ecaba6e0b1eecbcea; path=/; secure; HttpOnly" ],
@@ -1149,7 +1149,7 @@
         "query" : {
           "client_id" : [ {
             "matcher" : "exact",
-            "value" : "6f32ad91d57a254341cb"
+            "value" : "b9e2c4a9c3995ea43cd7"
           } ],
           "redirect_uri" : [ {
             "matcher" : "exact",
@@ -1455,7 +1455,7 @@
           "X-Frame-Options" : [ "deny" ],
           "X-Github-Media-Type" : [ "github.beta; format=json" ],
           "X-Github-Request-Id" : [ "C1CE:7278:5707:AC15:5CEEAAC7" ],
-          "X-Oauth-Client-Id" : [ "6f32ad91d57a254341cb" ],
+          "X-Oauth-Client-Id" : [ "b9e2c4a9c3995ea43cd7" ],
           "X-Oauth-Scopes" : [ "read:user, read:org, user:email" ],
           "X-Ratelimit-Limit" : [ "5000" ],
           "X-Ratelimit-Remaining" : [ "4995" ],
@@ -1539,7 +1539,7 @@
           "X-Frame-Options" : [ "deny" ],
           "X-Github-Media-Type" : [ "github.beta; format=json" ],
           "X-Github-Request-Id" : [ "C1CE:7278:572D:AD7C:5CEEAAC9" ],
-          "X-Oauth-Client-Id" : [ "6f32ad91d57a254341cb" ],
+          "X-Oauth-Client-Id" : [ "b9e2c4a9c3995ea43cd7" ],
           "X-Oauth-Scopes" : [ "read:user, read:org, user:email" ],
           "X-Ratelimit-Limit" : [ "5000" ],
           "X-Ratelimit-Remaining" : [ "4994" ],
@@ -1615,7 +1615,7 @@
           "X-Frame-Options" : [ "deny" ],
           "X-Github-Media-Type" : [ "unknown, github.v3" ],
           "X-Github-Request-Id" : [ "C1CE:7278:5744:ADAB:5CEEAAC9" ],
-          "X-Oauth-Client-Id" : [ "6f32ad91d57a254341cb" ],
+          "X-Oauth-Client-Id" : [ "b9e2c4a9c3995ea43cd7" ],
           "X-Oauth-Scopes" : [ "read:user, read:org, user:email" ],
           "X-Ratelimit-Limit" : [ "5000" ],
           "X-Ratelimit-Remaining" : [ "4993" ],

--- a/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
+++ b/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
@@ -878,10 +878,6 @@
             "matcher" : "exact",
             "value" : "Sign in to GitHub · GitHub"
           } ],
-          "dimensions[tz_seconds]" : [ {
-            "matcher" : "exact",
-            "value" : "3600"
-          } ],
           "dimensions[user_agent]" : [ {
             "matcher" : "regex",
             "value" : ".*"
@@ -898,7 +894,7 @@
         "headers" : {
           "Accept" : [ {
             "matcher" : "exact",
-            "value" : "image/webp,image/apng,image/*,*/*;q=0.8"
+            "value" : "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8"
           } ],
           "Accept-Encoding" : [ {
             "matcher" : "exact",

--- a/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
+++ b/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
@@ -49,10 +49,6 @@
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
           } ],
-          "Accept-Language" : [ {
-            "matcher" : "exact",
-            "value" : "en-US"
-          } ],
           "Connection" : [ {
             "matcher" : "exact",
             "value" : "keep-alive"

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/insertHelpers.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/insertHelpers.kt
@@ -122,9 +122,10 @@ fun insertReport(name: String,
                  author: String = "author authorson",
                  requester: String = "requester mcfunder",
                  display: String? = null,
-                 addOrderlyWebReportVersion: Boolean = true)
+                 addOrderlyWebReportVersion: Boolean = true,
+                 elapsed: Double = 0.0)
 {
-    insertReportAndVersion(name, version, published, date, display, addOrderlyWebReportVersion)
+    insertReportAndVersion(name, version, published, date, display, elapsed, addOrderlyWebReportVersion)
 
     JooqContext().use {
         val authorFieldRecord = it.dsl.newRecord(Tables.REPORT_VERSION_CUSTOM_FIELDS)
@@ -251,6 +252,7 @@ private fun insertReportAndVersion(name: String,
                                    published: Boolean,
                                    date: Timestamp,
                                    display: String? = null,
+                                   elapsed: Double = 0.0,
                                    addOrderlyWebReportVersion: Boolean = true)
 {
     JooqContext().use {
@@ -282,7 +284,7 @@ private fun insertReportAndVersion(name: String,
                     this.author = ""
                     this.published = false
                     this.connection = false
-                    this.elapsed = 100.0
+                    this.elapsed = elapsed
                 }
         reportVersionRecord.store()
 


### PR DESCRIPTION
Adds start and elapse time to the report version page metadata tab. 

This involved adding the `elapsed` property a new report version variant data class. 

This branch is deployed to UAT, where you can see how it displays some real report elapsed times e.g [here](https://support.montagu.dide.ic.ac.uk:10443/reports/report/paper-second-summarise-with-unique-data/20201209-145215-a8c89a46#metadata)

Also updated dependencies to run with latest `create_orderly_demo` and fixed failing customConfig tests

Not sure why codecov is failing, the line it's complaining about is definitely tested e.g. [here](https://github.com/vimc/orderly-web/pull/315/files#diff-c43e5bc7d771cca4fb3157c1ed102c76cd67d8d4b7f331a551c1616fed0d9e50R109)