### PR TITLE
Add report names to workflow status response

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ works, which is necessary because it is called implicitly during the Docker imag
 
 [settings files]: https://github.com/vimc/orderly-web/tree/master/src/.idea/codeStyles
 
+### Coverage
+
+The `@NoCoverage` annotation defined in [Annotations.kt](src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Annotations.kt)
+excludes specified classes from processing by JaCoCo in order to avoid the necessity of writing artificial test logic
+simply to satisfy coverage metrics. It is only intended for use with `internal data class`es used to
+(de)serialise orderly.server responses.
+
 ### Regenerate database interface
 ```
 cd src

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Annotations.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/Annotations.kt
@@ -1,0 +1,6 @@
+package org.vaccineimpact.orderlyweb
+
+@Retention(AnnotationRetention.BINARY)
+annotation class NoCoverageGenerated
+
+typealias NoCoverage = NoCoverageGenerated

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebWorkflowRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebWorkflowRouteConfig.kt
@@ -24,5 +24,6 @@ object WebWorkflowRouteConfig : RouteConfig
         WebEndpoint("/workflows/:key/status", WorkflowRunController::class, "getWorkflowRunStatus")
             .json()
             .secure(runReports)
+            .transform()
     )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
@@ -2,18 +2,13 @@ package org.vaccineimpact.orderlyweb.controllers.web
 
 import com.google.gson.JsonSyntaxException
 import com.google.gson.annotations.SerializedName
-import org.vaccineimpact.orderlyweb.ActionContext
-import org.vaccineimpact.orderlyweb.OrderlyServer
-import org.vaccineimpact.orderlyweb.OrderlyServerAPI
-import org.vaccineimpact.orderlyweb.Serializer
+import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.controllers.Controller
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyWebWorkflowRunRepository
 import org.vaccineimpact.orderlyweb.db.repositories.WorkflowRunRepository
 import org.vaccineimpact.orderlyweb.errors.BadRequest
-import org.vaccineimpact.orderlyweb.models.WorkflowRun
-import org.vaccineimpact.orderlyweb.models.WorkflowRunRequest
-import org.vaccineimpact.orderlyweb.models.WorkflowRunSummary
+import org.vaccineimpact.orderlyweb.models.*
 import org.vaccineimpact.orderlyweb.viewmodels.WorkflowRunViewModel
 import java.net.HttpURLConnection.HTTP_OK
 import java.time.Instant
@@ -110,24 +105,35 @@ class WorkflowRunController(
         return passThroughResponse(response)
     }
 
+    @NoCoverage
     internal data class WorkflowRunStatusResponse(
         @SerializedName(value = "workflow_key")
         val key: String,
-        val status: String
+        val status: String,
+        val reports: List<WorkflowRunStatusResponseReport>
     )
+    {
+        @NoCoverage
+        data class WorkflowRunStatusResponseReport(
+            val key: String,
+            val status: String,
+            val version: String?
+        )
+    }
 
-    fun getWorkflowRunStatus(): String
+    fun getWorkflowRunStatus(): WorkflowRunStatus
     {
         val key = context.params(":key")
-        val response = orderlyServerAPI.get(
-            "/v1/workflow/$key/status/",
-            emptyMap()
-        )
-        if (response.statusCode == HTTP_OK)
-        {
-            val workflowRunStatusResponse = response.data(WorkflowRunStatusResponse::class.java)
-            workflowRunRepository.updateWorkflowRun(workflowRunStatusResponse.key, workflowRunStatusResponse.status)
-        }
-        return passThroughResponse(response)
+        val response = orderlyServerAPI
+            .throwOnError()
+            .get("/v1/workflow/$key/status/", emptyMap())
+        val workflowRunStatusResponse = response.data(WorkflowRunStatusResponse::class.java)
+        workflowRunRepository.updateWorkflowRun(key, workflowRunStatusResponse.status)
+        val reportNames = workflowRunRepository.getWorkflowRunDetails(key).reports.map { it.name }
+        return WorkflowRunStatus(
+            workflowRunStatusResponse.status,
+            workflowRunStatusResponse.reports.zip(reportNames) { report, reportName ->
+                WorkflowRunStatus.WorkflowRunReportStatus(reportName, report.key, report.status, report.version)
+            })
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/WorkflowRun.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/WorkflowRun.kt
@@ -32,6 +32,19 @@ data class WorkflowRun(
     val gitCommit: String? = null
 )
 
+data class WorkflowRunStatus(
+    val status: String,
+    val reports: List<WorkflowRunReportStatus>
+)
+{
+    data class WorkflowRunReportStatus(
+        val name: String,
+        val key: String,
+        val status: String,
+        val version: String? = null
+    )
+}
+
 data class WorkflowRunSummary(
     val name: String,
     val key: String,

--- a/src/config/detekt/baseline-main.yml
+++ b/src/config/detekt/baseline-main.yml
@@ -53,7 +53,6 @@
     <ID>FinalNewline:org.vaccineimpact.orderlyweb.app_start.routing.web.WebGitRouteConfig.kt:1</ID>
     <ID>FinalNewline:org.vaccineimpact.orderlyweb.app_start.routing.web.WebSettingsRouteConfig.kt:1</ID>
     <ID>FinalNewline:org.vaccineimpact.orderlyweb.app_start.routing.web.WebUserRouteConfig.kt:1</ID>
-    <ID>FinalNewline:org.vaccineimpact.orderlyweb.app_start.routing.web.WebWorkflowRouteConfig.kt:1</ID>
     <ID>FinalNewline:org.vaccineimpact.orderlyweb.controllers.api.UserController.kt:1</ID>
     <ID>FinalNewline:org.vaccineimpact.orderlyweb.controllers.web.AdminController.kt:1</ID>
     <ID>FinalNewline:org.vaccineimpact.orderlyweb.controllers.web.PermissionController.kt:1</ID>
@@ -169,6 +168,7 @@
     <ID>MandatoryBracesIfStatements:ReportRepository.kt$OrderlyReportRepository$CHANGELOG_LABEL.PUBLIC.isTrue.and(CHANGELOG.REPORT_VERSION_PUBLIC.isNotNull)</ID>
     <ID>MandatoryBracesIfStatements:ReportRepository.kt$OrderlyReportRepository$trueCondition()</ID>
     <ID>MandatoryBracesIfStatements:ResourceController.kt$ResourceController$throw OrderlyFileNotFoundError(resourcename)</ID>
+    <ID>MatchingDeclarationName:Annotations.kt$NoCoverageGenerated</ID>
     <ID>MaxLineLength:AmbiguousRelationBetweenTables.kt$AmbiguousRelationBetweenTables$"Attempted to construct join from ${from.name} to ${to.name}, but there is more than one key relating those tables."</ID>
     <ID>MaxLineLength:AppViewModel.kt$DefaultViewModel$constructor</ID>
     <ID>MaxLineLength:AuthorizationRepository.kt$OrderlyAuthorizationRepository$.</ID>
@@ -361,7 +361,6 @@
     <ID>NewLineAtEndOfFile:WebSettingsRouteConfig.kt$org.vaccineimpact.orderlyweb.app_start.routing.web.WebSettingsRouteConfig.kt</ID>
     <ID>NewLineAtEndOfFile:WebTokenHelper.kt$org.vaccineimpact.orderlyweb.security.WebTokenHelper.kt</ID>
     <ID>NewLineAtEndOfFile:WebUserRouteConfig.kt$org.vaccineimpact.orderlyweb.app_start.routing.web.WebUserRouteConfig.kt</ID>
-    <ID>NewLineAtEndOfFile:WebWorkflowRouteConfig.kt$org.vaccineimpact.orderlyweb.app_start.routing.web.WebWorkflowRouteConfig.kt</ID>
     <ID>NewLineAtEndOfFile:WebloginViewModel.kt$org.vaccineimpact.orderlyweb.viewmodels.WebloginViewModel.kt</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.APIEndpoint.kt:64</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.Helpers.kt:33</ID>
@@ -446,8 +445,6 @@
     <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:4</ID>
     <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.controllers.web.GitController.kt:6</ID>
     <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.controllers.web.GitController.kt:7</ID>
-    <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.controllers.web.IndexController.kt:11</ID>
-    <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.controllers.web.IndexController.kt:12</ID>
     <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.db.UserMapper.kt:4</ID>
     <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.db.UserMapper.kt:6</ID>
     <ID>NoUnusedImports:org.vaccineimpact.orderlyweb.models.ReportVersionWithDescCustomFieldsLatestParamsTags.kt:3</ID>
@@ -855,7 +852,6 @@
     <ID>SpacingAroundColon:org.vaccineimpact.orderlyweb.controllers.api.UserController.kt:13</ID>
     <ID>SpacingAroundColon:org.vaccineimpact.orderlyweb.controllers.web.GitController.kt:11</ID>
     <ID>SpacingAroundColon:org.vaccineimpact.orderlyweb.controllers.web.GitController.kt:16</ID>
-    <ID>SpacingAroundColon:org.vaccineimpact.orderlyweb.controllers.web.IndexController.kt:20</ID>
     <ID>SpacingAroundColon:org.vaccineimpact.orderlyweb.controllers.web.RoleController.kt:123</ID>
     <ID>SpacingAroundColon:org.vaccineimpact.orderlyweb.db.JoinPath.kt:71</ID>
     <ID>SpacingAroundColon:org.vaccineimpact.orderlyweb.db.JoinPath.kt:72</ID>


### PR DESCRIPTION
This basically switches from passing through [orderly.server response](https://github.com/vimc/orderly.server/blob/master/inst/schema/WorkflowStatus.schema.json) for workflow status to constructing our [own response](https://github.com/vimc/orderly-web/pull/351/files#diff-dff48e9479fe9b6280d0afa5ecaaa0e280232ac01ad361f397263d8f3ad9d97aR319), principally to include report names (as needed for the workflow progress page), but also to exclude fields we don't need (per-report queue status) or are already retrieved via other endpoints (report logs).

I've tried to address the recurring issue of having to add redundant code to tests just to ensure coverage of data classes by adding a `NoCoverage` annotation (aliased because JaCoCo only ignores classes annotated with something included `Generated`). This is only intended to be used for "internal" data classes e.g. those used to deserialise orderly.server responses. The alternative is to centralise these classes to a new package and to exclude that package from coverage reports, which seems less flexible but opinions/alternatives very welcome.
