### PR TITLE
mrc-2311_git create an independent component for changelog

### DIFF
--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -1,0 +1,62 @@
+<template>
+    <div>
+        <div v-if="showChangelog">
+            <div v-if="showChangeMessage" id="changelog-message" class="form-group row">
+                <label for="changelogMessage" class="col-sm-2 col-form-label text-right">Changelog Message</label>
+                <div class="col-sm-6">
+                        <textarea class="form-control" id="changelogMessage" v-model="changeLogMessageValue"
+                                  rows="2"></textarea>
+                </div>
+            </div>
+            <div id="changelog-type" class="form-group row">
+                <label for="changelogType" class="col-sm-2 col-form-label text-right">Changelog Type</label>
+                <div class="col-sm-6">
+                    <select class="form-control" id="changelogType" v-model="changeLogTypeValue">
+                        <option v-for="option in reportMetadata.changelog_types" :value="option">
+                            {{ option }}
+                        </option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import {RunMetadata} from "../../utils/types";
+
+interface Props {
+    showChangelog: boolean
+    showChangeMessage: boolean
+    changeLogMessageValue: string
+    changeLogTypeValue: string
+    reportMetadata: RunMetadata[] | null
+}
+
+export default Vue.extend<unknown, unknown, unknown, Props>({
+    name: "changeLog",
+    props: {
+        showChangelog: {
+            required: true,
+            type: Boolean
+        },
+        showChangeMessage: {
+            required: true,
+            type: Boolean
+        },
+        changeLogMessageValue: {
+            required: true,
+            type: String
+        },
+        changeLogTypeValue: {
+            required: true,
+            type: String
+        },
+        reportMetadata: null
+    },
+    methods: {
+
+    }
+})
+</script>

--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -1,28 +1,26 @@
 <template>
     <div>
-        <div v-if="showChangelog">
-            <div v-if="showChangeMessage" id="changelog-message" class="form-group row">
-                <label for="changelogMessage" class="col-sm-2 col-form-label text-right">Changelog Message</label>
-                <div class="col-sm-6">
+        <div v-if="showChangeMessage" id="changelog-message" class="form-group row">
+            <label for="changelogMessage" class="col-sm-2 col-form-label text-right">Changelog Message</label>
+            <div class="col-sm-6">
                         <textarea class="form-control" id="changelogMessage"
                                   v-model="changeLogMessageValue"
                                   @input="handleChangeLogMessage"
                                   rows="2">
                         </textarea>
-                </div>
             </div>
-            <div id="changelog-type" class="form-group row">
-                <label for="changelogType" class="col-sm-2 col-form-label text-right">Changelog Type</label>
-                <div class="col-sm-6">
-                    <select class="form-control"
-                            id="changelogType"
-                            v-model="changeLogTypeValue"
-                            @change="handleChangeLogType">
-                        <option v-for="option in reportMetadata.changelog_types" :value="option">
-                            {{ option }}
-                        </option>
-                    </select>
-                </div>
+        </div>
+        <div id="changelog-type" class="form-group row">
+            <label for="changelogType" class="col-sm-2 col-form-label text-right">Changelog Type</label>
+            <div class="col-sm-6">
+                <select class="form-control"
+                        id="changelogType"
+                        v-model="changeLogTypeValue"
+                        @change="handleChangeLogType">
+                    <option v-for="option in reportMetadata.changelog_types" :value="option">
+                        {{ option }}
+                    </option>
+                </select>
             </div>
         </div>
     </div>
@@ -33,7 +31,6 @@
     import {ReportMetadata} from "../../utils/types";
 
     interface Props {
-        showChangelog: boolean
         showChangeMessage: boolean
         reportMetadata: ReportMetadata[] | null
     }
@@ -57,10 +54,6 @@
             }
         },
         props: {
-            showChangelog: {
-                required: true,
-                type: Boolean
-            },
             showChangeMessage: {
                 required: true,
                 type: Boolean

--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -4,14 +4,20 @@
             <div v-if="showChangeMessage" id="changelog-message" class="form-group row">
                 <label for="changelogMessage" class="col-sm-2 col-form-label text-right">Changelog Message</label>
                 <div class="col-sm-6">
-                        <textarea class="form-control" id="changelogMessage" v-model="changeLogMessageValue"
-                                  rows="2"></textarea>
+                        <textarea class="form-control" id="changelogMessage"
+                                  v-model="changeLogMessageValue"
+                                  @input="handleChangeLogMessage"
+                                  rows="2">
+                        </textarea>
                 </div>
             </div>
             <div id="changelog-type" class="form-group row">
                 <label for="changelogType" class="col-sm-2 col-form-label text-right">Changelog Type</label>
                 <div class="col-sm-6">
-                    <select class="form-control" id="changelogType" v-model="changeLogTypeValue">
+                    <select class="form-control"
+                            id="changelogType"
+                            v-model="changeLogTypeValue"
+                            @change="handleChangeLogType">
                         <option v-for="option in reportMetadata.changelog_types" :value="option">
                             {{ option }}
                         </option>
@@ -23,40 +29,51 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import {RunMetadata} from "../../utils/types";
+    import Vue from "vue";
+    import {ReportMetadata} from "../../utils/types";
 
-interface Props {
-    showChangelog: boolean
-    showChangeMessage: boolean
-    changeLogMessageValue: string
-    changeLogTypeValue: string
-    reportMetadata: RunMetadata[] | null
-}
-
-export default Vue.extend<unknown, unknown, unknown, Props>({
-    name: "changeLog",
-    props: {
-        showChangelog: {
-            required: true,
-            type: Boolean
-        },
-        showChangeMessage: {
-            required: true,
-            type: Boolean
-        },
-        changeLogMessageValue: {
-            required: true,
-            type: String
-        },
-        changeLogTypeValue: {
-            required: true,
-            type: String
-        },
-        reportMetadata: null
-    },
-    methods: {
-
+    interface Props {
+        showChangelog: boolean
+        showChangeMessage: boolean
+        reportMetadata: ReportMetadata[] | null
     }
-})
+
+    interface Data {
+        changeLogMessageValue: string
+        changeLogTypeValue: string
+    }
+
+    interface Methods {
+        handleChangeLogMessage: () => void
+        handleChangeLogType: () => void
+    }
+
+    export default Vue.extend<Data, Methods, unknown, Props>({
+        name: "changeLog",
+        data(): Data {
+            return {
+                changeLogMessageValue: "",
+                changeLogTypeValue: ""
+            }
+        },
+        props: {
+            showChangelog: {
+                required: true,
+                type: Boolean
+            },
+            showChangeMessage: {
+                required: true,
+                type: Boolean
+            },
+            reportMetadata: null
+        },
+        methods: {
+            handleChangeLogType: function () {
+                this.$emit("changelogType", this.changeLogTypeValue)
+            },
+            handleChangeLogMessage: function () {
+                this.$emit("changelogMessage", this.changeLogMessageValue)
+            }
+        }
+    })
 </script>

--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -2,9 +2,9 @@
     <div v-if="showChangelog">
         <div id="changelog-message" class="form-group row">
             <label for="changelogMessage"
-                   :class="`col-sm-${changelogStyle.label.size} ${changelogStyle.label.justify}`"
+                   :class="displayStyle.label"
                    class="col-form-label">Changelog Message</label>
-            <div :class="`col-sm-${changelogStyle.control.size}`">
+            <div id="change-message-control" :class="displayStyle.control">
                         <textarea class="form-control" id="changelogMessage"
                                   v-model="changeLogMessageValue"
                                   @input="handleChangeLogMessage"
@@ -14,9 +14,9 @@
         </div>
         <div id="changelog-type" class="form-group row">
             <label for="changelogType"
-                   :class="`col-sm-${changelogStyle.label.size} ${changelogStyle.label.justify}`"
+                   :class="displayStyle.label.toString()"
                    class="col-form-label">Changelog Type</label>
-            <div :class="`col-sm-${changelogStyle.control.size}`">
+            <div id="change-type-control" :class="displayStyle.control.toString()">
                 <select class="form-control"
                         id="changelogType"
                         v-model="changeLogTypeValue"
@@ -32,12 +32,11 @@
 
 <script lang="ts">
     import Vue from "vue";
-    import {ChangelogStyle} from "../../utils/types";
 
     interface Props {
         showChangelog: boolean
         changelogTypeOptions: string[]
-        changelogStyle: ChangelogStyle
+        changelogStyleReport: boolean
     }
 
     interface Data {
@@ -50,7 +49,11 @@
         handleChangeLogType: () => void
     }
 
-    export default Vue.extend<Data, Methods, unknown, Props>({
+    interface Computed {
+        displayStyle: object
+    }
+
+    export default Vue.extend<Data, Methods, Computed, Props>({
         name: "changeLog",
         data(): Data {
             return {
@@ -63,8 +66,21 @@
                 required: true,
                 type: Boolean
             },
-            changelogStyle: Object,
-            changelogTypeOptions: []
+            changelogStyleReport: {
+                required: false,
+                type: Boolean,
+                default: false
+            },
+            changelogTypeOptions: Array
+        },
+        computed: {
+            displayStyle() {
+                if (this.changelogStyleReport) {
+                    return {label: "col-sm-2 text-right", control: "col-sm-6"}
+                }
+
+                return {label: "col-sm-4 text-left", control: "col-sm-4"}
+            }
         },
         methods: {
             handleChangeLogType: function () {
@@ -75,7 +91,7 @@
             }
         },
         mounted() {
-            if(this.changelogTypeOptions) {
+            if (this.changelogTypeOptions) {
                 this.changeLogTypeValue = this.changelogTypeOptions[0]
                 this.$emit("changelogType", this.changeLogTypeValue)
             }

--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -2,9 +2,9 @@
     <div>
         <div id="changelog-message" class="form-group row">
             <label for="changelogMessage"
-                   :class="displayStyle.label"
+                   :class="customStyle.label"
                    class="col-form-label">Changelog Message</label>
-            <div id="change-message-control" :class="displayStyle.control">
+            <div id="change-message-control" :class="customStyle.control">
                         <textarea class="form-control" id="changelogMessage"
                                   v-model="changeLogMessageValue"
                                   @input="handleChangeLogMessage"
@@ -14,9 +14,9 @@
         </div>
         <div id="changelog-type" class="form-group row">
             <label for="changelogType"
-                   :class="displayStyle.label.toString()"
+                   :class="customStyle.label"
                    class="col-form-label">Changelog Type</label>
-            <div id="change-type-control" :class="displayStyle.control.toString()">
+            <div id="change-type-control" :class="customStyle.control">
                 <select class="form-control"
                         id="changelogType"
                         v-model="changeLogTypeValue"
@@ -32,10 +32,11 @@
 
 <script lang="ts">
     import Vue from "vue";
+    import {ChangelogStyle} from "../../utils/types";
 
     interface Props {
         changelogTypeOptions: string[]
-        changelogStyleReport: boolean
+        customStyle: ChangelogStyle
     }
 
     interface Data {
@@ -48,11 +49,7 @@
         handleChangeLogType: () => void
     }
 
-    interface Computed {
-        displayStyle: object
-    }
-
-    export default Vue.extend<Data, Methods, Computed, Props>({
+    export default Vue.extend<Data, Methods, unknown, Props>({
         name: "changeLog",
         data(): Data {
             return {
@@ -61,21 +58,8 @@
             }
         },
         props: {
-            changelogStyleReport: {
-                required: false,
-                type: Boolean,
-                default: false
-            },
+            customStyle: {},
             changelogTypeOptions: Array
-        },
-        computed: {
-            displayStyle() {
-                if (this.changelogStyleReport) {
-                    return {label: "col-sm-2 text-right", control: "col-sm-6"}
-                }
-
-                return {label: "col-sm-4 text-left", control: "col-sm-4"}
-            }
         },
         methods: {
             handleChangeLogType: function () {

--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="showChangelog">
+    <div>
         <div id="changelog-message" class="form-group row">
             <label for="changelogMessage"
                    :class="displayStyle.label"
@@ -34,7 +34,6 @@
     import Vue from "vue";
 
     interface Props {
-        showChangelog: boolean
         changelogTypeOptions: string[]
         changelogStyleReport: boolean
     }
@@ -62,10 +61,6 @@
             }
         },
         props: {
-            showChangelog: {
-                required: true,
-                type: Boolean
-            },
             changelogStyleReport: {
                 required: false,
                 type: Boolean,

--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="showChangeMessage">
+    <div v-if="showChangelog">
         <div id="changelog-message" class="form-group row">
             <label for="changelogMessage"
                    :class="`col-sm-${changelogStyle.label.size} ${changelogStyle.label.justify}`"
@@ -21,7 +21,7 @@
                         id="changelogType"
                         v-model="changeLogTypeValue"
                         @change="handleChangeLogType">
-                    <option v-for="option in reportMetadata.changelog_types" :value="option">
+                    <option v-for="option in changelogTypeOptions" :value="option">
                         {{ option }}
                     </option>
                 </select>
@@ -32,11 +32,11 @@
 
 <script lang="ts">
     import Vue from "vue";
-    import {ChangelogStyle, ReportMetadata} from "../../utils/types";
+    import {ChangelogStyle} from "../../utils/types";
 
     interface Props {
-        showChangeMessage: boolean
-        reportMetadata: ReportMetadata[] | null
+        showChangelog: boolean
+        changelogTypeOptions: string[]
         changelogStyle: ChangelogStyle
     }
 
@@ -59,12 +59,12 @@
             }
         },
         props: {
-            showChangeMessage: {
+            showChangelog: {
                 required: true,
                 type: Boolean
             },
             changelogStyle: Object,
-            reportMetadata: null
+            changelogTypeOptions: []
         },
         methods: {
             handleChangeLogType: function () {

--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -1,8 +1,10 @@
 <template>
-    <div>
-        <div v-if="showChangeMessage" id="changelog-message" class="form-group row">
-            <label for="changelogMessage" class="col-sm-2 col-form-label text-right">Changelog Message</label>
-            <div class="col-sm-6">
+    <div v-if="showChangeMessage">
+        <div id="changelog-message" class="form-group row">
+            <label for="changelogMessage"
+                   :class="`col-sm-${changelogStyle.label.size} ${changelogStyle.label.justify}`"
+                   class="col-form-label">Changelog Message</label>
+            <div :class="`col-sm-${changelogStyle.control.size}`">
                         <textarea class="form-control" id="changelogMessage"
                                   v-model="changeLogMessageValue"
                                   @input="handleChangeLogMessage"
@@ -11,8 +13,10 @@
             </div>
         </div>
         <div id="changelog-type" class="form-group row">
-            <label for="changelogType" class="col-sm-2 col-form-label text-right">Changelog Type</label>
-            <div class="col-sm-6">
+            <label for="changelogType"
+                   :class="`col-sm-${changelogStyle.label.size} ${changelogStyle.label.justify}`"
+                   class="col-form-label">Changelog Type</label>
+            <div :class="`col-sm-${changelogStyle.control.size}`">
                 <select class="form-control"
                         id="changelogType"
                         v-model="changeLogTypeValue"
@@ -28,11 +32,12 @@
 
 <script lang="ts">
     import Vue from "vue";
-    import {ReportMetadata} from "../../utils/types";
+    import {ChangelogStyle, ReportMetadata} from "../../utils/types";
 
     interface Props {
         showChangeMessage: boolean
         reportMetadata: ReportMetadata[] | null
+        changelogStyle: ChangelogStyle
     }
 
     interface Data {
@@ -58,6 +63,7 @@
                 required: true,
                 type: Boolean
             },
+            changelogStyle: Object,
             reportMetadata: null
         },
         methods: {

--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -73,6 +73,12 @@
             handleChangeLogMessage: function () {
                 this.$emit("changelogMessage", this.changeLogMessageValue)
             }
+        },
+        mounted() {
+            if(this.changelogTypeOptions) {
+                this.changeLogTypeValue = this.changelogTypeOptions[0]
+                this.$emit("changelogType", this.changeLogTypeValue)
+            }
         }
     })
 </script>

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -55,6 +55,7 @@
             <div v-if="showChangelog">
             <change-log :show-change-message="showChangeMessage"
                         :report-metadata="metadata"
+                        :changelog-style="changelogStyle"
                         @changelogMessage="handleChangeLogMessageValue"
                         @changelogType="handleChangeLogTypeValue">
             </change-log>
@@ -114,7 +115,11 @@
                 disableRun: false,
                 parameterValues: [],
                 changeLogMessageValue: "",
-                changeLogTypeValue: ""
+                changeLogTypeValue: "",
+                changelogStyle: {
+                    label: {size: 2, justify: "text-right"},
+                    control: {size: 6}
+                }
             }
         },
         computed: {

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -280,9 +280,6 @@
             } else {
                 this.updateReports();
             }
-            if(this.metadata.changelog_types) {
-                this.changeLogTypeValue = this.metadata.changelog_types[0]
-            }
 
             if (this.metadata.instances_supported) {
                 const instances = this.metadata.instances;

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -53,8 +53,8 @@
                                 :params="parameterValues"></parameter-list>
             </div>
             <div v-if="showChangelog">
-            <change-log :show-change-message="showChangeMessage"
-                        :report-metadata="metadata"
+            <change-log :show-changelog="handleChangeLogType"
+                        :changelog-type-options="metadata.changelog_types"
                         :changelog-style="changelogStyle"
                         @changelogMessage="handleChangeLogMessageValue"
                         @changelogType="handleChangeLogTypeValue">
@@ -144,7 +144,7 @@
             showChangelog: function () {
                 return !!this.selectedReport
             },
-            showChangeMessage: function () {
+            handleChangeLogType: function () {
                 return this.metadata.changelog_types
             }
         },

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -52,25 +52,12 @@
                 <parameter-list id="params-component" @paramsChanged="getParameterValues"
                                 :params="parameterValues"></parameter-list>
             </div>
-            <div v-if="showChangelog">
-                <div v-if="showChangeMessage" id="changelog-message" class="form-group row">
-                    <label for="changelogMessage" class="col-sm-2 col-form-label text-right">Changelog Message</label>
-                    <div class="col-sm-6">
-                        <textarea class="form-control" id="changelogMessage" v-model="changeLogMessageValue"
-                                  rows="2"></textarea>
-                    </div>
-                </div>
-                <div id="changelog-type" class="form-group row">
-                    <label for="changelogType" class="col-sm-2 col-form-label text-right">Changelog Type</label>
-                    <div class="col-sm-6">
-                        <select class="form-control" id="changelogType" v-model="changeLogTypeValue">
-                            <option v-for="option in metadata.changelog_types" :value="option">
-                                {{ option }}
-                            </option>
-                        </select>
-                    </div>
-                </div>
-            </div>
+            <change-log :show-changelog="showChangelog"
+                        :show-change-message="showChangeMessage"
+                        :change-log-message-value="changeLogMessageValue"
+                        :change-log-type-value="changeLogTypeValue"
+                        :report-metadata="metadata">
+            </change-log>
             <div v-if="showRunButton" id="run-form-group" class="form-group row">
                 <div class="col-sm-2"></div>
                 <div class="col-sm-6">
@@ -94,6 +81,7 @@
     import ErrorInfo from "../errorInfo.vue";
     import Vue from "vue";
     import ReportList from "./reportList.vue";
+    import ChangeLog from "./changeLog.vue";
 
     export default Vue.extend({
         name: "runReport",
@@ -105,7 +93,8 @@
         components: {
             ErrorInfo,
             ReportList,
-            ParameterList
+            ParameterList,
+            ChangeLog
         },
         data: () => {
             return {

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -52,12 +52,13 @@
                 <parameter-list id="params-component" @paramsChanged="getParameterValues"
                                 :params="parameterValues"></parameter-list>
             </div>
-            <change-log :show-changelog="showChangelog"
-                        :show-change-message="showChangeMessage"
+            <div v-if="showChangelog">
+            <change-log :show-change-message="showChangeMessage"
                         :report-metadata="metadata"
                         @changelogMessage="handleChangeLogMessageValue"
                         @changelogType="handleChangeLogTypeValue">
             </change-log>
+            </div>
             <div v-if="showRunButton" id="run-form-group" class="form-group row">
                 <div class="col-sm-2"></div>
                 <div class="col-sm-6">

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -54,9 +54,9 @@
             </div>
             <change-log :show-changelog="showChangelog"
                         :show-change-message="showChangeMessage"
-                        :change-log-message-value="changeLogMessageValue"
-                        :change-log-type-value="changeLogTypeValue"
-                        :report-metadata="metadata">
+                        :report-metadata="metadata"
+                        @changelogMessage="handleChangeLogMessageValue"
+                        @changelogType="handleChangeLogTypeValue">
             </change-log>
             <div v-if="showRunButton" id="run-form-group" class="form-group row">
                 <div class="col-sm-2"></div>
@@ -136,13 +136,19 @@
                 return this.selectedReport && this.parameterValues.length
             },
             showChangelog: function () {
-                return this.selectedReport
+                return !!this.selectedReport
             },
             showChangeMessage: function () {
                 return this.metadata.changelog_types
             }
         },
         methods: {
+            handleChangeLogTypeValue: function (type: string) {
+                this.changeLogTypeValue = type
+            },
+            handleChangeLogMessageValue: function (message: string) {
+                this.changeLogMessageValue = message
+            },
             refreshGit: function () {
                 this.gitRefreshing = true
                 api.get('/git/fetch/')

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -34,7 +34,7 @@
                 <parameter-list id="params-component" @paramsChanged="getParameterValues"
                                 :params="parameterValues"></parameter-list>
             </div>
-            <change-log :show-changelog="showChangelog"
+            <change-log v-if="showChangelog"
                         :changelog-type-options="metadata.changelog_types"
                         :changelog-style-report="true"
                         @changelogMessage="handleChangeLogMessageValue"
@@ -203,9 +203,6 @@
             }
         },
         mounted() {
-            if (this.metadata.changelog_types) {
-                this.changeLogTypeValue = this.metadata.changelog_types[0]
-            }
             if (this.metadata.instances_supported) {
                 const instances = this.metadata.instances;
                 for (const key in instances) {

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -36,7 +36,7 @@
             </div>
             <change-log v-if="showChangelog"
                         :changelog-type-options="metadata.changelog_types"
-                        :changelog-style-report="true"
+                        :custom-style="changelogStyle"
                         @changelogMessage="handleChangeLogMessageValue"
                         @changelogType="handleChangeLogTypeValue">
             </change-log>
@@ -94,7 +94,8 @@
                 disableRun: false,
                 parameterValues: [],
                 changeLogMessageValue: "",
-                changeLogTypeValue: ""
+                changeLogTypeValue: "",
+                changelogStyle: {label: "col-sm-2 text-right", control: "col-sm-6"}
             }
         },
         computed: {

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -34,14 +34,12 @@
                 <parameter-list id="params-component" @paramsChanged="getParameterValues"
                                 :params="parameterValues"></parameter-list>
             </div>
-            <div v-if="showChangelog">
-            <change-log :show-changelog="handleShowChangeLog"
+            <change-log :show-changelog="showChangelog"
                         :changelog-type-options="metadata.changelog_types"
-                        :changelog-style="changelogStyle"
+                        :changelog-style-report="true"
                         @changelogMessage="handleChangeLogMessageValue"
                         @changelogType="handleChangeLogTypeValue">
             </change-log>
-            </div>
             <div v-if="showRunButton" id="run-form-group" class="form-group row">
                 <div class="col-sm-2"></div>
                 <div class="col-sm-6">
@@ -96,11 +94,7 @@
                 disableRun: false,
                 parameterValues: [],
                 changeLogMessageValue: "",
-                changeLogTypeValue: "",
-                changelogStyle: {
-                    label: {size: 2, justify: "text-right"},
-                    control: {size: 6}
-                }
+                changeLogTypeValue: ""
             }
         },
         computed: {
@@ -117,10 +111,7 @@
                 return this.selectedReport && this.parameterValues.length
             },
             showChangelog: function () {
-                return !!this.selectedReport
-            },
-            handleShowChangeLog: function () {
-                return this.metadata.changelog_types
+                return !!this.selectedReport && this.metadata.changelog_types
             }
         },
         methods: {

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -53,7 +53,7 @@
                                 :params="parameterValues"></parameter-list>
             </div>
             <div v-if="showChangelog">
-            <change-log :show-changelog="handleChangeLogType"
+            <change-log :show-changelog="handleShowChangeLog"
                         :changelog-type-options="metadata.changelog_types"
                         :changelog-style="changelogStyle"
                         @changelogMessage="handleChangeLogMessageValue"
@@ -144,7 +144,7 @@
             showChangelog: function () {
                 return !!this.selectedReport
             },
-            handleChangeLogType: function () {
+            handleShowChangeLog: function () {
                 return this.metadata.changelog_types
             }
         },

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -247,15 +247,16 @@
                 this.changedBranch();
             } else {
                 this.updateReports();
-            if(this.metadata.changelog_types) {
-                this.changeLogTypeValue = this.metadata.changelog_types[0]
-            }
+                if (this.metadata.changelog_types) {
+                    this.changeLogTypeValue = this.metadata.changelog_types[0]
+                }
 
-            if (this.metadata.instances_supported) {
-                const instances = this.metadata.instances;
-                for (const key in instances) {
-                    if (instances[key].length > 0) {
-                        this.$set(this.selectedInstances, key, instances[key][0]);
+                if (this.metadata.instances_supported) {
+                    const instances = this.metadata.instances;
+                    for (const key in instances) {
+                        if (instances[key].length > 0) {
+                            this.$set(this.selectedInstances, key, instances[key][0]);
+                        }
                     }
                 }
             }

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -130,35 +130,6 @@
             handleChangeLogMessageValue: function (message: string) {
                 this.changeLogMessageValue = message
             },
-            refreshGit: function () {
-                this.gitRefreshing = true
-                api.get('/git/fetch/')
-                    .then(({data}) => {
-                        this.gitRefreshing = false
-                        this.gitBranches = data.data.map(branch => branch.name)
-                    })
-                    .catch((error) => {
-                        this.gitRefreshing = false
-                        this.error = error;
-                        this.defaultMessage = "An error occurred refreshing Git";
-                    });
-            },
-            changedBranch() {
-                api.get(`/git/branch/${this.selectedBranch}/commits/`)
-                    .then(({data}) => {
-                        this.gitCommits = data.data;
-                        if (this.gitCommits.length) {
-                            this.selectedCommitId = this.gitCommits[0].id;
-                            this.changedCommit();
-                        }
-                        this.error = "";
-                        this.defaultMessage = "";
-                    })
-                    .catch((error) => {
-                        this.error = error;
-                        this.defaultMessage = "An error occurred fetching Git commits";
-                    });
-            },
             getParameterValues(values, valid) {
                 if (valid) {
                     this.parameterValues = [...values]
@@ -241,22 +212,14 @@
             }
         },
         mounted() {
-            if (this.metadata.git_supported) {
-                this.gitBranches = [...this.initialGitBranches]
-                this.selectedBranch = this.gitBranches.length ? this.gitBranches[0] : [];
-                this.changedBranch();
-            } else {
-                this.updateReports();
-                if (this.metadata.changelog_types) {
-                    this.changeLogTypeValue = this.metadata.changelog_types[0]
-                }
-
-                if (this.metadata.instances_supported) {
-                    const instances = this.metadata.instances;
-                    for (const key in instances) {
-                        if (instances[key].length > 0) {
-                            this.$set(this.selectedInstances, key, instances[key][0]);
-                        }
+            if (this.metadata.changelog_types) {
+                this.changeLogTypeValue = this.metadata.changelog_types[0]
+            }
+            if (this.metadata.instances_supported) {
+                const instances = this.metadata.instances;
+                for (const key in instances) {
+                    if (instances[key].length > 0) {
+                        this.$set(this.selectedInstances, key, instances[key][0]);
                     }
                 }
             }

--- a/src/app/static/src/js/utils/types.ts
+++ b/src/app/static/src/js/utils/types.ts
@@ -67,3 +67,8 @@ export interface ReportDependencies {
     direction: "upstream" | "downstream",
     dependency_tree: ReportDependency
 }
+
+export interface ChangelogStyle {
+    label: string,
+    control: string
+}

--- a/src/app/static/src/js/utils/types.ts
+++ b/src/app/static/src/js/utils/types.ts
@@ -67,8 +67,3 @@ export interface ReportDependencies {
     direction: "upstream" | "downstream",
     dependency_tree: ReportDependency
 }
-
-export interface ChangelogStyle {
-    label: { size: number, justify: string },
-    control: { size: number }
-}

--- a/src/app/static/src/js/utils/types.ts
+++ b/src/app/static/src/js/utils/types.ts
@@ -51,12 +51,9 @@ export interface ReportDependencies {
     dependency_tree: ReportDependency
 }
 
-export interface RunMetadata {
-    git_branches: [],
-    metadata: {
-        changelog_types: [] | null,
-        git_supported: boolean,
-        instances: {} | null,
-        instances_supported: boolean
-    }
+export interface ReportMetadata {
+    changelog_types: [] | null,
+    git_supported: boolean,
+    instances: {} | null,
+    instances_supported: boolean
 }

--- a/src/app/static/src/js/utils/types.ts
+++ b/src/app/static/src/js/utils/types.ts
@@ -51,13 +51,6 @@ export interface ReportDependencies {
     dependency_tree: ReportDependency
 }
 
-export interface ReportMetadata {
-    changelog_types: [] | null,
-    git_supported: boolean,
-    instances: {} | null,
-    instances_supported: boolean
-}
-
 export interface ChangelogStyle {
     label: { size: number, justify: string },
     control: { size: number }

--- a/src/app/static/src/js/utils/types.ts
+++ b/src/app/static/src/js/utils/types.ts
@@ -50,3 +50,13 @@ export interface ReportDependencies {
     direction: "upstream" | "downstream",
     dependency_tree: ReportDependency
 }
+
+export interface RunMetadata {
+    git_branches: [],
+    metadata: {
+        changelog_types: [] | null,
+        git_supported: boolean,
+        instances: {} | null,
+        instances_supported: boolean
+    }
+}

--- a/src/app/static/src/js/utils/types.ts
+++ b/src/app/static/src/js/utils/types.ts
@@ -57,3 +57,8 @@ export interface ReportMetadata {
     instances: {} | null,
     instances_supported: boolean
 }
+
+export interface ChangelogStyle {
+    label: { size: number, justify: string },
+    control: { size: number }
+}

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -1,18 +1,14 @@
 import {mount} from "@vue/test-utils";
 import ChangeLog from "../../../js/components/runReport/changeLog.vue";
+import changeLog from "../../../js/components/runReport/changeLog.vue";
 
 describe(`changeLog`, () => {
     const changelogTypeOptions = ["internal", "public"]
 
-    const changelogStyle = {
-        label: {size: 2, justify: "text-right"},
-        control: {size: 6}
-    }
     const getWrapper = () => {
         return mount(ChangeLog,
             {
                 propsData: {
-                    changelogStyle: changelogStyle,
                     showChangelog: true,
                     changelogTypeOptions: changelogTypeOptions
                 }
@@ -27,7 +23,7 @@ describe(`changeLog`, () => {
         expect(wrapper.vm.$props).toEqual(
             {
                 changelogTypeOptions,
-                changelogStyle,
+                "changelogStyleReport": false,
                 "showChangelog": true
             })
     })
@@ -65,5 +61,20 @@ describe(`changeLog`, () => {
         expect(wrapper.vm.$data.changeLogTypeValue).toBe("public")
         const typeValue = wrapper.find("#changelogType").element as HTMLSelectElement
         expect(typeValue.value).toBe("public")
+    })
+
+    it(`renders changelog col styles correctly if changelog-style-report prop is not set`, () => {
+        const wrapper = getWrapper();
+
+        const label = ["col-form-label", "col-sm-4", "text-left"]
+        const control = ["col-sm-4"]
+
+        const changelogMessage = wrapper.find(changeLog).find("#changelog-message")
+        const changelogType= wrapper.find(changeLog).find("#changelog-type")
+
+        expect(changelogMessage.find("label").classes()).toEqual(label)
+        expect(changelogMessage.find("#change-message-control").classes()).toEqual(control)
+        expect(changelogType.find("label").classes()).toEqual(label)
+        expect(changelogType.find("#change-type-control").classes()).toEqual(control)
     })
 })

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -2,18 +2,7 @@ import {mount} from "@vue/test-utils";
 import ChangeLog from "../../../js/components/runReport/changeLog.vue";
 
 describe(`changeLog`, () => {
-    const changelogTypes = ["internal", "public"]
-    const source = ["prod", "uat"]
-
-    const reportMetadata = {
-            changelog_types: changelogTypes,
-            git_supported: false,
-            instances_supported: true,
-            instances: {
-                source: source,
-                annex: ["one"]
-            }
-    }
+    const changelogTypeOptions = ["internal", "public"]
 
     const changelogStyle = {
         label: {size: 2, justify: "text-right"},
@@ -24,8 +13,8 @@ describe(`changeLog`, () => {
             {
                 propsData: {
                     changelogStyle: changelogStyle,
-                    showChangeMessage: true,
-                    reportMetadata: reportMetadata
+                    showChangelog: true,
+                    changelogTypeOptions: changelogTypeOptions
                 }
             })
     }
@@ -37,15 +26,15 @@ describe(`changeLog`, () => {
         expect(wrapper.vm.$data).toEqual({"changeLogMessageValue": "", "changeLogTypeValue": ""})
         expect(wrapper.vm.$props).toEqual(
             {
-                reportMetadata,
+                changelogTypeOptions,
                 changelogStyle,
-                "showChangeMessage": true
+                "showChangelog": true
             })
     })
 
     it(`does not render component if showChangeMessage is false`, async() => {
         const wrapper = getWrapper();
-        await wrapper.setData({showChangeMessage: false})
+        await wrapper.setData({showChangelog: false})
         expect(wrapper.find("#changelog-message").exists()).toBeFalsy()
         expect(wrapper.find("#changelog-type").exists()).toBeFalsy()
     })
@@ -70,7 +59,7 @@ describe(`changeLog`, () => {
         options.at(1).setSelected()
 
         expect(wrapper.emitted().changelogType.length).toBe(1)
-        expect(wrapper.emitted().changelogType[0][0]).toEqual(changelogTypes[1])
+        expect(wrapper.emitted().changelogType[0][0]).toEqual(changelogTypeOptions[1])
 
         expect(wrapper.vm.$data.changeLogTypeValue).toBe("public")
         const typeValue = wrapper.find("#changelogType").element as HTMLSelectElement

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -23,7 +23,7 @@ describe(`changeLog`, () => {
         const wrapper = getWrapper();
         expect(wrapper.find("#changelog-message").exists()).toBeTruthy()
         expect(wrapper.find("#changelog-type").exists()).toBeTruthy()
-        expect(wrapper.vm.$data).toEqual({"changeLogMessageValue": "", "changeLogTypeValue": ""})
+        expect(wrapper.vm.$data).toEqual({"changeLogMessageValue": "", "changeLogTypeValue": "internal"})
         expect(wrapper.vm.$props).toEqual(
             {
                 changelogTypeOptions,
@@ -58,8 +58,9 @@ describe(`changeLog`, () => {
             .find("select").findAll("option")
         options.at(1).setSelected()
 
-        expect(wrapper.emitted().changelogType.length).toBe(1)
-        expect(wrapper.emitted().changelogType[0][0]).toEqual(changelogTypeOptions[1])
+        expect(wrapper.emitted().changelogType.length).toBe(2)
+        expect(wrapper.emitted().changelogType[0][0]).toEqual(changelogTypeOptions[0]) //on mount initial selection
+        expect(wrapper.emitted().changelogType[1][0]).toEqual(changelogTypeOptions[1])  // selected value
 
         expect(wrapper.vm.$data.changeLogTypeValue).toBe("public")
         const typeValue = wrapper.find("#changelogType").element as HTMLSelectElement

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -18,7 +18,6 @@ describe(`changeLog`, () => {
         return mount(ChangeLog,
             {
                 propsData: {
-                    showChangelog: true,
                     showChangeMessage: true,
                     reportMetadata: reportMetadata
                 }
@@ -33,16 +32,15 @@ describe(`changeLog`, () => {
         expect(wrapper.vm.$props).toEqual(
             {
                 reportMetadata,
-                "showChangeMessage": true,
-                "showChangelog": true
+                "showChangeMessage": true
             })
     })
 
-    it(`does not render component if showChangelog is false`, async() => {
+    it(`does not render component if showChangeMessage is false`, async() => {
         const wrapper = getWrapper();
-        await wrapper.setData({showChangelog: false})
+        await wrapper.setData({showChangeMessage: false})
         expect(wrapper.find("#changelog-message").exists()).toBeFalsy()
-        expect(wrapper.find("#changelog-type").exists()).toBeFalsy()
+        expect(wrapper.find("#changelog-type").exists()).toBeTruthy()
     })
 
     it(`can set and get changelog message`, () => {

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -9,7 +9,8 @@ describe(`changeLog`, () => {
         return mount(ChangeLog,
             {
                 propsData: {
-                    changelogTypeOptions: changelogTypeOptions
+                    changelogTypeOptions: changelogTypeOptions,
+                    customStyle: {label: "col-sm-2 text-right", control: "col-sm-6"}
                 }
             })
     }
@@ -22,7 +23,7 @@ describe(`changeLog`, () => {
         expect(wrapper.vm.$props).toEqual(
             {
                 changelogTypeOptions,
-                "changelogStyleReport": false
+                customStyle: {label: "col-sm-2 text-right", control: "col-sm-6"}
             })
     })
 
@@ -60,11 +61,11 @@ describe(`changeLog`, () => {
         expect(typeValue.value).toBe("public")
     })
 
-    it(`renders changelog col styles correctly if changelog-style-report prop is not set`, () => {
+    it(`renders changelog col styles correctly if custom-style prop is set`, () => {
         const wrapper = getWrapper();
 
-        const label = ["col-form-label", "col-sm-4", "text-left"]
-        const control = ["col-sm-4"]
+        const label = ["col-form-label", "col-sm-2", "text-right"]
+        const control = ["col-sm-6"]
 
         const changelogMessage = wrapper.find(changeLog).find("#changelog-message")
         const changelogType= wrapper.find(changeLog).find("#changelog-type")

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -14,10 +14,16 @@ describe(`changeLog`, () => {
                 annex: ["one"]
             }
     }
+
+    const changelogStyle = {
+        label: {size: 2, justify: "text-right"},
+        control: {size: 6}
+    }
     const getWrapper = () => {
         return mount(ChangeLog,
             {
                 propsData: {
+                    changelogStyle: changelogStyle,
                     showChangeMessage: true,
                     reportMetadata: reportMetadata
                 }
@@ -32,6 +38,7 @@ describe(`changeLog`, () => {
         expect(wrapper.vm.$props).toEqual(
             {
                 reportMetadata,
+                changelogStyle,
                 "showChangeMessage": true
             })
     })
@@ -40,7 +47,7 @@ describe(`changeLog`, () => {
         const wrapper = getWrapper();
         await wrapper.setData({showChangeMessage: false})
         expect(wrapper.find("#changelog-message").exists()).toBeFalsy()
-        expect(wrapper.find("#changelog-type").exists()).toBeTruthy()
+        expect(wrapper.find("#changelog-type").exists()).toBeFalsy()
     })
 
     it(`can set and get changelog message`, () => {

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -1,0 +1,74 @@
+import {mount} from "@vue/test-utils";
+import ChangeLog from "../../../js/components/runReport/changeLog.vue";
+
+describe(`changeLog`, () => {
+    const changelogTypes = ["internal", "public"]
+    const source = ["prod", "uat"]
+
+    const reportMetadata = {
+            changelog_types: changelogTypes,
+            git_supported: false,
+            instances_supported: true,
+            instances: {
+                source: source,
+                annex: ["one"]
+            }
+    }
+    const getWrapper = () => {
+        return mount(ChangeLog,
+            {
+                propsData: {
+                    showChangelog: true,
+                    showChangeMessage: true,
+                    reportMetadata: reportMetadata
+                }
+            })
+    }
+
+    it(`renders component as expected`, () => {
+        const wrapper = getWrapper();
+        expect(wrapper.find("#changelog-message").exists()).toBeTruthy()
+        expect(wrapper.find("#changelog-type").exists()).toBeTruthy()
+        expect(wrapper.vm.$data).toEqual({"changeLogMessageValue": "", "changeLogTypeValue": ""})
+        expect(wrapper.vm.$props).toEqual(
+            {
+                reportMetadata,
+                "showChangeMessage": true,
+                "showChangelog": true
+            })
+    })
+
+    it(`does not render component if showChangelog is false`, async() => {
+        const wrapper = getWrapper();
+        await wrapper.setData({showChangelog: false})
+        expect(wrapper.find("#changelog-message").exists()).toBeFalsy()
+        expect(wrapper.find("#changelog-type").exists()).toBeFalsy()
+    })
+
+    it(`can set and get changelog message`, () => {
+        const wrapper = getWrapper();
+        const message = wrapper.find("#changelogMessage")
+        message.setValue("new message")
+        expect(wrapper.vm.$data.changeLogMessageValue).toBe("new message")
+
+        expect(wrapper.emitted().changelogMessage.length).toBe(1)
+        expect(wrapper.emitted().changelogMessage[0][0]).toEqual("new message")
+
+        const messageValue = message.element as HTMLTextAreaElement
+        expect(messageValue.value).toBe("new message")
+    })
+
+    it(`can select and get changelog type`, () => {
+        const wrapper = getWrapper();
+        const options = wrapper.find("#changelogType")
+            .find("select").findAll("option")
+        options.at(1).setSelected()
+
+        expect(wrapper.emitted().changelogType.length).toBe(1)
+        expect(wrapper.emitted().changelogType[0][0]).toEqual(changelogTypes[1])
+
+        expect(wrapper.vm.$data.changeLogTypeValue).toBe("public")
+        const typeValue = wrapper.find("#changelogType").element as HTMLSelectElement
+        expect(typeValue.value).toBe("public")
+    })
+})

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -9,7 +9,6 @@ describe(`changeLog`, () => {
         return mount(ChangeLog,
             {
                 propsData: {
-                    showChangelog: true,
                     changelogTypeOptions: changelogTypeOptions
                 }
             })
@@ -23,16 +22,14 @@ describe(`changeLog`, () => {
         expect(wrapper.vm.$props).toEqual(
             {
                 changelogTypeOptions,
-                "changelogStyleReport": false,
-                "showChangelog": true
+                "changelogStyleReport": false
             })
     })
 
-    it(`does not render component if showChangeMessage is false`, async() => {
+    it(`emits changelogType first index when component gets mounted`, () => {
         const wrapper = getWrapper();
-        await wrapper.setData({showChangelog: false})
-        expect(wrapper.find("#changelog-message").exists()).toBeFalsy()
-        expect(wrapper.find("#changelog-type").exists()).toBeFalsy()
+        expect(wrapper.emitted().changelogType.length).toBe(1)
+        expect(wrapper.emitted().changelogType[0][0]).toBe("internal")
     })
 
     it(`can set and get changelog message`, () => {

--- a/src/app/static/src/tests/components/runReport/runReport.test.ts
+++ b/src/app/static/src/tests/components/runReport/runReport.test.ts
@@ -5,6 +5,7 @@ import ReportList from "../../../js/components/runReport/reportList.vue";
 import ErrorInfo from "../../../js/components/errorInfo.vue";
 import {mockAxios} from "../../mockAxios";
 import ParameterList from "../../../js/components/runReport/parameterList.vue";
+import changeLog from "../../../js/components/runReport/changeLog.vue";
 
 describe("runReport", () => {
     beforeEach(() => {
@@ -800,7 +801,6 @@ describe("runReport", () => {
             }
         }
         });
-
         const options = wrapper.find("#changelogType")
             .find("select").findAll("option")
         options.at(1).setSelected()

--- a/src/app/static/src/tests/components/runReport/runReport.test.ts
+++ b/src/app/static/src/tests/components/runReport/runReport.test.ts
@@ -5,7 +5,6 @@ import ReportList from "../../../js/components/runReport/reportList.vue";
 import ErrorInfo from "../../../js/components/errorInfo.vue";
 import {mockAxios} from "../../mockAxios";
 import ParameterList from "../../../js/components/runReport/parameterList.vue";
-import changeLog from "../../../js/components/runReport/changeLog.vue";
 
 describe("runReport", () => {
     beforeEach(() => {
@@ -783,7 +782,7 @@ describe("runReport", () => {
         expect(wrapper.find("#changelog-type").exists()).toBe(false);
     });
 
-    it("it can accepts changelog  and type log message values", () => {
+    it("it can accepts changelog  and type log message values", async () => {
         const changelogTypes =  ["internal", "public"]
         const wrapper = mount(RunReport, {
             propsData: {
@@ -805,7 +804,6 @@ describe("runReport", () => {
             .find("select").findAll("option")
         options.at(1).setSelected()
         expect(wrapper.vm.$data.changeLogTypeValue).toBe("public")
-
         wrapper.find("#changelogMessage").setValue("New message")
         expect(wrapper.vm.$data.changeLogMessageValue).toBe("New message")
     });

--- a/src/app/static/src/tests/components/runReport/runReport.test.ts
+++ b/src/app/static/src/tests/components/runReport/runReport.test.ts
@@ -782,8 +782,8 @@ describe("runReport", () => {
         expect(wrapper.find("#changelog-type").exists()).toBe(false);
     });
 
-    it("it can accepts changelog  and type log message values", async () => {
-        const changelogTypes =  ["internal", "public"]
+    it("it can accepts changelog type and log message values", () => {
+        const changelogTypes = ["internal", "public"]
         const wrapper = mount(RunReport, {
             propsData: {
                 metadata: {
@@ -793,16 +793,18 @@ describe("runReport", () => {
                 initialGitBranches
             },
             data() {
-            return {
-                selectedReport: "report",
-                changeLogMessageValue: "Text area message",
-                changeLogTypeValue: "selectedType"
+                return {
+                    selectedReport: "report",
+                    changeLogMessageValue: "Text area message",
+                    changeLogTypeValue: "selectedType"
+                }
             }
-        }
         });
+
         const options = wrapper.find("#changelogType")
             .find("select").findAll("option")
         options.at(1).setSelected()
+
         expect(wrapper.vm.$data.changeLogTypeValue).toBe("public")
         wrapper.find("#changelogMessage").setValue("New message")
         expect(wrapper.vm.$data.changeLogMessageValue).toBe("New message")

--- a/src/app/static/src/tests/components/runReport/runReport.test.ts
+++ b/src/app/static/src/tests/components/runReport/runReport.test.ts
@@ -782,8 +782,8 @@ describe("runReport", () => {
         expect(wrapper.find("#changelog-type").exists()).toBe(false);
     });
 
-    it("it can accepts changelog type and log message values", () => {
-        const changelogTypes = ["internal", "public"]
+    it("it can accepts changelog  and type log message values", () => {
+        const changelogTypes =  ["internal", "public"]
         const wrapper = mount(RunReport, {
             propsData: {
                 metadata: {
@@ -793,19 +793,19 @@ describe("runReport", () => {
                 initialGitBranches
             },
             data() {
-                return {
-                    selectedReport: "report",
-                    changeLogMessageValue: "Text area message",
-                    changeLogTypeValue: "selectedType"
-                }
+            return {
+                selectedReport: "report",
+                changeLogMessageValue: "Text area message",
+                changeLogTypeValue: "selectedType"
             }
+        }
         });
 
         const options = wrapper.find("#changelogType")
             .find("select").findAll("option")
         options.at(1).setSelected()
-
         expect(wrapper.vm.$data.changeLogTypeValue).toBe("public")
+
         wrapper.find("#changelogMessage").setValue("New message")
         expect(wrapper.vm.$data.changeLogMessageValue).toBe("New message")
     });

--- a/src/app/static/src/tests/components/runReport/runReport.test.ts
+++ b/src/app/static/src/tests/components/runReport/runReport.test.ts
@@ -3,9 +3,9 @@ import {mount, shallowMount} from "@vue/test-utils";
 import RunReport from "../../../js/components/runReport/runReport.vue";
 import ReportList from "../../../js/components/runReport/reportList.vue";
 import GitUpdateReports from "../../../js/components/runReport/gitUpdateReports.vue";
-import ErrorInfo from "../../../js/components/errorInfo.vue";
 import {mockAxios} from "../../mockAxios";
 import ParameterList from "../../../js/components/runReport/parameterList.vue";
+import changeLog from "../../../js/components/runReport/changeLog.vue";
 
 describe("runReport", () => {
     const mockParams = [
@@ -583,26 +583,6 @@ describe("runReport", () => {
         expect(wrapper.find("#changelog-type").exists()).toBe(false);
     });
 
-    it("it does not render changelog message and type if changeLogType is empty", () => {
-        const changelogTypes =  []
-        const wrapper = mount(RunReport, {
-            propsData: {
-                metadata: {
-                    git_supported: true,
-                    changelog_types: changelogTypes,
-                },
-                data() {
-                    return {
-                        selectedReport: "report"
-                    }
-                },
-                initialGitBranches
-            }
-        });
-        expect(wrapper.find("#changelog-message").exists()).toBe(false);
-        expect(wrapper.find("#changelog-type").exists()).toBe(false);
-    });
-
     it("it can accepts changelog  and type log message values", () => {
         const changelogTypes =  ["internal", "public"]
         const wrapper = mount(RunReport, {
@@ -622,6 +602,9 @@ describe("runReport", () => {
         }
         });
 
+        const label = ["col-form-label", "col-sm-2", "text-right"]
+        const control = ["col-sm-6"]
+
         const options = wrapper.find("#changelogType")
             .find("select").findAll("option")
         options.at(1).setSelected()
@@ -629,6 +612,14 @@ describe("runReport", () => {
 
         wrapper.find("#changelogMessage").setValue("New message")
         expect(wrapper.vm.$data.changeLogMessageValue).toBe("New message")
+
+        const changelogMessage = wrapper.find(changeLog).find("#changelog-message")
+        const changelogType= wrapper.find(changeLog).find("#changelog-type")
+
+        expect(changelogMessage.find("label").classes()).toEqual(label)
+        expect(changelogMessage.find("#change-message-control").classes()).toEqual(control)
+        expect(changelogType.find("label").classes()).toEqual(label)
+        expect(changelogType.find("#change-type-control").classes()).toEqual(control)
     });
 
     it("it does not disable runButton or display error msg when parameters pass validation", async () => {


### PR DESCRIPTION
This PR separates changeLog component from runReport component. This was necessary to have a clean implementation for mrc-2311. Components implementation and tests are self-explanatory and should be easy to review.

Please ignore the mrc-name, I have separated changeling for reusability.