### PR TITLE
mrc-2486 HTML encode requested url in Github login template

### DIFF
--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     compile "com.opencsv:opencsv:3.9"
 
     compile "org.apache.commons:commons-lang3:3.12.0"
+    compile "org.apache.commons:commons-text:1.9"
+
     compile "org.postgresql:postgresql:9.4.1212.jre7"
     compile "org.jooq:jooq:3.9.1"
     compile "org.jooq:jooq-meta:3.9.1"

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/SecurityController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/SecurityController.kt
@@ -3,6 +3,7 @@ package org.vaccineimpact.orderlyweb.controllers.web
 import org.vaccineimpact.orderlyweb.ActionContext
 import org.vaccineimpact.orderlyweb.controllers.Controller
 import org.vaccineimpact.orderlyweb.viewmodels.WebloginViewModel
+import org.apache.commons.text.StringEscapeUtils.escapeHtml4
 
 class SecurityController(actionContext: ActionContext) : Controller(actionContext)
 {
@@ -12,7 +13,7 @@ class SecurityController(actionContext: ActionContext) : Controller(actionContex
         //This action handles displaying the 'landing page' with links to the external auth providers e.g. GitHub
         //This is the redirect location for the OrderlyWebIndirectClient, which secures the WebEndpoints of the app
         val requestedUrl = context.queryParams("requestedUrl")
-        return WebloginViewModel(context, requestedUrl?:"/")
+        return WebloginViewModel(context, escapeHtml4(requestedUrl?:"/"))
     }
 
     fun webloginExternal()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/SecurityControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/SecurityControllerTests.kt
@@ -32,6 +32,19 @@ class SecurityControllerTests : ControllerTest()
     }
 
     @Test
+    fun `HTML encodes requested URL for view model`()
+    {
+        val mockContext = mock<ActionContext> {
+            on { this.queryParams("requestedUrl") } doReturn "<testUrl>"
+        }
+
+        val sut = SecurityController(mockContext)
+
+        val result = sut.weblogin()
+        Assertions.assertThat(result.requestedUrl).isEqualTo("&lt;testUrl&gt;")
+    }
+
+    @Test
     fun `defaults to homepage as requestedUrl when no url is explicitly requested`()
     {
         val sut = SecurityController(mock())

--- a/src/config/detekt/baseline-main.yml
+++ b/src/config/detekt/baseline-main.yml
@@ -10,12 +10,12 @@
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.Helpers.kt:92</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.SparkWrapper.kt:7</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.DocumentController.kt:98</ID>
-    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:12</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:13</ID>
-    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:20</ID>
+    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:14</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:21</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:22</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:23</ID>
+    <ID>CommentSpacing:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:24</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.db.TokenStore.kt:5</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.db.repositories.AuthorizationRepository.kt:244</ID>
     <ID>CommentSpacing:org.vaccineimpact.orderlyweb.db.repositories.ReportRepository.kt:140</ID>
@@ -374,7 +374,7 @@
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.api.ResourceController.kt:52</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.api.VersionController.kt:101</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.web.AdminController.kt:20</ID>
-    <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:27</ID>
+    <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:28</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.Orderly.kt:179</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.SQLiteTokenStore.kt:44</ID>
     <ID>NoBlankLineBeforeRbrace:org.vaccineimpact.orderlyweb.db.repositories.ArtefactRepository.kt:20</ID>
@@ -901,7 +901,7 @@
     <ID>SpacingAroundColon:org.vaccineimpact.orderlyweb.viewmodels.PublishReportsViewModel.kt:9</ID>
     <ID>SpacingAroundComma:org.vaccineimpact.orderlyweb.security.authentication.GithubOAuthAuthenticator.kt:15</ID>
     <ID>SpacingAroundOperators:org.vaccineimpact.orderlyweb.APIEndpoint.kt:41</ID>
-    <ID>SpacingAroundOperators:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:15</ID>
+    <ID>SpacingAroundOperators:org.vaccineimpact.orderlyweb.controllers.web.SecurityController.kt:16</ID>
     <ID>SpacingAroundOperators:org.vaccineimpact.orderlyweb.security.providers.GithubApiClientAuthHelper.kt:99</ID>
     <ID>StringTemplate:org.vaccineimpact.orderlyweb.controllers.web.GitController.kt:19</ID>
     <ID>StringTemplate:org.vaccineimpact.orderlyweb.viewmodels.ReportFileViewModelBuilder.kt:14</ID>

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubWebTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubWebTests.kt
@@ -72,4 +72,12 @@ class GithubWebTests : SeleniumTest()
         driver.get(RequestHelper.webBaseUrl + "/reports/testreport/20170103-143015-1234abcd/")
         assertThat(driver.findElement(By.cssSelector("h1")).text).isEqualTo("Page not found")
     }
+
+    @Test
+    fun `requestedUrl in login query string is not interpreted as HTML`()
+    {
+        startApp("auth.provider=github")
+        driver.get("http://localhost:${AppConfig()["app.port"]}/weblogin?requestedUrl=<<<<\"ksrcdg%20>>>545454")
+        assertThat(driver.findElement(By.className("btn-xl")).text).isEqualTo("Log in with\nGitHub")
+    }
 }


### PR DESCRIPTION
Fixes bug where if you request a url like `weblogin?requestedUrl=<<<<"ksrcdg%20>>>545454` the requested url was interpreted as html and displayed in the page. 

This actually somewhat concerning as I thought that Freemarker templates did HTML encoding for us, but perhaps not in attributes? We should investigate this.. But this should fix this particular issue!
