### PR TITLE
mrc-2559 Avoid submitting empty changelog with workflow definition

### DIFF
--- a/src/app/static/src/js/components/runReport/changeLog.vue
+++ b/src/app/static/src/js/components/runReport/changeLog.vue
@@ -5,11 +5,11 @@
                    :class="customStyle.label"
                    class="col-form-label">Changelog Message</label>
             <div id="change-message-control" :class="customStyle.control">
-                        <textarea class="form-control" id="changelogMessage"
-                                  v-model="changeLogMessageValue"
-                                  @input="handleChangeLogMessage"
-                                  rows="2">
-                        </textarea>
+                <textarea class="form-control" id="changelogMessage"
+                          v-model="changeLogMessageValue"
+                          @input="emitChangelog"
+                          rows="2">
+                </textarea>
             </div>
         </div>
         <div id="changelog-type" class="form-group row">
@@ -20,7 +20,7 @@
                 <select class="form-control"
                         id="changelogType"
                         v-model="changeLogTypeValue"
-                        @change="handleChangeLogType">
+                        @change="emitChangelog">
                     <option v-for="option in changelogTypeOptions" :value="option">
                         {{ option }}
                     </option>
@@ -37,7 +37,7 @@
     interface Props {
         changelogTypeOptions: string[]
         customStyle: ChildCustomStyle
-        initialMessage: string,
+        initialMessage: string
         initialType: string
     }
 
@@ -47,8 +47,7 @@
     }
 
     interface Methods {
-        handleChangeLogMessage: () => void
-        handleChangeLogType: () => void
+        emitChangelog: () => void
     }
 
     export default Vue.extend<Data, Methods, unknown, Props>({
@@ -66,11 +65,11 @@
             initialType: String
         },
         methods: {
-            handleChangeLogType: function () {
-                this.$emit("changelogType", this.changeLogTypeValue)
-            },
-            handleChangeLogMessage: function () {
-                this.$emit("changelogMessage", this.changeLogMessageValue)
+            emitChangelog() {
+                this.$emit("changelog", this.changeLogMessageValue ? {
+                    message: this.changeLogMessageValue,
+                    type: this.changeLogTypeValue
+                } : null);
             }
         },
         mounted() {
@@ -80,8 +79,8 @@
             if (this.initialType) {
                 this.changeLogTypeValue = this.initialType;
             } else if (this.changelogTypeOptions) {
-                this.changeLogTypeValue = this.changelogTypeOptions[0]
-                this.$emit("changelogType", this.changeLogTypeValue)
+                this.changeLogTypeValue = this.changelogTypeOptions[0];
+                this.emitChangelog();
             }
         }
     })

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -32,8 +32,7 @@
             <change-log v-if="showChangelog"
                         :changelog-type-options="metadata.changelog_types"
                         :custom-style="childCustomStyle"
-                        @changelogMessage="handleChangeLogMessageValue"
-                        @changelogType="handleChangeLogTypeValue">
+                        @changelog="handleChangelog">
             </change-log>
             <div v-if="showRunButton" id="run-form-group" class="form-group row">
                 <div class="col-sm-2"></div>
@@ -90,8 +89,7 @@
                 runningKey: "",
                 disableRun: false,
                 parameterValues: [],
-                changeLogMessageValue: "",
-                changeLogTypeValue: "",
+                changelog: null,
                 childCustomStyle: {label: "col-sm-2 text-right", control: "col-sm-6"}
             }
         },
@@ -116,11 +114,8 @@
             handleInstancesValue: function (instances) {
                 this.selectedInstances = instances
             },
-            handleChangeLogTypeValue: function (type: string) {
-                this.changeLogTypeValue = type
-            },
-            handleChangeLogMessageValue: function (message: string) {
-                this.changeLogMessageValue = message
+            handleChangelog: function (changelog: object | null) {
+                this.changelog = changelog;
             },
             getParameterValues(values, valid) {
                 if (valid) {
@@ -167,18 +162,10 @@
                 let params = {};
                 params = this.parameterValues.reduce((params, param) => ({...params, [param.name]: param.value}), {});
 
-                let changelog = null;
-                if (this.changeLogMessageValue) {
-                    changelog = {
-                        message: this.changeLogMessageValue,
-                        type: this.changeLogTypeValue
-                    }
-                }
-
                 api.post(`/report/${this.selectedReport}/actions/run/`, {
                     instances,
                     params,
-                    changelog,
+                    changelog: this.changelog,
                     gitBranch: this.selectedBranch,
                     gitCommit: this.selectedCommitId,
                 })
@@ -201,7 +188,7 @@
                 this.runningStatus = "";
                 this.runningKey = "";
                 this.disableRun = false;
-                this.changeLogMessageValue = ""
+                this.changelog = null;
             }
         },
         mounted() {

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowRun.vue
@@ -25,8 +25,7 @@
                         :custom-style="childCustomStyle"
                         :initial-message="initialChangelogMessage"
                         :initial-type="initialChangelogType"
-                        @changelogMessage="handleChangeLogMessageValue"
-                        @changelogType="handleChangeLogTypeValue">
+                        @changelog="handleChangelog">
             </change-log>
         </div>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>
@@ -64,9 +63,8 @@
         getRunMetadata: () => void
         handleWorkflowName: (event: Event) => void
         getWorkflows: () => void
-        handleChangeLogTypeValue: (changelogType: string) => void,
-        handleChangeLogMessageValue: (changelogMessage: string) => void,
-        handleInstancesValue: (instances: Object) => void
+        handleChangelog: (changelog: object) => void,
+        handleInstancesValue: (instances: object) => void
         validateWorkflowName: (workflowName: string) => void
     }
 
@@ -107,18 +105,7 @@
             handleInstancesValue: function (instances) {
                 this.$emit("update", {instances});
             },
-            handleChangeLogTypeValue: function (changelogType) {
-                const changelog = {
-                    message: this.workflowMetadata.changelog?.message || "",
-                    type: changelogType
-                };
-                this.$emit("update", {changelog});
-            },
-            handleChangeLogMessageValue: function (changelogMessage) {
-                const changelog = {
-                    message: changelogMessage,
-                    type: this.workflowMetadata.changelog?.type || ""
-                };
+            handleChangelog: function (changelog) {
                 this.$emit("update", {changelog});
             },
             getRunMetadata: function () {

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -28,34 +28,34 @@ describe(`changeLog`, () => {
             })
     })
 
-    it(`emits changelogType first index when component gets mounted`, () => {
+    it(`emits null changelog when component gets mounted`, () => {
         const wrapper = getWrapper();
-        expect(wrapper.emitted().changelogType.length).toBe(1)
-        expect(wrapper.emitted().changelogType[0][0]).toBe("internal")
+        expect(wrapper.emitted().changelog.length).toBe(1)
+        expect(wrapper.emitted().changelog[0][0]).toBe(null)
     })
 
-    it(`can set and get changelog message`, () => {
+    it(`can set and get changelog message`, async () => {
         const wrapper = getWrapper();
         const message = wrapper.find("#changelogMessage")
-        message.setValue("new message")
+        await message.setValue("new message")
         expect(wrapper.vm.$data.changeLogMessageValue).toBe("new message")
 
-        expect(wrapper.emitted().changelogMessage.length).toBe(1)
-        expect(wrapper.emitted().changelogMessage[0][0]).toEqual("new message")
+        expect(wrapper.emitted().changelog.length).toBe(2)
+        expect(wrapper.emitted().changelog[1][0].message).toEqual("new message")
 
         const messageValue = message.element as HTMLTextAreaElement
         expect(messageValue.value).toBe("new message")
     })
 
-    it(`can select and get changelog type`, () => {
+    it(`can select and get changelog type`, async () => {
         const wrapper = getWrapper();
-        const options = wrapper.find("#changelogType")
-            .find("select").findAll("option")
-        options.at(1).setSelected()
+        await wrapper.find("#changelogMessage").setValue("new message")
 
-        expect(wrapper.emitted().changelogType.length).toBe(2)
-        expect(wrapper.emitted().changelogType[0][0]).toEqual(changelogTypeOptions[0]) //on mount initial selection
-        expect(wrapper.emitted().changelogType[1][0]).toEqual(changelogTypeOptions[1])  // selected value
+        wrapper.find("#changelogType").findAll("option").at(1).setSelected()
+        expect(wrapper.emitted().changelog.length).toBe(3)
+        expect(wrapper.emitted().changelog[0][0]).toBeNull() // on mount
+        expect(wrapper.emitted().changelog[1][0]["type"]).toEqual(changelogTypeOptions[0]) // message set
+        expect(wrapper.emitted().changelog[2][0]["type"]).toEqual(changelogTypeOptions[1]) // type updated
 
         expect(wrapper.vm.$data.changeLogTypeValue).toBe("public")
         const typeValue = wrapper.find("#changelogType").element as HTMLSelectElement

--- a/src/app/static/src/tests/components/runReport/runReport.test.ts
+++ b/src/app/static/src/tests/components/runReport/runReport.test.ts
@@ -417,7 +417,10 @@ describe("runReport", () => {
             await Vue.nextTick();
 
             wrapper.setData({
-                changeLogMessageValue: "test changelog"
+                changelog: {
+                    message: "test changelog",
+                    type: "internal"
+                }
             });
 
             wrapper.find("#run-form-group button").trigger("click");
@@ -588,7 +591,7 @@ describe("runReport", () => {
         expect(wrapper.find("#changelog-type").exists()).toBe(false);
     });
 
-    it("it can accepts changelog  and type log message values", () => {
+    it("it can accepts changelog  and type log message values", async () => {
         const changelogTypes =  ["internal", "public"]
         const wrapper = mount(RunReport, {
             propsData: {
@@ -599,24 +602,22 @@ describe("runReport", () => {
                 initialGitBranches
             },
             data() {
-            return {
-                selectedReport: "report",
-                changeLogMessageValue: "Text area message",
-                changeLogTypeValue: "selectedType"
+                return {
+                    selectedReport: "report"
+                }
             }
-        }
         });
 
         const label = ["col-form-label", "col-sm-2", "text-right"]
         const control = ["col-sm-6"]
 
-        const options = wrapper.find("#changelogType")
-            .find("select").findAll("option")
-        options.at(1).setSelected()
-        expect(wrapper.vm.$data.changeLogTypeValue).toBe("public")
+        await wrapper.find("#changelogMessage").setValue("Message")
+        const options = wrapper.find("#changelogType").findAll("select option")
+        await options.at(1).setSelected()
+        expect(wrapper.vm.$data.changelog.type).toBe("public")
 
-        wrapper.find("#changelogMessage").setValue("New message")
-        expect(wrapper.vm.$data.changeLogMessageValue).toBe("New message")
+        await wrapper.find("#changelogMessage").setValue("New message")
+        expect(wrapper.vm.$data.changelog.message).toBe("New message")
 
         const changelogMessage = wrapper.find(changeLog).find("#changelog-message")
         const changelogType= wrapper.find(changeLog).find("#changelog-type")

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowRun.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowRun.test.ts
@@ -258,12 +258,12 @@ describe(`runWorkflowRun`, () => {
             expect(changelog.find("textarea").exists()).toBe(true)
 
             // expect initial emit of default selected type + selected instances
-            expect(wrapper.emitted().update.length).toBe(2);
-            expect(wrapper.emitted().update[1][0]).toStrictEqual({changelog: {message: "", type: "internal"}})
+            expect(wrapper.emitted().update.length).toBe(2)
+            expect(wrapper.emitted().update[1][0]).toStrictEqual({changelog: null})
 
             await textarea.setValue("test message input")
-            expect(wrapper.emitted().update.length).toBe(3);
-            expect(wrapper.emitted().update[2][0]).toStrictEqual({changelog: {message: "test message input", type: ""}})
+            expect(wrapper.emitted().update.length).toBe(3)
+            expect(wrapper.emitted().update[2][0]).toStrictEqual({changelog: {message: "test message input", type: "internal"}})
             done()
         })
     });
@@ -314,13 +314,19 @@ describe(`runWorkflowRun`, () => {
     it(`emits update on changelog type change`, async (done) => {
         const wrapper = getWrapper();
 
-        setTimeout(async () => {
-            const changelogType = wrapper.find("#changelog-type");
+        setTimeout(async() => {
+            const changelogType = wrapper.find("#changelog-type")
             expect(wrapper.find("#changelog-type label").text()).toEqual("Changelog Type");
-            const selectOptions = changelogType.find("select")
-            selectOptions.setValue(changelogTypes[1]);
-            expect(wrapper.emitted().update.length).toBe(3);
-            expect(wrapper.emitted().update[2][0]).toStrictEqual({changelog: {message: "", type: "public"}});
+
+            await wrapper.find("#changelog-message").find("textarea").setValue("test message input")
+            await changelogType.find("select").setValue(changelogTypes[1])
+            expect(wrapper.emitted().update.length).toBe(4)
+            expect(wrapper.emitted().update[3][0]).toStrictEqual({
+                changelog: {
+                    message: "test message input",
+                    type: "public"
+                }
+            })
             done()
         })
     })


### PR DESCRIPTION
- Modify the `<change-log>` component to emit an object `{type, message}` rather than `type` and `message` strings separately, and make corresponding changes to downstream components for running reports and workflows
- This is better because a changelog with an empty message is invalid and rejected by orderly
- So the component now only emits valid changelog items: either `null` (which means no changelog and is already removed by Kotlin before request is sent to orderly.server) or an fully populated object
- This means that `runWorkflowMetadata` never contains values for `changelog` that aren't valid - which was previously the case and prevented workflows that didn't have a changelog message from being executed successfully (obviously only the case where changelog itself was enabled i.e. more than one type was specified in the orderly config).
- Overall this is a simplification and reduces total amount of code
- I haven't changed the pattern of the component emitting on mount, even though it will always emit null because the message textbox will always be empty (even if re-running - as this field is not repopulated here). In two minds about this - opinions welcome.
- No user-visible changes here. To test you can try submitting a workflow using mrc-2323 with an empty changelog message and observe failure. Then apply this patch (it applies cleanly at time of writing) and try again. Obviously running reports with changelogs should still work too...
- This PR doesn't actually depend on mrc-2323, but that branch allows workflow submission via UI and therefore manual testing