### PR TITLE
mrc-2511_types Refactor workflow metadata types

### DIFF
--- a/src/app/static/src/js/components/runWorkflow/runWorkflowCreate.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowCreate.vue
@@ -70,13 +70,11 @@
 
     const emptyWorkflowMetadata = {
         name: "",
-        date: "",
-        email: "",
         reports: [],
         instances: {},
         git_branch: null,
         git_commit: null,
-        key: ""
+        changelog: null
     };
 
     interface Computed {

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowProgress.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowProgress.vue
@@ -4,16 +4,8 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import {WorkflowRun} from "../../utils/types";
 
-interface Props {
-    workflowRun: WorkflowRun | null
-}
-
-export default Vue.extend<unknown, unknown, unknown, Props>({
-    name: "runWorkflowProgress",
-    props: {
-        workflowRun: null
-    }
+export default Vue.extend<unknown, unknown, unknown, unknown>({
+    name: "runWorkflowProgress"
 })
 </script>

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowProgress.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowProgress.vue
@@ -4,16 +4,16 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import {RunWorkflowMetadata} from "../../utils/types";
+import {WorkflowRun} from "../../utils/types";
 
 interface Props {
-    workflowMetadata: RunWorkflowMetadata | null
+    workflowRun: WorkflowRun | null
 }
 
 export default Vue.extend<unknown, unknown, unknown, Props>({
     name: "runWorkflowProgress",
     props: {
-        workflowMetadata: null
+        workflowRun: null
     }
 })
 </script>

--- a/src/app/static/src/js/utils/types.ts
+++ b/src/app/static/src/js/utils/types.ts
@@ -33,14 +33,24 @@ export interface RunReportMetadata {
     changelog_types: string[]
 }
 
-export interface RunWorkflowMetadata {
-    name: string
-    date: string
-    email: string
+export interface WorkflowMetadata {
+    name: string,
     reports: WorkflowReportWithParams[],
     instances: Record<string, string>,
     git_branch: string | null
     git_commit: string | null
+}
+
+export interface RunWorkflowMetadata extends WorkflowMetadata {
+    changelog: {
+        message: string,
+        type: string
+    } | null
+}
+
+export interface WorkflowRun extends WorkflowMetadata {
+    date: string
+    email: string
     key: string
 }
 

--- a/src/app/static/src/js/utils/types.ts
+++ b/src/app/static/src/js/utils/types.ts
@@ -33,25 +33,16 @@ export interface RunReportMetadata {
     changelog_types: string[]
 }
 
-export interface WorkflowMetadata {
+export interface RunWorkflowMetadata {
     name: string,
     reports: WorkflowReportWithParams[],
     instances: Record<string, string>,
-    git_branch: string | null
-    git_commit: string | null
-}
-
-export interface RunWorkflowMetadata extends WorkflowMetadata {
+    git_branch: string | null,
+    git_commit: string | null,
     changelog: {
         message: string,
         type: string
     } | null
-}
-
-export interface WorkflowRun extends WorkflowMetadata {
-    date: string
-    email: string
-    key: string
 }
 
 export interface WorkflowReportWithParams {

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflow.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflow.test.ts
@@ -14,15 +14,13 @@ describe(`runWorkflow`, () => {
     ]
 
     const workflowMetadata = [{
-        name: "interim report",
-        date: "2021-05-19T16:28:24Z",
         email: "test@example.com",
         reports: [{"name": "reportA", "params": {"param1": "one", "param2": "two"}},
             {"name": "reportB", "params": {"param3": "three"}}],
         instances: {'name': 'value'},
         git_branch: "branch",
         git_commit: "commit",
-        key: "fake"
+        changelog: {type: "message", message: "test changelog"}
     }]
 
     beforeEach(() => {

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowCreate.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowCreate.test.ts
@@ -6,13 +6,11 @@ import Vue from "vue";
 
 export const emptyWorkflowMetadata = {
     name: "",
-    date: "",
-    email: "",
     reports: [],
     instances: {},
     git_branch: null,
     git_commit: null,
-    key: ""
+    changelog: null
 };
 
 describe(`runWorkflowCreate`, () => {
@@ -27,26 +25,22 @@ describe(`runWorkflowCreate`, () => {
 
     const runnableWorkflowMetadata = [{
         name: "interim report",
-        date: "",
-        email: "",
         reports: [{"name": "reportA", "params": {"param1": "one", "param2": "two"}},
             {"name": "reportB", "params": {"param3": "three"}}],
         instances: {'name': 'value'},
         git_branch: "branch",
         git_commit: "commit",
-        key: ""
+        changelog: null,
     }]
 
     const clonedWorkflowMetadata = [{
         name: "",
-        date: "",
-        email: "",
         reports: [{"name": "reportA", "params": {"param1": "one", "param2": "two"}},
             {"name": "reportB", "params": {"param3": "three"}}],
         instances: {},
         git_branch: "branch",
         git_commit: "commit",
-        key: ""
+        changelog: null
     }]
 
     const workflowSummaryMetadata = [

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowProgress.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowProgress.test.ts
@@ -11,11 +11,4 @@ describe(`runWorkflowProgress`, () => {
         const wrapper = getWrapper()
         expect(wrapper.find("p").text()).toBe("Run workflow progress is coming soon")
     })
-
-    it(`it can set and render props correctly`, async() => {
-        const workflowRun = {placeholder: "test placeholder"}
-        const wrapper = getWrapper()
-        await wrapper.setProps({workflowRun: workflowRun})
-        expect(wrapper.vm.$props.workflowRun).toBe(workflowRun)
-    })
 })

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowProgress.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowProgress.test.ts
@@ -13,9 +13,9 @@ describe(`runWorkflowProgress`, () => {
     })
 
     it(`it can set and render props correctly`, async() => {
-        const workflowMeta = {placeholder: "test placeholder"}
+        const workflowRun = {placeholder: "test placeholder"}
         const wrapper = getWrapper()
-        await wrapper.setProps({workflowMetadata: workflowMeta})
-        expect(wrapper.vm.$props.workflowMetadata).toBe(workflowMeta)
+        await wrapper.setProps({workflowRun: workflowRun})
+        expect(wrapper.vm.$props.workflowRun).toBe(workflowRun)
     })
 })


### PR DESCRIPTION
Following our discussion earlier, I thought it would be worth refactoring the metadata types as agreed in a separate branch to the other changes in this ticket, so that the new metadata type for submission is available for Nick's ticket ASAP. 

There are fields which are common for both submitting workflows, and the workflow details used when creating a new workflow from an existing workflow. These are:
- name
- reports
- instances
- git_branch
- git_commit

In addition, for submission, there is:
- changelog

..and for returned workflow details there are:
- date
- email
- key

However, we do not need a type for the details response since the code in `runWorkflowCreate` which fetches that just uses destructuring to immediately translate it into a RunWorkflowMetadata, without key etc, and the `runWorkflowProgress` component uses other types (`WorkflowRunSummary` and `WorkflowRunStatus`). Therefore, I have updated the `RunWorkflowMetadata` type to match the required submission type in the back end.  

I've removed the `workflowMetadata` prop from `runWorkflowProgress` as it did not appear to be used, either in master or in  mrc-2312 branch, and it just added to the confusion! @Nicolas-Dolan does that make sense?
