### PR TITLE
mrc-2625 Fix workflow display of long report names

### DIFF
--- a/src/app/static/src/js/components/runWorkflow/runWorkflowReport.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowReport.vue
@@ -14,7 +14,7 @@
         <h2 id="add-report-header" class="pb-2">Add reports</h2>
         <div v-if="isReady">
             <div class="pb-4">
-                <h2 id="git-header">Git</h2>
+                <h3 id="git-header">Git</h3>
                 <div>
                     <git-update-reports
                         :report-metadata="runReportMetadata"
@@ -28,14 +28,14 @@
                 </div>
             </div>
             <div class="pb-4" id="workflow-reports">
-                <h2 id="report-sub-header">Reports</h2>
+                <h3 id="report-sub-header">Reports</h3>
                 <div>
                     <div v-for="(report, index) in workflowMetadata.reports"
                          :id="`workflow-report-${index}`"
                          :key="index"
                          class="form-group row">
 
-                        <label class="col-sm-2 col-form-label text-right">{{report.name}}</label>
+                        <label class="col-sm-2 col-form-label text-right text-truncate" :title="report.name">{{report.name}}</label>
                         <parameter-list
                             v-if="reportParameters[index].length > 0"
                             :params="reportParameters[index]"

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
@@ -207,12 +207,14 @@ describe(`runWorkflowReport`, () => {
 
             const report1Div = workflowReports.find("#workflow-report-0");
             expect(report1Div.find("label").text()).toBe("minimal");
+            expect(report1Div.find("label").attributes("title")).toBe("minimal");
             expect(report1Div.find("parameter-list-stub").exists()).toBe(false);
             expect(report1Div.find(".no-parameters").text()).toBe("No parameters");
             expect(report1Div.find(".remove-report-button").text()).toBe("Remove report");
 
             const report2Div = workflowReports.find("#workflow-report-1");
             expect(report2Div.find("label").text()).toBe("other");
+            expect(report2Div.find("label").attributes("title")).toBe("other");
             expect(report2Div.find("parameter-list-stub").exists()).toBe(true);
             expect(report2Div.find("parameter-list-stub").props("params")).toStrictEqual([
                 {"name": "p1", "value": "v1"},


### PR DESCRIPTION
- Truncate label and make full name available via tooltip
- Also fix header sizes - previously all `<h2>`
- We could also potentially increase `col-sm-2` to `col-sm-3` to allow more of the name to be displayed - we have the horizontal space to do this without reducing width of other inputs. But this would require similar change to git component, and therefore report running page too (unless we make width configurable via props, or change page layouts to be more automatically adaptive).
- To test:
  - Run app, using git model
  - Create a new report with a long name:
    ```shell
    docker exec -it -w /orderly/upstream/src montagu_orderly_server_1 bash
    cp -r global new_report_with_a_much_longer_name
    git add .
    git commit -m new_report
    ```
  - Go to http://localhost:8888/run-workflow
  - Create a blank workflow
  - Refresh git
  - Add report with long name to workflow

- Preview:

![Screenshot from 2021-09-30 16-10-17](https://user-images.githubusercontent.com/1724545/135484422-b4c5f4c8-764b-415e-a0e0-e66f1de98a28.png)