### PR TITLE
mrc-2511 Emit changes in runWorkflowRun to persist then in workflow metadata

### DIFF
--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -37,6 +37,8 @@
     interface Props {
         changelogTypeOptions: string[]
         customStyle: ChildCustomStyle
+        initialMessage: string,
+        initialType: string
     }
 
     interface Data {
@@ -59,7 +61,9 @@
         },
         props: {
             customStyle: {},
-            changelogTypeOptions: Array
+            changelogTypeOptions: Array,
+            initialMessage: String,
+            initialType: String
         },
         methods: {
             handleChangeLogType: function () {
@@ -70,7 +74,12 @@
             }
         },
         mounted() {
-            if (this.changelogTypeOptions) {
+            if (this.initialMessage) {
+                this.changeLogMessageValue = this.initialMessage;
+            }
+            if (this.initialType) {
+                this.changeLogTypeValue = this.initialType;
+            } else if (this.changelogTypeOptions) {
                 this.changeLogTypeValue = this.changelogTypeOptions[0]
                 this.$emit("changelogType", this.changeLogTypeValue)
             }

--- a/src/app/static/src/js/components/runReport/instances.vue
+++ b/src/app/static/src/js/components/runReport/instances.vue
@@ -25,6 +25,7 @@
     interface Props {
         instances: Record<string, any>
         customStyle: ChildCustomStyle
+        initialSelectedInstances: Record<string, string>
     }
 
     interface Data {
@@ -50,6 +51,10 @@
             customStyle: {
                 required: true,
                 type: Object
+            },
+            initialSelectedInstances: {
+                required: false,
+                type: Object
             }
         },
         data(): Data {
@@ -64,13 +69,14 @@
             selectInitialInstance: function () {
                 if (this.instances && this.showInstances) {
                     const instances = this.instances;
+                    const initialInstances = this.initialSelectedInstances || {};
                     for (const key in instances) {
                         if (instances[key].length > 0) {
-                            this.$set(this.selectedInstances, key, instances[key][0]);
+                            this.$set(this.selectedInstances, key, initialInstances[key] || instances[key][0]);
                         }
                     }
+                    this.$emit("selectedValues", this.selectedInstances);
                 }
-                this.$emit("selectedValues", this.selectedInstances);
             }
         },
         computed: {

--- a/src/app/static/src/js/components/runReport/instances.vue
+++ b/src/app/static/src/js/components/runReport/instances.vue
@@ -70,12 +70,22 @@
                 if (this.showInstances) {
                     const instances = this.instances;
                     const initialInstances = this.initialSelectedInstances || {};
+                    let updated = false;
                     for (const key in instances) {
                         if (instances[key].length > 0) {
-                            this.$set(this.selectedInstances, key, initialInstances[key] || instances[key][0]);
+                            let initialValue;
+                            if (initialInstances[key]){
+                                initialValue = initialInstances[key];
+                            } else {
+                                initialValue = instances[key][0];
+                                updated = true;
+                            }
+                            this.$set(this.selectedInstances, key, initialValue);
                         }
                     }
-                    this.$emit("selectedValues", this.selectedInstances);
+                    if (updated) {
+                        this.$emit("selectedValues", this.selectedInstances);
+                    }
                 }
             }
         },

--- a/src/app/static/src/js/components/runReport/instances.vue
+++ b/src/app/static/src/js/components/runReport/instances.vue
@@ -67,7 +67,7 @@
                 this.$emit("selectedValues", this.selectedInstances);
             },
             selectInitialInstance: function () {
-                if (this.instances && this.showInstances) {
+                if (this.showInstances) {
                     const instances = this.instances;
                     const initialInstances = this.initialSelectedInstances || {};
                     for (const key in instances) {

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
@@ -145,7 +145,6 @@
                     })
             },
             handleWorkflowName: function (event: Event) {
-                console.log("hnadling workflow name")
                 const workflowName = (event.target as HTMLInputElement).value;
                 let valid = !!workflowName;
                 this.workflowNameError = "";

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
@@ -116,7 +116,7 @@
             handleChangeLogMessageValue: function (changelogMessage) {
                 const changelog = {
                     message: changelogMessage,
-                    type: this.workflowMetadata.changelog.type || ""
+                    type: this.workflowMetadata.changelog?.type || ""
                 };
                 this.$emit("update", {changelog});
             },
@@ -145,6 +145,7 @@
                     })
             },
             handleWorkflowName: function (event: Event) {
+                console.log("hnadling workflow name")
                 const workflowName = (event.target as HTMLInputElement).value;
                 let valid = !!workflowName;
                 this.workflowNameError = "";

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
@@ -6,8 +6,8 @@
             <div class="col-sm-4">
                 <input type="text"
                        :readonly="disableRename"
-                       @input="handleValidation"
-                       v-model="workflowName"
+                       :value="workflowMetadata.name"
+                       @input="handleWorkflowName"
                        class="form-control"
                        id="run-workflow-name">
                 <small class="text-danger">{{ workflowNameError }}</small>
@@ -15,6 +15,7 @@
         </div>
         <div v-if="showInstances">
             <instances :instances="runMetadata.metadata.instances"
+                       :initial-selected-instances="workflowMetadata.instances"
                        :custom-style="childCustomStyle"
                        @selectedValues="handleInstancesValue"/>
         </div>
@@ -22,6 +23,8 @@
             <change-log
                         :changelog-type-options="this.runMetadata.metadata.changelog_types"
                         :custom-style="childCustomStyle"
+                        :initial-message="initialChangelogMessage"
+                        :initial-type="initialChangelogType"
                         @changelogMessage="handleChangeLogMessageValue"
                         @changelogType="handleChangeLogTypeValue">
             </change-log>
@@ -45,26 +48,24 @@
 
     interface Computed {
         showInstances: boolean,
-        showChangelog: void
+        showChangelog: void,
+        initialChangelogMessage: string | null,
+        initialChangelogType: string | null
     }
 
     interface Data {
-        selectedInstances: {};
-        workflowName: string;
-        runMetadata: RunReportMetadata | null;
-        changeLogTypeValue: string;
-        changeLogMessageValue: string;
-        workflows: WorkflowSummary[];
+        runMetadata: RunReportMetadata | null,
+        workflows: WorkflowSummary[],
         workflowNameError: string,
         childCustomStyle: ChildCustomStyle
     }
 
     interface Methods {
         getRunMetadata: () => void
-        handleValidation: () => void
+        handleWorkflowName: (event: Event) => void
         getWorkflows: () => void
-        handleChangeLogTypeValue: (changelogType: string) => void
-        handleChangeLogMessageValue: (changelogMessage: string) => void
+        handleChangeLogTypeValue: (changelogType: string) => void,
+        handleChangeLogMessageValue: (changelogMessage: string) => void,
         handleInstancesValue: (instances: Object) => void
     }
 
@@ -79,11 +80,7 @@
         },
         data() {
             return {
-                selectedInstances: {},
-                workflowName: "",
                 runMetadata: null,
-                changeLogTypeValue: "",
-                changeLogMessageValue: "",
                 error: "",
                 defaultMessage: "",
                 workflows: [],
@@ -97,17 +94,31 @@
             },
             showChangelog: function () {
                 return this.runMetadata && !!this.runMetadata.metadata.changelog_types;
+            },
+            initialChangelogMessage() {
+                return this.workflowMetadata.changelog?.message
+            },
+            initialChangelogType() {
+                return this.workflowMetadata.changelog?.type
             }
         },
         methods: {
             handleInstancesValue: function (instances) {
-                this.selectedInstances = instances
+                this.$emit("update", {instances});
             },
             handleChangeLogTypeValue: function (changelogType) {
-                this.changeLogTypeValue = changelogType
+                const changelog = {
+                    message: this.workflowMetadata.changelog?.message || "",
+                    type: changelogType
+                };
+                this.$emit("update", {changelog});
             },
             handleChangeLogMessageValue: function (changelogMessage) {
-                this.changeLogMessageValue = changelogMessage
+                const changelog = {
+                    message: changelogMessage,
+                    type: this.workflowMetadata.changelog.type || ""
+                };
+                this.$emit("update", {changelog});
             },
             getRunMetadata: function () {
                 api.get('/report/run-metadata')
@@ -133,24 +144,22 @@
                         this.defaultMessage = "An error occurred while retrieving previously run workflows";
                     })
             },
-            handleValidation: function () {
-                let valid = !!this.workflowName;
+            handleWorkflowName: function (event: Event) {
+                const workflowName = (event.target as HTMLInputElement).value;
+                let valid = !!workflowName;
                 this.workflowNameError = "";
                 if (this.workflows.find(workflow =>
-                    workflow.name.toLowerCase() === this.workflowName.toLowerCase())) {
+                    workflow.name.toLowerCase() === workflowName.toLowerCase())) {
                     valid = false;
                     this.workflowNameError = "Workflow name already exists, please rename your workflow."
                 }
                 this.$emit("valid", valid);
-                if(this.workflowName) {
-                    this.$emit("update", {name: this.workflowName})
-                }
+                this.$emit("update", {name: workflowName});
             }
         },
         mounted() {
             this.getRunMetadata();
             if (this.disableRename) {
-                this.workflowName = this.workflowMetadata.name
                 this.$emit("valid", true);
             } else {
                 this.getWorkflows();

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
@@ -67,6 +67,7 @@
         handleChangeLogTypeValue: (changelogType: string) => void,
         handleChangeLogMessageValue: (changelogMessage: string) => void,
         handleInstancesValue: (instances: Object) => void
+        validateWorkflowName: (workflowName: string) => void
     }
 
     export default Vue.extend<Data, Methods, Computed, Props>({
@@ -138,6 +139,7 @@
                         this.workflows = data.data
                         this.error = "";
                         this.defaultMessage = "";
+                        this.validateWorkflowName(this.workflowMetadata.name);
                     })
                     .catch((error) => {
                         this.error = error
@@ -146,6 +148,10 @@
             },
             handleWorkflowName: function (event: Event) {
                 const workflowName = (event.target as HTMLInputElement).value;
+                this.validateWorkflowName(workflowName);
+                this.$emit("update", {name: workflowName});
+            },
+            validateWorkflowName: function(workflowName: string) {
                 let valid = !!workflowName;
                 this.workflowNameError = "";
                 if (this.workflows.find(workflow =>
@@ -154,7 +160,6 @@
                     this.workflowNameError = "Workflow name already exists, please rename your workflow."
                 }
                 this.$emit("valid", valid);
-                this.$emit("update", {name: workflowName});
             }
         },
         mounted() {

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -1,16 +1,17 @@
 import {mount} from "@vue/test-utils";
+import Vue from "vue";
 import ChangeLog from "../../../js/components/runReport/changeLog.vue";
-import changeLog from "../../../js/components/runReport/changeLog.vue";
 
 describe(`changeLog`, () => {
     const changelogTypeOptions = ["internal", "public"]
 
-    const getWrapper = () => {
+    const getWrapper = (propsData: any = {}) => {
         return mount(ChangeLog,
             {
                 propsData: {
                     changelogTypeOptions: changelogTypeOptions,
-                    customStyle: {label: "col-sm-2 text-right", control: "col-sm-6"}
+                    customStyle: {label: "col-sm-2 text-right", control: "col-sm-6"},
+                    ...propsData,
                 }
             })
     }
@@ -67,12 +68,27 @@ describe(`changeLog`, () => {
         const label = ["col-form-label", "col-sm-2", "text-right"]
         const control = ["col-sm-6"]
 
-        const changelogMessage = wrapper.find(changeLog).find("#changelog-message")
-        const changelogType= wrapper.find(changeLog).find("#changelog-type")
+        const changelogMessage = wrapper.find(ChangeLog).find("#changelog-message")
+        const changelogType= wrapper.find(ChangeLog).find("#changelog-type")
 
         expect(changelogMessage.find("label").classes()).toEqual(label)
         expect(changelogMessage.find("#change-message-control").classes()).toEqual(control)
         expect(changelogType.find("label").classes()).toEqual(label)
         expect(changelogType.find("#change-type-control").classes()).toEqual(control)
-    })
+    });
+
+    it(`can set changelog message from initial value`, async () => {
+        const wrapper = getWrapper({initialMessage: "some message"});
+        expect(wrapper.vm.$data.changeLogMessageValue).toBe("some message");
+        await Vue.nextTick();
+        expect((wrapper.find("#changelogMessage").element as HTMLTextAreaElement).value).toBe("some message");
+    });
+
+    it(`can set changelog message from initial type`, async () => {
+        const wrapper = getWrapper({initialType: "public"});
+        expect(wrapper.vm.$data.changeLogTypeValue).toBe("public");
+        await Vue.nextTick();
+        expect((wrapper.find("#changelogType").element as HTMLSelectElement).value).toBe("public");
+        expect(wrapper.emitted().changelogType).toBeUndefined();
+    });
 })

--- a/src/app/static/src/tests/components/runReport/instances.test.ts
+++ b/src/app/static/src/tests/components/runReport/instances.test.ts
@@ -1,16 +1,18 @@
 import {shallowMount} from "@vue/test-utils";
+import Vue from "vue";
 import Instances from "../../../js/components/runReport/instances.vue"
 
 describe(`instances`, () => {
 
 
-    const getWrapper = () => {
+    const getWrapper = (propsData: any = {}) => {
         return shallowMount(Instances, {
             propsData: {
                 instances: {
                     source: ["prod", "uat"]
                 },
-                customStyle: {}
+                customStyle: {},
+                ...propsData,
             }
         })
     }
@@ -49,4 +51,25 @@ describe(`instances`, () => {
         expect(wrapper.emitted().selectedValues[0][0]).toEqual({"source": "prod"})
     });
 
+    it(`can set initial selected instances`, async () => {
+        const wrapper = getWrapper({initialSelectedInstances: {source: "uat"}});
+        expect(wrapper.vm.$data.selectedInstances).toStrictEqual({source: "uat"});
+        await Vue.nextTick();
+        expect((wrapper.find("select").element as HTMLSelectElement).value).toBe("uat")
+    });
+
+    it(`can set initial selected instances with defaults where no initial value provided`, async () => {
+        const wrapper = getWrapper({
+            instances: {
+                annexe: ["annexe1", "annexe2"],
+                source: ["prod", "uat"]
+            },
+            initialSelectedInstances: {source: "uat"}
+        });
+        expect(wrapper.vm.$data.selectedInstances).toStrictEqual({annexe: "annexe1", source: "uat"});
+        await Vue.nextTick();
+        const selects = wrapper.findAll("select");
+        expect((selects.at(0).element as HTMLSelectElement).value).toBe("annexe1");
+        expect((selects.at(1).element as HTMLSelectElement).value).toBe("uat");
+    });
 })

--- a/src/app/static/src/tests/components/runReport/instances.test.ts
+++ b/src/app/static/src/tests/components/runReport/instances.test.ts
@@ -72,4 +72,38 @@ describe(`instances`, () => {
         expect((selects.at(0).element as HTMLSelectElement).value).toBe("annexe1");
         expect((selects.at(1).element as HTMLSelectElement).value).toBe("uat");
     });
+
+    it("emits initial selectedValues event when no defaults provided", () => {
+        const wrapper = getWrapper({
+            instances: {
+                annexe: ["annexe1", "annexe2"],
+                source: ["prod", "uat"]
+            }
+        });
+        expect(wrapper.emitted("selectedValues").length).toBe(1);
+        expect(wrapper.emitted("selectedValues")[0][0]).toStrictEqual({annexe: "annexe1", source: "prod"});
+    });
+
+    it("does not emit initial selectedValues when all defaults provided", () => {
+        const wrapper = getWrapper({
+            instances: {
+                annexe: ["annexe1", "annexe2"],
+                source: ["prod", "uat"]
+            },
+            initialSelectedInstances: {annexe: "annexe2", source: "uat"}
+        });
+        expect(wrapper.emitted("selectedValues")).toBeUndefined();
+    });
+
+    it("emits initial selectedValues event when some defaults provided", () => {
+        const wrapper = getWrapper({
+            instances: {
+                annexe: ["annexe1", "annexe2"],
+                source: ["prod", "uat"]
+            },
+            initialSelectedInstances: {annexe: "annexe2"}
+        });
+        expect(wrapper.emitted("selectedValues").length).toBe(1);
+        expect(wrapper.emitted("selectedValues")[0][0]).toStrictEqual({annexe: "annexe2", source: "prod"});
+    });
 })

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowRun.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowRun.test.ts
@@ -3,6 +3,8 @@ import runWorkflowRun from "../../../js/components/runWorkflow/runWorkflowRun.vu
 import {mockAxios} from "../../mockAxios";
 import ErrorInfo from "../../../js/components/errorInfo.vue";
 import Instances from "../../../js/components/runReport/instances.vue";
+import Changelog from "../../../js/components/runReport/changeLog.vue";
+import {emptyWorkflowMetadata} from "./runWorkflowCreate.test";
 
 describe(`runWorkflowRun`, () => {
 
@@ -34,17 +36,16 @@ describe(`runWorkflowRun`, () => {
             .reply(200, {"data": workflowSummaryMetadata});
     })
 
-    const getWrapper = () => {
+    const getWrapper = (propsData: any = {}) => {
         return mount(runWorkflowRun,
             {
-                propsData: {workflowMetadata: {}},
+                propsData: {
+                    workflowMetadata: {...emptyWorkflowMetadata},
+                    ...propsData
+                },
                 data() {
                     return {
-                        selectedInstances: {},
-                        workflowName: "",
                         runMetadata: null,
-                        changeLogTypeValue: "",
-                        changeLogMessageValue: "",
                         workflows: [],
                         workflowNameError: ""
                     }
@@ -58,22 +59,58 @@ describe(`runWorkflowRun`, () => {
         expect(wrapper.find("#run-header").text()).toBe("Run workflow")
     })
 
-    it(`can render workflow-name elements`, (done) => {
+    it(`can render workflow-name elements, and emit update event on name change`, async () => {
         const wrapper = getWrapper()
-        setTimeout(async () => {
-            const workflowName = wrapper.find("#workflow-name-div")
-            expect(workflowName.text()).toBe("Name")
-            const workflowNameInput = workflowName.find("input#run-workflow-name")
-            expect(workflowNameInput.exists()).toBe(true)
 
-            await workflowNameInput.setValue("New Workflow name")
-            const workflowNameValue = workflowNameInput.element as HTMLInputElement
-            expect(workflowNameValue.value).toEqual("New Workflow name")
-            expect(workflowName.find("small").text())
-                .toEqual("")
-            done()
-        })
+        const workflowName = wrapper.find("#workflow-name-div")
+        expect(workflowName.text()).toBe("Name")
+        const workflowNameInput = workflowName.find("input#run-workflow-name")
+        expect(workflowNameInput.exists()).toBe(true)
+
+        await workflowNameInput.setValue("New Workflow name")
+        expect(workflowName.find("small").text())
+            .toEqual("")
+        expect(wrapper.emitted().update.length).toBe(1);
+        expect(wrapper.emitted().update[0][0]).toStrictEqual({name: "New Workflow name"});
+
+        expect(wrapper.emitted().valid.length).toBe(1);
+        expect(wrapper.emitted().valid[0][0]).toBe(true);
     })
+
+    it(`emits valid false on workflow name change to empty string`, (done) => {
+        const wrapper = getWrapper({
+            workflowMetadata: {name: "interim report3"}
+        });
+        setTimeout(async () => {
+            const workflowNameInput = wrapper.find("input#run-workflow-name");
+            await workflowNameInput.setValue("");
+
+            expect(wrapper.emitted().valid.length).toBe(1);
+            expect(wrapper.emitted().valid[0][0]).toBe(false);
+            done();
+        });
+    });
+
+    it(`emits valid false on workflow name change to name of existing workflow`, (done) => {
+        const wrapper = getWrapper({
+            workflowMetadata: {name: "interim report3"}
+        });
+        setTimeout(async () => {
+            const workflowNameInput = wrapper.find("input#run-workflow-name");
+            await workflowNameInput.setValue("interim report");
+
+            expect(wrapper.emitted().valid.length).toBe(1);
+            expect(wrapper.emitted().valid[0][0]).toBe(false);
+            done();
+        });
+    });
+
+    it("can display workflow name from metadata", () => {
+        const wrapper = getWrapper({
+            workflowMetadata: {name: "Test Workflow"}
+        });
+        expect((wrapper.find("#run-workflow-name").element as HTMLInputElement).value).toBe("Test Workflow");
+    });
 
     it(`shows error message if workflow name already exists`, async (done) => {
         const wrapper = getWrapper()
@@ -84,19 +121,20 @@ describe(`runWorkflowRun`, () => {
             expect(workflowNameInput.exists()).toBe(true)
 
             await workflowNameInput.setValue("interim report")
-            const workflowNameValue = workflowNameInput.element as HTMLInputElement
-            expect(workflowNameValue.value).toEqual("interim report")
+            expect(wrapper.emitted().update[wrapper.emitted().update.length-1][0])
+                .toStrictEqual({name: "interim report"});
             expect(workflowName.find("small").text())
                 .toEqual("Workflow name already exists, please rename your workflow.")
             done()
         })
     })
 
-    it(`can render workflow-source elements`, async (done) => {
+    it(`can render instances elements`, (done) => {
         const wrapper = getWrapper()
-        setTimeout(async () => {
-            expect(wrapper.find(Instances).emitted().selectedValues.length).toBe(1)
-            expect(wrapper.find(Instances).emitted().selectedValues[0][0]).toEqual({"annex": "one", "source": "prod"})
+
+        setTimeout(() => {
+            expect(wrapper.findComponent(Instances).emitted().selectedValues.length).toBe(1)
+            expect(wrapper.findComponent(Instances).emitted().selectedValues[0][0]).toEqual({"annex": "one", "source": "prod"})
 
             const label = wrapper.findAll("#instances-div label")
             expect(label.length).toBe(1)
@@ -110,11 +148,11 @@ describe(`runWorkflowRun`, () => {
             expect(sourceOptions.at(1).text()).toBe("uat");
 
             expect(wrapper.find("#annex").exists()).toBe(false); // only 1 option so don't show
-            done()
-        })
+            done();
+        });
     })
 
-    it(`can select workflow-source`, async (done) => {
+    it(`emits update event on select instance`,  (done) => {
         const wrapper = getWrapper()
 
         setTimeout(async () => {
@@ -122,21 +160,38 @@ describe(`runWorkflowRun`, () => {
             expect(label.length).toBe(1)
             expect(label.at(0).text()).toBe("Database \"source\"")
 
-            expect(wrapper.vm.$data.selectedInstances).toStrictEqual({source: "prod", annex: "one"});
+            //expect initial emit on instances + changelog mount
+            expect(wrapper.emitted().update.length).toBe(2);
+            expect(wrapper.emitted().update[0][0]).toStrictEqual({instances: {source: "prod", annex: "one"}});
 
             const selectedOption = wrapper.find("#source");
             await selectedOption.setValue("uat")
-            expect(wrapper.vm.$data.selectedInstances).toStrictEqual({source: "uat", annex: "one"});
-            const selectedOptionValue = selectedOption.element as HTMLSelectElement
-            expect(selectedOptionValue.value).toEqual(source[1])
-            done()
-        })
+            expect(wrapper.emitted().update.length).toBe(3);
+            expect(wrapper.emitted().update[2][0]).toStrictEqual({instances: {source: "uat", annex: "one"}});
+            done();
+        });
     })
+
+    it("initialises instances from workflow metadata", (done) => {
+        const wrapper = getWrapper({
+            workflowMetadata: {
+                instances: {source: "uat"}
+            }
+        });
+
+        setTimeout(() => {
+            expect(wrapper.findComponent(Instances).props("initialSelectedInstances")).toStrictEqual({source: "uat"});
+
+            expect(wrapper.emitted().update.length).toBe(2);
+            expect(wrapper.emitted().update[0][0]).toStrictEqual({instances: {source: "uat", annex: "one"}});
+            done();
+        });
+    });
 
     it(`can render workflow-changelog message elements`, async (done) => {
         const wrapper = getWrapper()
 
-        setTimeout(async () => {
+        setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(2);
             expect(mockAxios.history.get[0].url).toBe("http://app/report/run-metadata");
             expect(mockAxios.history.get[1].url).toBe("http://app/workflows");
@@ -154,7 +209,7 @@ describe(`runWorkflowRun`, () => {
         })
     })
 
-    it(`can set workflow-changelog message`, async (done) => {
+    it(`emits update on changelog message change`, (done) => {
         const wrapper = getWrapper()
 
         setTimeout(async () => {
@@ -163,13 +218,39 @@ describe(`runWorkflowRun`, () => {
             const textarea = changelog.find("textarea")
             expect(changelog.find("textarea").exists()).toBe(true)
 
+            // expect initial emit of default selected type + selected instances
+            expect(wrapper.emitted().update.length).toBe(2);
+            expect(wrapper.emitted().update[1][0]).toStrictEqual({changelog: {message: "", type: "internal"}})
+
             await textarea.setValue("test message input")
-            const textAreaValue = textarea.element as HTMLTextAreaElement
-            expect(textAreaValue.value).toBe("test message input")
-            expect(wrapper.vm.$data.changeLogMessageValue).toEqual("test message input")
+            expect(wrapper.emitted().update.length).toBe(3);
+            expect(wrapper.emitted().update[2][0]).toStrictEqual({changelog: {message: "test message input", type: ""}})
             done()
         })
-    })
+    });
+
+    it(`changelog message change updates with existing changelog type`, (done) => {
+        const wrapper = getWrapper({
+            workflowMetadata: {
+                changelog: {message: "", type: "public"}
+            }
+        });
+
+        setTimeout(async () => {
+            const changelog = wrapper.find("#changelog-message")
+            expect(changelog.find("label").text()).toBe("Changelog Message")
+            const textarea = changelog.find("textarea")
+            expect(changelog.find("textarea").exists()).toBe(true)
+
+            // expect initial emit of default selected instances
+            expect(wrapper.emitted().update.length).toBe(1);
+
+            await textarea.setValue("test message input")
+            expect(wrapper.emitted().update.length).toBe(2);
+            expect(wrapper.emitted().update[1][0]).toStrictEqual({changelog: {message: "test message input", type: "public"}})
+            done()
+        })
+    });
 
     it(`can render workflow-changelog-type`, async (done) => {
         const wrapper = getWrapper()
@@ -191,20 +272,59 @@ describe(`runWorkflowRun`, () => {
         })
     })
 
-    it(`can select workflow-changelog-type`, async (done) => {
-        const wrapper = getWrapper()
+    it(`emits update on changelog type change`, async (done) => {
+        const wrapper = getWrapper();
 
         setTimeout(async () => {
-            const changelogType = wrapper.find("#changelog-type")
-            expect(wrapper.find("#changelog-type label").text()).toEqual("Changelog Type")
+            const changelogType = wrapper.find("#changelog-type");
+            expect(wrapper.find("#changelog-type label").text()).toEqual("Changelog Type");
             const selectOptions = changelogType.find("select")
-            selectOptions.setValue(changelogTypes[1])
-            const optionsValue = selectOptions.element as HTMLSelectElement
-            expect(optionsValue.value).toEqual(changelogTypes[1])
-            expect(wrapper.vm.$data.selectedInstances).toEqual({"annex": "one", "source": "prod"})
+            selectOptions.setValue(changelogTypes[1]);
+            expect(wrapper.emitted().update.length).toBe(3);
+            expect(wrapper.emitted().update[2][0]).toStrictEqual({changelog: {message: "", type: "public"}});
             done()
         })
     })
+
+    it(`changelog type change updates with existing changelog message`, (done) => {
+        const wrapper = getWrapper({
+            workflowMetadata: {
+                changelog: {message: "existing message", type: "internal"}
+            }
+        });
+
+        setTimeout(async () => {
+            // expect initial emit of default selected instances
+            expect(wrapper.emitted().update.length).toBe(1);
+
+            const changelogType = wrapper.find("#changelog-type")
+            expect(wrapper.find("#changelog-type label").text()).toEqual("Changelog Type")
+            const selectOptions = changelogType.find("select")
+            await selectOptions.setValue(changelogTypes[1]);
+
+            expect(wrapper.emitted().update.length).toBe(2);
+            expect(wrapper.emitted().update[1][0]).toStrictEqual({changelog: {message: "existing message", type: "public"}})
+            done()
+        })
+    });
+
+    it(`initialises changelog type and value from workflow metadata`, () => {
+        const wrapper = getWrapper({
+            workflowMetadata: {
+                changelog: {
+                    message: "Workflow message",
+                    type: "public"
+                }
+            }
+        });
+        setTimeout(() => {
+            expect(wrapper.findComponent(Changelog).props("initialMessage")).toBe("Workflow message");
+            expect(wrapper.findComponent(Changelog).props("initialType")).toBe("public");
+
+            expect((wrapper.find("#changelogMessage").element as HTMLTextAreaElement).value).toBe("Workflow message");
+            expect((wrapper.find("#changelogType").element as HTMLSelectElement).value).toBe("public");
+        });
+    });
 
     it(`it can set and render props correctly`, async (done) => {
         const workflowMeta = {placeholder: "test placeholder"}

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowRun.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowRun.test.ts
@@ -59,22 +59,61 @@ describe(`runWorkflowRun`, () => {
         expect(wrapper.find("#run-header").text()).toBe("Run workflow")
     })
 
-    it(`can render workflow-name elements, and emit update event on name change`, async () => {
+    it("emits initial valid event when workflow name is blank", (done) => {
+        const wrapper = getWrapper();
+        setTimeout(() => {
+            expect(wrapper.emitted("valid").length).toBe(1);
+            expect(wrapper.emitted("valid")[0][0]).toBe(false);
+            done();
+        });
+    });
+
+    it("emits initial valid event when workflow name matches existing workflow", (done) => {
+        const wrapper = getWrapper({
+            workflowMetadata: {
+                ...emptyWorkflowMetadata,
+                name: "Interim report"
+            }
+        });
+        setTimeout(() => {
+            expect(wrapper.emitted("valid").length).toBe(1);
+            expect(wrapper.emitted("valid")[0][0]).toBe(false);
+            done();
+        });
+    });
+
+    it("emits initial valid event when workflow name is valid", (done) => {
+        const wrapper = getWrapper({
+            workflowMetadata: {
+                ...emptyWorkflowMetadata,
+                name: "Interim report3"
+            }
+        });
+        setTimeout(() => {
+            expect(wrapper.emitted("valid").length).toBe(1);
+            expect(wrapper.emitted("valid")[0][0]).toBe(true);
+            done();
+        });
+    });
+
+    it(`can render workflow-name elements, and emit update event on name change`, (done) => {
         const wrapper = getWrapper()
 
         const workflowName = wrapper.find("#workflow-name-div")
         expect(workflowName.text()).toBe("Name")
         const workflowNameInput = workflowName.find("input#run-workflow-name")
         expect(workflowNameInput.exists()).toBe(true)
+        setTimeout(async () => {
+            await workflowNameInput.setValue("New Workflow name")
+            expect(workflowName.find("small").text())
+                .toEqual("")
+            expect(wrapper.emitted().update.length).toBe(3); // this follows initial changelog and instances updates
+            expect(wrapper.emitted().update[2][0]).toStrictEqual({name: "New Workflow name"});
 
-        await workflowNameInput.setValue("New Workflow name")
-        expect(workflowName.find("small").text())
-            .toEqual("")
-        expect(wrapper.emitted().update.length).toBe(1);
-        expect(wrapper.emitted().update[0][0]).toStrictEqual({name: "New Workflow name"});
-
-        expect(wrapper.emitted().valid.length).toBe(1);
-        expect(wrapper.emitted().valid[0][0]).toBe(true);
+            expect(wrapper.emitted().valid.length).toBe(2);
+            expect(wrapper.emitted().valid[1][0]).toBe(true);
+            done();
+        });
     })
 
     it(`emits valid false on workflow name change to empty string`, (done) => {
@@ -85,8 +124,8 @@ describe(`runWorkflowRun`, () => {
             const workflowNameInput = wrapper.find("input#run-workflow-name");
             await workflowNameInput.setValue("");
 
-            expect(wrapper.emitted().valid.length).toBe(1);
-            expect(wrapper.emitted().valid[0][0]).toBe(false);
+            expect(wrapper.emitted().valid.length).toBe(2);
+            expect(wrapper.emitted().valid[1][0]).toBe(false);
             done();
         });
     });
@@ -99,8 +138,8 @@ describe(`runWorkflowRun`, () => {
             const workflowNameInput = wrapper.find("input#run-workflow-name");
             await workflowNameInput.setValue("interim report");
 
-            expect(wrapper.emitted().valid.length).toBe(1);
-            expect(wrapper.emitted().valid[0][0]).toBe(false);
+            expect(wrapper.emitted().valid.length).toBe(2);
+            expect(wrapper.emitted().valid[1][0]).toBe(false);
             done();
         });
     });
@@ -308,7 +347,7 @@ describe(`runWorkflowRun`, () => {
         })
     });
 
-    it(`initialises changelog type and value from workflow metadata`, () => {
+    it(`initialises changelog type and value from workflow metadata`, (done) => {
         const wrapper = getWrapper({
             workflowMetadata: {
                 changelog: {
@@ -323,6 +362,7 @@ describe(`runWorkflowRun`, () => {
 
             expect((wrapper.find("#changelogMessage").element as HTMLTextAreaElement).value).toBe("Workflow message");
             expect((wrapper.find("#changelogType").element as HTMLSelectElement).value).toBe("public");
+            done();
         });
     });
 

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
@@ -168,7 +168,17 @@ class RunWorkflowTests : SeleniumTest()
         val nextButton = driver.findElement(By.id("next-workflow"))
         assertThat(nextButton.isEnabled).isTrue()
         nextButton.click()
-        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("run-header")))
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("change-type-control")))
+
+        val submitButton = driver.findElement(By.id("next-workflow"))
+        assertThat(submitButton.isEnabled).isFalse()
+        val changelogTypes = driver.findElements(By.cssSelector("#change-type-control option"))
+        assertThat(changelogTypes.count()).isEqualTo(2)
+        assertThat(changelogTypes[0].text).isEqualTo("internal")
+        assertThat(changelogTypes[1].text).isEqualTo("public")
+
+        driver.findElement(By.id("run-workflow-name")).sendKeys("new workflow name")
+        wait.until(ExpectedConditions.elementToBeClickable(submitButton))
     }
 
     @Test


### PR DESCRIPTION
This branch brings `runWorkflowRun`, the finalise workflow page, into line with `runWorkflowReport` by having it emit any workflow metadata changes to the wizard rather than managing them internally. This means the that metadata will be updated ready to be submitted when user presses 'Run workflow'. 

It also means that it should be possible to go back to the previous step, then forward again to the finalise change, and see that any changes previously made have been retained. This required updating the changelog and instances components to support mounting with initial values. 