### PR TITLE
mrc-2419 Fix Selenium test for report-running progress

### DIFF
--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -113,10 +113,7 @@ class RunReportPageTests : SeleniumTest()
         assertThat(driver.findElement(By.id("run-report-status")).text).startsWith("Run started")
 
         driver.findElement(By.id("logs-link")).click()
-        wait.until(ExpectedConditions.textToBePresentInElementLocated(By.cssSelector("h2"), "Running report logs"))
-        wait.until(ExpectedConditions.textToBePresentInElementLocated(By.cssSelector("#report-logs textarea"),
-                "[ git        ]  fetch")) //This is always the first log message
-
+        wait.until(ExpectedConditions.textToBe(By.cssSelector("#report-status .font-weight-bold"), "running"))
     }
 
     @Test


### PR DESCRIPTION
See mrc-2149 for background.

Explanation:
* The previously failing test runs a report and then checks that the execution log looks correct
* The test suite uses a different orderly.sqlite file to the one being updated by orderly.server (see [here](https://github.com/vimc/orderly-web/blob/master/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt#L40))
* The test only passes if at least part of the log is returned before the job finishes. If the logs are only returned on completion (which now seems to be the case, at least for this short-running job, but I guess would also be the case if a job finishes instantaneously), then the logs can't be stored in the orderlyweb_report_run table because the insert also tries to set the newly-available report version ID, but the FK constraint fails because the ID doesn't actually appear in the report_version table of our copy of the database
* This can be verified by disabling FK constraints, which fixes the test
* Patch up the test by checking that the page displays the status ("running") rather than some output, in order to get master working on Buildkite
* There is no issue with actually using the app - the relevant functionality works fine with shared database, as in real-world deployment
* Will need to consider how we fix this properly - it seems that longer-term we'll need orderly.server and OW to share the same database during tests, as the previous version of this test only passed as a result of some fortunate assertions and some specific behaviour of orderly.server (i.e. job taking long enough, and logs being returned while it was running). Note that the job status stored in the db and shown on the page can never actually reach "success" with the current setup - because the db can't be updated with a report version ID.
* Would also be good to know exactly how/why orderly.server behaviour has changed - am talking to Rob about this