### PR TITLE
mrc-1925 Update TreeTables to improve performance with large number of reports

### DIFF
--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -14784,8 +14784,9 @@
       "optional": true
     },
     "treetables": {
-      "version": "github:reside-ic/TreeTables#bbe9b887b9656f76f45eca3428c92446ce6169f1",
-      "from": "github:reside-ic/TreeTables#mrc-1925",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/treetables/-/treetables-1.2.1.tgz",
+      "integrity": "sha512-/saaotTokktuDxl9ZqvO5e5sm2ffcguF86NtrHBrFUigv7Eue4JDmtzy/uZXjcDKlKtlf6cDBnYqeekEjCGPHw==",
       "dev": true,
       "requires": {
         "datatables.net": "^1.10.19",

--- a/src/app/static/package-lock.json
+++ b/src/app/static/package-lock.json
@@ -14784,9 +14784,8 @@
       "optional": true
     },
     "treetables": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/treetables/-/treetables-1.2.0.tgz",
-      "integrity": "sha512-RO6nm3cfAizKYyktAx5tsI3Z5RGoksBNpay1cdGtn3SVVY4VQWOJewr8Sy0aON8PzUhP4quoSzguXrOsRn0U/A==",
+      "version": "github:reside-ic/TreeTables#bbe9b887b9656f76f45eca3428c92446ce6169f1",
+      "from": "github:reside-ic/TreeTables#mrc-1925",
       "dev": true,
       "requires": {
         "datatables.net": "^1.10.19",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -44,7 +44,7 @@
     "sinon": "^7.5.0",
     "through": "^2.3.8",
     "tokenize2": "^1.3.1",
-    "treetables": "^1.2.0",
+    "treetables": "reside-ic/TreeTables#mrc-1925",
     "ts-jest": "^26.5.0",
     "ts-loader": "^8.0.14",
     "typescript": "^4.1.3",

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -44,7 +44,7 @@
     "sinon": "^7.5.0",
     "through": "^2.3.8",
     "tokenize2": "^1.3.1",
-    "treetables": "reside-ic/TreeTables#mrc-1925",
+    "treetables": "^1.2.1",
     "ts-jest": "^26.5.0",
     "ts-loader": "^8.0.14",
     "typescript": "^4.1.3",


### PR DESCRIPTION
Pinned to git branch for QA purposes - will be updated to `1.2.1` on TreeTables release following merge of reside-ic/TreeTables#32