### PR TITLE
mrc-2593 Make orderly server container depends on redis container

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - ${MONTAGU_ORDERLY_PATH}:/orderly
     environment:
       REDIS_URL: redis://redis
+    depends_on:
+      - "redis"
   api:
     image: vimc/montagu-api:master
     ports:


### PR DESCRIPTION
I found that local dependencies were still intermittently failing to start the orderly server container. The error logged was `Error in redis_connect_tcp... Failed to create context: Connection refused.` suggesting that the redis container was not available when orderly server started up - but needs to be.

Updated the docker compose file to specify that the orderly server container depends on the redis container, meaning that redis will be started before orderly server. (see https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on)
This *seems* to have fixed the problem - @richfitz does this sound plausible?

