### PR TITLE
mrc-2467 Add endpoint to get report run metadata

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/routing/web/WebReportRouteConfig.kt
@@ -81,6 +81,11 @@ object WebReportRouteConfig : RouteConfig
             WebEndpoint("/report/:name/dependencies/",
                     ReportController::class, "getDependencies")
                     .json()
-                    .secure(readReports)
+                    .secure(readReports),
+            WebEndpoint("/report/run-metadata",
+                    ReportController::class, "getRunMetadata")
+                    .json()
+                    .transform()
+                    .secure(runReports)
     )
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -51,26 +51,17 @@ class ReportController(
         val reportKey = "report-name"
         val reportName = context.queryParams(reportKey).toString()
 
-        val metadata = orderlyServerAPI
-                .throwOnError()
-                .get("/run-metadata", emptyMap())
-                .data(RunReportMetadata::class.java)
-
-        val gitBranches = if (metadata.gitSupported)
-        {
-            val branchResponse = orderlyServerAPI
-                    .throwOnError()
-                    .get("/git/branches", emptyMap())
-
-            branchResponse.listData(GitBranch::class.java)
-                    .map { it.name }
-        }
-        else
-        {
-            listOf()
-        }
+        val metadata = getReportRunMetadata()
+        val gitBranches = getGitBranches(metadata)
 
         return RunReportViewModel(context, metadata, gitBranches, reportName)
+    }
+
+    fun getRunMetadata(): RunReportMetadataWithBranches
+    {
+        val metadata = getReportRunMetadata()
+        val gitBranches = getGitBranches(metadata)
+        return RunReportMetadataWithBranches(metadata, gitBranches)
     }
 
     fun getRunnableReports(): List<ReportWithDate>
@@ -146,5 +137,30 @@ class ReportController(
         val name = context.params(":name")
         val response = orderlyServerAPI.get("/v1/reports/$name/dependencies/", context)
         return passThroughResponse(response)
+    }
+
+    private fun getReportRunMetadata(): RunReportMetadata
+    {
+        return orderlyServerAPI
+                .throwOnError()
+                .get("/run-metadata", emptyMap())
+                .data(RunReportMetadata::class.java)
+    }
+
+    private fun getGitBranches(metadata: RunReportMetadata): List<String>
+    {
+        return if (metadata.gitSupported)
+        {
+            val branchResponse = orderlyServerAPI
+                    .throwOnError()
+                    .get("/git/branches", emptyMap())
+
+            branchResponse.listData(GitBranch::class.java)
+                    .map { it.name }
+        }
+        else
+        {
+            listOf()
+        }
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/RunReportMetadata.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/RunReportMetadata.kt
@@ -5,3 +5,8 @@ data class RunReportMetadata(
         val gitSupported: Boolean,
         val instances: Map<String, List<String>>,
         val changelogTypes: List<String>)
+
+data class RunReportMetadataWithBranches(
+    val metadata: RunReportMetadata,
+    val gitBranches: List<String>
+)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportTests.kt
@@ -135,4 +135,33 @@ class ReportTests : IntegrationTest()
         assertThat(responseData["dependency_tree"]["name"].textValue()).isEqualTo("minimal")
         assertThat(responseData["dependency_tree"]["id"].textValue().count()).isGreaterThan(0)
     }
+
+    @Test
+    fun `report runners can get report run metadata`()
+    {
+        val url="/report/run-metadata"
+        val response = webRequestHelper.loginWithMontaguAndMakeRequest(url,
+                setOf(ReifiedPermission("reports.run", Scope.Global())),
+                method = HttpMethod.get,
+                contentType = ContentTypes.json)
+        assertSuccessful(response)
+        assertJsonContentType(response)
+        val responseData = JSONValidator.getData(response.text)
+        assertThat(responseData["metadata"]["instances_supported"].asBoolean()).isFalse()
+        assertThat(responseData["metadata"]["git_supported"].asBoolean()).isTrue()
+        assertThat(responseData["metadata"]["instances"]["source"].count()).isEqualTo(0)
+        assertThat(responseData["metadata"]["changelog_types"].count()).isEqualTo(2)
+        assertThat(responseData["git_branches"].count()).isEqualTo(2)
+        assertThat(responseData["git_branches"][0].asText()).isEqualTo("master")
+    }
+
+    @Test
+    fun `only report runners can get report run metadata`()
+    {
+        val url = "/report/run-metadata"
+        assertWebUrlSecured(url,
+                setOf(ReifiedPermission("reports.run", Scope.Global())),
+                method = HttpMethod.get,
+                contentType = ContentTypes.json)
+    }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunReportTests.kt
@@ -95,6 +95,28 @@ class RunReportTests
     }
 
     @Test
+    fun `getRunMetadata returns run report metadata`()
+    {
+        val mockOrderlyServerWithError = mock<OrderlyServerAPI> {
+            on { get("/git/branches", mapOf()) } doReturn
+                    OrderlyServerResponse(Serializer.instance.toResult(fakeBranchResponse), 200)
+            on { get("/run-metadata", mapOf()) } doReturn
+                    OrderlyServerResponse(Serializer.instance.toResult(fakeMetadata), 200)
+        }
+        val mockOrderlyServer = mock<OrderlyServerAPI> {
+            on { throwOnError() } doReturn mockOrderlyServerWithError
+        }
+
+        val sut = ReportController(mock(), mock(), mockOrderlyServer, mock(), mock())
+        val result = sut.getRunMetadata()
+        assertThat(result.gitBranches).hasSameElementsAs(listOf("master", "dev"))
+        assertThat(result.metadata.gitSupported).isTrue()
+        assertThat(result.metadata.instancesSupported).isTrue()
+        assertThat(result.metadata.changelogTypes).hasSameElementsAs(listOf("internal", "published"))
+        assertThat(result.metadata.instances["source"]).hasSameElementsAs(listOf("uat", "science"))
+    }
+
+    @Test
     fun `gets parameters for report as expected with commitId`()
     {
         val mockContext: ActionContext = mock {


### PR DESCRIPTION
Both mrc-2310 (add reports to workflow) and mrc-2311 (finalise workflow) require report run metadata. This metadata is also used by the run report page, where it is injected into the template by the backend. However, it makes more sense for the more autonomous workflow wizard child components to fetch this metadata themsevles. This ticket adds the endpoint and modifies the controller to use the same methods to fetch metadata for both usages. 

The metadata endpoint actually returns both the metadata object and the list of initial git branches. 
