### PR TITLE
Ensure interrupted orderly-web CI builds are cleaned-up

### DIFF
--- a/buildkite/build-app.sh
+++ b/buildkite/build-app.sh
@@ -28,6 +28,7 @@ $here/../scripts/run-dependencies.sh
 
 # Compile, test and package the app
 function cleanup() {
+  $here/../scripts/clear-docker.sh
   zip -qr reports.zip reports
   $here/codecov.sh -s coverage/
   sudo chown -R $UID reports coverage

--- a/buildkite/build-cli.sh
+++ b/buildkite/build-cli.sh
@@ -23,6 +23,10 @@ docker build --tag orderly-web-cli-build \
 $here/make-db.sh
 
 # Run the created image
+function cleanup() {
+  $here/../scripts/clear-docker.sh
+}
+trap cleanup EXIT
 docker run --rm \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $BUILDKITE_DOCKER_AUTH_PATH:/root/.docker/config.json \

--- a/buildkite/common
+++ b/buildkite/common
@@ -29,10 +29,3 @@ export GIT_ID=$GIT_ID
 export GIT_BRANCH=$GIT_BRANCH
 export MONTAGU_ORDERLY_PATH=$PWD/git
 export ORDERLY_SERVER_USER_ID=$UID
-
-function cleardocker() {
-  $here/../scripts/clear-docker.sh
-}
-trap cleardocker EXIT
-
-

--- a/buildkite/run-custom-config-tests-in-container.sh
+++ b/buildkite/run-custom-config-tests-in-container.sh
@@ -18,6 +18,10 @@ $here/make-db.sh
 $here/../scripts/run-dependencies.sh
 
 # Run the created image
+function cleanup() {
+  $here/../scripts/clear-docker.sh
+}
+trap cleanup EXIT
 docker run --rm \
     -v $PWD/git:/api/src/customConfigTests/git \
     --network=host \

--- a/buildkite/run-smoke-test.sh
+++ b/buildkite/run-smoke-test.sh
@@ -13,6 +13,10 @@ $here/../scripts/run-dependencies.sh
 # Run the OrderlyWeb image
 IMAGE=$ORG/orderly-web:$GIT_ID
 docker pull $IMAGE
+function cleanup() {
+  $here/../scripts/clear-docker.sh
+}
+trap cleanup EXIT
 docker run --rm \
     -d \
     -v $PWD/demo:/orderly \


### PR DESCRIPTION
Move `cleardocker` exit handler from `common` to scripts that require it i.e. those that invoke `docker run`