### PR TITLE
mrc-2720 Validate workflow csv against orderly

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/ActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/ActionContext.kt
@@ -16,7 +16,7 @@ interface ActionContext
     fun contentType(): String
 
     fun queryString(): String?
-    fun queryParams(): Map<String, String?>
+    fun queryParams(): Map<String, String>
     fun queryParams(key: String): String?
     fun params(): Map<String, String?>
     fun params(key: String): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
@@ -35,7 +35,7 @@ open class DirectActionContext(
     constructor(request: Request, response: Response) : this(SparkWebContext(request, response))
 
     override fun contentType(): String = request.contentType()
-    override fun queryParams(): Map<String, String?> = request.queryParams().associateWith { request.queryParams(it) }
+    override fun queryParams(): Map<String, String> = request.queryParams().associateWith { request.queryParams(it) }
     override fun queryParams(key: String): String? = request.queryParams(key)
     override fun queryString(): String? = request.queryString()
     override fun params(): Map<String, String?> = request.params()

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/DirectActionContext.kt
@@ -7,6 +7,7 @@ import org.pac4j.core.profile.ProfileManager
 import org.pac4j.sparkjava.SparkWebContext
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.Config
+import org.vaccineimpact.orderlyweb.errors.BadRequest
 import org.vaccineimpact.orderlyweb.errors.MissingParameterError
 import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
 import org.vaccineimpact.orderlyweb.models.Scope
@@ -129,6 +130,10 @@ open class DirectActionContext(
 
     override fun getPartReader(partName: String): Reader
     {
+        if (request.contentLength() == 0) {
+            throw BadRequest("No data provided")
+        }
+
         request.attribute("org.eclipse.jetty.multipartConfig",
             MultipartConfigElement(System.getProperty("java.io.tmpdir")))
         val stream = request.raw().getPart(partName).inputStream

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -39,7 +39,7 @@ interface OrderlyServerAPI
     fun get(url: String, context: ActionContext): OrderlyServerResponse
 
     @Throws(OrderlyServerError::class)
-    fun get(url: String, queryParams: Map<String, String?>): OrderlyServerResponse
+    fun get(url: String, queryParams: Map<String, String>): OrderlyServerResponse
 
     @Throws(OrderlyServerError::class)
     fun delete(url: String, context: ActionContext): OrderlyServerResponse
@@ -47,10 +47,10 @@ interface OrderlyServerAPI
     fun throwOnError(): OrderlyServerAPI
 
     @Throws(OrderlyServerError::class)
-    fun getRunnableReportNames(queryParams: Map<String, String?>): List<String>
+    fun getRunnableReportNames(queryParams: Map<String, String>): List<String>
 
     @Throws(OrderlyServerError::class)
-    fun getReportParameters(reportName: String, queryParams: Map<String, String?>): List<Parameter>
+    fun getReportParameters(reportName: String, queryParams: Map<String, String>): List<Parameter>
 }
 
 class OrderlyServerResponse(val bytes: ByteArray, val statusCode: Int)
@@ -112,7 +112,7 @@ class OrderlyServer(
         return transformResponse(response.code, response.body!!.string())
     }
 
-    override fun get(url: String, queryParams: Map<String, String?>): OrderlyServerResponse
+    override fun get(url: String, queryParams: Map<String, String>): OrderlyServerResponse
     {
         val buildUrl = urlBase.toHttpUrl().newBuilder()
                 .addPathSegments(url.trimStart('/'))
@@ -212,12 +212,12 @@ class OrderlyServer(
         return transformResponse(response.code, response.body!!.string())
     }
 
-    override fun getRunnableReportNames(queryParams: Map<String, String?>): List<String>
+    override fun getRunnableReportNames(queryParams: Map<String, String>): List<String>
     {
         return get("/reports/source", queryParams).listData(String::class.java)
     }
 
-    override fun getReportParameters(reportName: String, queryParams: Map<String, String?>): List<Parameter>
+    override fun getReportParameters(reportName: String, queryParams: Map<String, String>): List<Parameter>
     {
         return get("/reports/$reportName/parameters", queryParams).listData(Parameter::class.java)
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -39,7 +39,7 @@ interface OrderlyServerAPI
     fun get(url: String, context: ActionContext): OrderlyServerResponse
 
     @Throws(OrderlyServerError::class)
-    fun get(url: String, queryParams: Map<String, String>): OrderlyServerResponse
+    fun get(url: String, queryParams: Map<String, String?>): OrderlyServerResponse
 
     @Throws(OrderlyServerError::class)
     fun delete(url: String, context: ActionContext): OrderlyServerResponse
@@ -47,10 +47,10 @@ interface OrderlyServerAPI
     fun throwOnError(): OrderlyServerAPI
 
     @Throws(OrderlyServerError::class)
-    fun getRunnableReportNames(context: ActionContext): List<String>
+    fun getRunnableReportNames(queryParams: Map<String, String?>): List<String>
 
     @Throws(OrderlyServerError::class)
-    fun getReportParameters(reportName: String, context: ActionContext): List<Parameter>
+    fun getReportParameters(reportName: String, queryParams: Map<String, String?>): List<Parameter>
 }
 
 class OrderlyServerResponse(val bytes: ByteArray, val statusCode: Int)
@@ -112,7 +112,7 @@ class OrderlyServer(
         return transformResponse(response.code, response.body!!.string())
     }
 
-    override fun get(url: String, queryParams: Map<String, String>): OrderlyServerResponse
+    override fun get(url: String, queryParams: Map<String, String?>): OrderlyServerResponse
     {
         val buildUrl = urlBase.toHttpUrl().newBuilder()
                 .addPathSegments(url.trimStart('/'))
@@ -212,12 +212,15 @@ class OrderlyServer(
         return transformResponse(response.code, response.body!!.string())
     }
 
-    override fun getRunnableReportNames(context: ActionContext): List<String> =
-        get("/reports/source", context).listData(String::class.java)
+    override fun getRunnableReportNames(queryParams: Map<String, String?>): List<String>
+    {
+        return get("/reports/source", queryParams).listData(String::class.java)
+    }
 
-    override fun getReportParameters(reportName: String, context: ActionContext): List<Parameter> =
-            get("/reports/$reportName/parameters", context)
-                .listData(Parameter::class.java)
+    override fun getReportParameters(reportName: String, queryParams: Map<String, String?>): List<Parameter>
+    {
+        return get("/reports/$reportName/parameters", queryParams).listData(Parameter::class.java)
+    }
 
     private fun transformResponse(code: Int, text: String): OrderlyServerResponse
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/OrderlyServerAPI.kt
@@ -16,6 +16,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.errors.OrderlyServerError
+import org.vaccineimpact.orderlyweb.models.Parameter
 
 interface OrderlyServerAPI
 {
@@ -44,6 +45,12 @@ interface OrderlyServerAPI
     fun delete(url: String, context: ActionContext): OrderlyServerResponse
 
     fun throwOnError(): OrderlyServerAPI
+
+    @Throws(OrderlyServerError::class)
+    fun getRunnableReportNames(context: ActionContext): List<String>
+
+    @Throws(OrderlyServerError::class)
+    fun getReportParameters(reportName: String, context: ActionContext): List<Parameter>
 }
 
 class OrderlyServerResponse(val bytes: ByteArray, val statusCode: Int)
@@ -204,6 +211,13 @@ class OrderlyServer(
         }
         return transformResponse(response.code, response.body!!.string())
     }
+
+    override fun getRunnableReportNames(context: ActionContext): List<String> =
+        get("/reports/source", context).listData(String::class.java)
+
+    override fun getReportParameters(reportName: String, context: ActionContext): List<Parameter> =
+            get("/reports/$reportName/parameters", context)
+                .listData(Parameter::class.java)
 
     private fun transformResponse(code: Int, text: String): OrderlyServerResponse
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -66,7 +66,7 @@ class ReportController(
 
     fun getRunnableReports(): List<ReportWithDate>
     {
-        val reports = orderlyServerAPI.getRunnableReportNames(context)
+        val reports = orderlyServerAPI.getRunnableReportNames(context.queryParams())
         val versionedReports = reportRepository.getLatestReportVersions(reports)
         return reports.map { name -> ReportWithDate(name, versionedReports.find { it.name == name }?.date) }
     }
@@ -74,7 +74,7 @@ class ReportController(
     fun getReportParameters(): List<Parameter>
     {
         val name = context.params(":name")
-        return orderlyServerAPI.getReportParameters(name, context)
+        return orderlyServerAPI.getReportParameters(name, context.queryParams())
     }
 
     fun tagVersion(): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/ReportController.kt
@@ -66,7 +66,7 @@ class ReportController(
 
     fun getRunnableReports(): List<ReportWithDate>
     {
-        val reports = orderlyServerAPI.get("/reports/source", context).listData(String::class.java)
+        val reports = orderlyServerAPI.getRunnableReportNames(context)
         val versionedReports = reportRepository.getLatestReportVersions(reports)
         return reports.map { name -> ReportWithDate(name, versionedReports.find { it.name == name }?.date) }
     }
@@ -74,9 +74,7 @@ class ReportController(
     fun getReportParameters(): List<Parameter>
     {
         val name = context.params(":name")
-        return orderlyServerAPI
-                .get("/reports/$name/parameters", context)
-                .listData(Parameter::class.java)
+        return orderlyServerAPI.getReportParameters(name, context)
     }
 
     fun tagVersion(): String

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
@@ -160,9 +160,9 @@ class WorkflowRunController(
     fun validateWorkflow(): List<WorkflowReportWithParams>
     {
         val reader = context.getPartReader("file")
+        val branch = context.queryParams("branch")
+        val commit = context.queryParams("commit")
 
-        val workflowReports = workflowLogic.parseAndValidateWorkflowCSV(reader, context, orderlyServerAPI)
-
-        return workflowReports
+        return workflowLogic.parseAndValidateWorkflowCSV(reader, branch, commit, orderlyServerAPI)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
@@ -160,7 +160,9 @@ class WorkflowRunController(
     fun validateWorkflow(): List<WorkflowReportWithParams>
     {
         val reader = context.getPartReader("file")
-        val workflowReports = workflowLogic.parseWorkflowCSV(reader)
+
+        //TODO: use gitBranch and git commit - these are coming from the context in the default usage in the orderly helper methods!
+        val workflowReports = workflowLogic.parseAndValidateWorkflowCSV(reader, context, orderlyServerAPI)
 
         // These will be used when we validate against orderly reports in mrc-2720
         val gitBranch = context.getPart("git_branch")

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
@@ -163,6 +163,6 @@ class WorkflowRunController(
         val branch = context.queryParams("branch")
         val commit = context.queryParams("commit")
 
-        return workflowLogic.parseAndValidateWorkflowCSV(reader, branch, commit, orderlyServerAPI)
+        return workflowLogic.parseAndValidateWorkflowCSV(reader, branch, commit)
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
@@ -161,12 +161,7 @@ class WorkflowRunController(
     {
         val reader = context.getPartReader("file")
 
-        //TODO: use gitBranch and git commit - these are coming from the context in the default usage in the orderly helper methods!
         val workflowReports = workflowLogic.parseAndValidateWorkflowCSV(reader, context, orderlyServerAPI)
-
-        // These will be used when we validate against orderly reports in mrc-2720
-        val gitBranch = context.getPart("git_branch")
-        val gitCommit = context.getPart("git_commit")
 
         return workflowReports
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/BadRequest.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/BadRequest.kt
@@ -2,7 +2,8 @@ package org.vaccineimpact.orderlyweb.errors
 
 import org.vaccineimpact.orderlyweb.models.ErrorInfo
 
-class BadRequest(message: String)
-    : OrderlyWebError(400, listOf(ErrorInfo("bad-request", message)))
-
-
+class BadRequest(messages: List<String>)
+    : OrderlyWebError(400, messages.map{ ErrorInfo("bad-request", it) })
+{
+    constructor(message: String) : this(listOf(message))
+}

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/BadRequest.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/BadRequest.kt
@@ -4,3 +4,5 @@ import org.vaccineimpact.orderlyweb.models.ErrorInfo
 
 class BadRequest(message: String)
     : OrderlyWebError(400, listOf(ErrorInfo("bad-request", message)))
+
+

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
@@ -56,7 +56,7 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
             val numCells = row.count()
             if (numCells != numCols)
             {
-                errors.add(errorTemplate(rowIdx + 1, "row should contain $numCols values, ${numCells} values found"))
+                errors.add(errorTemplate(rowIdx + 1, "row should contain $numCols values, $numCells values found"))
             }
 
             val reportName = row[0]

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
@@ -84,10 +84,21 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
         errorTemplate: (index: Int, msg: String) -> String
     ): List<String>
     {
-        val runnableReports = orderly.getRunnableReportNames(mapOf("branch" to branch, "commit" to commit))
+        val reportsQsParams: MutableMap<String, String> = mutableMapOf()
+        val parametersQsParams: MutableMap<String, String> = mutableMapOf()
+        if (commit != null)
+        {
+            reportsQsParams["commit"] = commit
+            parametersQsParams["commit"] = commit
+        }
+        if (branch != null)
+        {
+            reportsQsParams["branch"] = branch
+        }
+
+        val runnableReports = orderly.getRunnableReportNames(reportsQsParams)
         val knownOrderlyReportParams: MutableMap<String, List<Parameter>> = mutableMapOf()
         val errors: MutableList<String> = mutableListOf()
-        val getParamsQs = mapOf("commit" to commit)
 
         reports.forEachIndexed { index, report ->
             val reportIdx = index + 1
@@ -100,7 +111,7 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
                 var orderlyParamsList = knownOrderlyReportParams[report.name]
                 if (orderlyParamsList == null)
                 {
-                    orderlyParamsList = orderly.getReportParameters(report.name, getParamsQs)
+                    orderlyParamsList = orderly.getReportParameters(report.name, parametersQsParams)
                     knownOrderlyReportParams[report.name] = orderlyParamsList
                 }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
@@ -10,15 +10,20 @@ import java.io.Reader
 
 interface WorkflowLogic
 {
-    fun parseAndValidateWorkflowCSV(reader: Reader, context: ActionContext, orderly: OrderlyServerAPI): List<WorkflowReportWithParams>
+    fun parseAndValidateWorkflowCSV(
+        reader: Reader,
+        context: ActionContext,
+        orderly: OrderlyServerAPI
+    ): List<WorkflowReportWithParams>
 }
 
 class OrderlyWebWorkflowLogic : WorkflowLogic
 {
     override fun parseAndValidateWorkflowCSV(
-            reader: Reader,
-            context: ActionContext,
-            orderly: OrderlyServerAPI): List<WorkflowReportWithParams>
+        reader: Reader,
+        context: ActionContext,
+        orderly: OrderlyServerAPI
+    ): List<WorkflowReportWithParams>
     {
         val rows = CSVReader(reader).use { it.readAll() }
         if (rows.isEmpty())
@@ -56,7 +61,7 @@ class OrderlyWebWorkflowLogic : WorkflowLogic
         }
 
         val errorTemplate = { index: Int, msg: String -> "Report row $index: $msg" }
-        errors+= validateWorkflowReports(reports, orderly, context, errorTemplate)
+        errors += validateWorkflowReports(reports, orderly, context, errorTemplate)
 
         if (errors.isNotEmpty())
         {
@@ -91,11 +96,19 @@ class OrderlyWebWorkflowLogic : WorkflowLogic
                 }
 
                 val orderlyParams = knownOrderlyReportParams[report.name]!!.associate{ it.name to it }
-                val missingParameters = orderlyParams.values.filter{ it.value == "" && !report.params.keys.contains(it.name) }
-                missingParameters.forEach{ errors.add(reportIdx, "required parameter '${it.name}' was not provided for report '${report.name}'") }
+                val missingParameters = orderlyParams.values
+                        .filter{ it.value == "" && !report.params.keys.contains(it.name) }
+                missingParameters.forEach{
+                    errors.add(
+                            reportIdx,
+                            "required parameter '${it.name}' was not provided for report '${report.name}'"
+                    )
+                }
 
                 val unexpectedParameters = report.params.keys.filterNot{ orderlyParams.keys.contains(it) }
-                unexpectedParameters.forEach{ errors.add(reportIdx, "unexpected parameter '$it' provided for report '${report.name}'") }
+                unexpectedParameters.forEach{
+                    errors.add(reportIdx, "unexpected parameter '$it' provided for report '${report.name}'")
+                }
             }
         }
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
@@ -1,7 +1,9 @@
 package org.vaccineimpact.orderlyweb.logic
 
 import com.opencsv.CSVReader
+import org.vaccineimpact.orderlyweb.OrderlyServer
 import org.vaccineimpact.orderlyweb.OrderlyServerAPI
+import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.errors.BadRequest
 import org.vaccineimpact.orderlyweb.models.Parameter
 import org.vaccineimpact.orderlyweb.models.WorkflowReportWithParams
@@ -12,18 +14,18 @@ interface WorkflowLogic
     fun parseAndValidateWorkflowCSV(
         reader: Reader,
         branch: String?,
-        commit: String?,
-        orderly: OrderlyServerAPI
+        commit: String?
     ): List<WorkflowReportWithParams>
 }
 
-class OrderlyWebWorkflowLogic : WorkflowLogic
+class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowLogic
 {
+    constructor() : this(OrderlyServer(AppConfig()).throwOnError())
+
     override fun parseAndValidateWorkflowCSV(
         reader: Reader,
         branch: String?,
-        commit: String?,
-        orderly: OrderlyServerAPI
+        commit: String?
     ): List<WorkflowReportWithParams>
     {
         val rows = CSVReader(reader).use { it.readAll() }
@@ -43,14 +45,18 @@ class OrderlyWebWorkflowLogic : WorkflowLogic
             throw BadRequest("File contains no reports")
         }
 
-        val columnCount = headers.count()
+        val numCols = headers.count()
+
+        // We expect the headers to be "report", param1, param2,...paramN
         val paramNames = headers.drop(1)
 
         val errors: MutableList<String> = mutableListOf()
+        val errorTemplate = { index: Int, msg: String -> "Report row $index: $msg" }
         val reports = rows.drop(1).mapIndexed { rowIdx, row ->
-            if (row.count() != columnCount)
+            val numCells = row.count()
+            if (numCells != numCols)
             {
-                errors.add("Report row ${rowIdx + 1} should contain $columnCount values, ${row.count()} values found")
+                errors.add(errorTemplate(rowIdx + 1, "row should contain $numCols values, ${numCells} values found"))
             }
 
             val reportName = row[0]
@@ -61,8 +67,7 @@ class OrderlyWebWorkflowLogic : WorkflowLogic
             WorkflowReportWithParams(reportName, parameters)
         }
 
-        val errorTemplate = { index: Int, msg: String -> "Report row $index: $msg" }
-        errors += validateWorkflowReports(reports, branch, commit, orderly, errorTemplate)
+        errors += validateWorkflowReports(reports, branch, commit, errorTemplate)
 
         if (errors.isNotEmpty())
         {
@@ -76,7 +81,6 @@ class OrderlyWebWorkflowLogic : WorkflowLogic
         reports: List<WorkflowReportWithParams>,
         branch: String?,
         commit: String?,
-        orderly: OrderlyServerAPI,
         errorTemplate: (index: Int, msg: String) -> String
     ): List<String>
     {

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
@@ -56,8 +56,8 @@ class OrderlyWebWorkflowLogic : WorkflowLogic
 
             val reportName = row[0]
             val parameters = paramNames.mapIndexed { i, name ->
-                name to row[i + 1]
-            }.filter { it.second.isNotBlank() }.toMap()
+                name to if (row.count() > i + 1) row[i + 1] else ""
+            }.filter { it.second.isNotEmpty() }.toMap()
 
             WorkflowReportWithParams(reportName, parameters)
         }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Report.kt
@@ -19,4 +19,4 @@ data class ReportWithDate
 constructor(val name: String, val date: Instant?)
 
 data class Parameter
-constructor(val name: String, val value: String)
+constructor(val name: String, val value: String?)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/IntegrationTest.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/IntegrationTest.kt
@@ -1,12 +1,16 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests
 
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
 import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.vaccineimpact.orderlyweb.ContentTypes
+import org.vaccineimpact.orderlyweb.OrderlyServer
 import org.vaccineimpact.orderlyweb.app_start.main
 import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.models.GitCommit
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.test_helpers.JSONValidator
 import org.vaccineimpact.orderlyweb.test_helpers.http.Response
@@ -123,5 +127,16 @@ abstract class IntegrationTest
         {
             checker.checkPermissionIsRequired(permission)
         }
+    }
+
+    protected fun getGitBranchCommit(branch: String): String
+    {
+        val commits = OrderlyServer(AppConfig()).get(
+                "/git/commits",
+                context = mock {
+                    on { queryString() } doReturn "branch=$branch"
+                }
+        )
+        return commits.listData(GitCommit::class.java).first().id
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RunReportPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RunReportPageTests.kt
@@ -2,21 +2,16 @@ package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.*
 import org.eclipse.jetty.http.HttpStatus
 import org.jsoup.Jsoup
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.*
 import org.vaccineimpact.orderlyweb.controllers.web.ReportController
-import org.vaccineimpact.orderlyweb.controllers.web.ReportRunController
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyReportRepository
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyWebReportRunRepository
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyWebTagRepository
-import org.vaccineimpact.orderlyweb.db.repositories.ReportRunRepository
-import org.vaccineimpact.orderlyweb.models.GitCommit
-import org.vaccineimpact.orderlyweb.models.ReportRunLog
 import org.vaccineimpact.orderlyweb.models.ReportWithDate
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RunReportPageTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/RunReportPageTests.kt
@@ -57,13 +57,7 @@ class RunReportPageTests : IntegrationTest()
     fun `can return parameter data`()
     {
         val branch = "master"
-        val commits = OrderlyServer(AppConfig()).get(
-                "/git/commits",
-                context = mock {
-                    on { queryString() } doReturn "branch=$branch"
-                }
-        )
-        val commit = commits.listData(GitCommit::class.java).first().id
+        val commit = getGitBranchCommit(branch)
         val url = "/report/minimal/config/parameters/?commit=$commit"
 
         val response = webRequestHelper.loginWithMontaguAndMakeRequest(url,
@@ -114,13 +108,7 @@ class RunReportPageTests : IntegrationTest()
     fun `lists runnable reports`()
     {
         val branch = "master"
-        val commits = OrderlyServer(AppConfig()).get(
-                "/git/commits",
-                context = mock {
-                    on { queryString() } doReturn "branch=$branch"
-                }
-        )
-        val commit = commits.listData(GitCommit::class.java).first().id
+        val commit = getGitBranchCommit(branch)
         val repo = OrderlyReportRepository(true, false)
         val controller = ReportController(
                 mock {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -287,11 +287,11 @@ class WorkflowRunTests : IntegrationTest()
         """.trimIndent()
         val response = webRequestHelper.requestWithSessionCookie(
             url,
-                sessionCookie,
-                ContentTypes.json,
-                HttpMethod.post,
-                formData,
-                mapOf("Content-Type" to ContentTypes.multipart + ";boundary=XXXX")
+            sessionCookie,
+            ContentTypes.json,
+            HttpMethod.post,
+            formData,
+            mapOf("Content-Type" to ContentTypes.multipart + ";boundary=XXXX")
         )
         assertSuccessful(response)
         assertJsonContentType(response)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -2,8 +2,6 @@ package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
 
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.github.fge.jackson.JsonLoader
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jetty.http.HttpStatus
 import org.jsoup.Jsoup

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -261,7 +261,18 @@ class WorkflowRunTests : IntegrationTest()
     }
 
     @Test
-    fun `validates workflow for default git branch and commit`()
+    fun `validates workflow with missing branch and commit parameters`()
+    {
+        validateWorkflowWithDefaultBranchAncCommit("/workflow/validate")
+    }
+
+    @Test
+    fun `validates workflow with empty branch and commit parameters`()
+    {
+        validateWorkflowWithDefaultBranchAncCommit("/workflow/validate?branch&commit")
+    }
+
+    fun validateWorkflowWithDefaultBranchAncCommit(url: String)
     {
         val sessionCookie = webRequestHelper.webLoginWithMontagu(runReportsPerm)
         val formData = """
@@ -275,7 +286,7 @@ class WorkflowRunTests : IntegrationTest()
         --XXXX--
         """.trimIndent()
         val response = webRequestHelper.requestWithSessionCookie(
-            "/workflow/validate",
+            url,
                 sessionCookie,
                 ContentTypes.json,
                 HttpMethod.post,

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.github.fge.jackson.JsonLoader
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
@@ -131,13 +132,7 @@ class WorkflowRunTests : IntegrationTest()
     fun `runs workflow`()
     {
         val branch = "other"
-        val commits = OrderlyServer(AppConfig()).get(
-            "/git/commits",
-            context = mock {
-                on { queryString() } doReturn "branch=$branch"
-            }
-        )
-        val commit = commits.listData(GitCommit::class.java).first().id
+        val commit = getGitBranchCommit("other")
 
         val json = """
                 {
@@ -266,7 +261,7 @@ class WorkflowRunTests : IntegrationTest()
     }
 
     @Test
-    fun `validates workflow`()
+    fun `validates workflow for default git branch and commit`()
     {
         val sessionCookie = webRequestHelper.webLoginWithMontagu(runReportsPerm)
         val formData = """
@@ -274,17 +269,9 @@ class WorkflowRunTests : IntegrationTest()
         Content-Disposition: form-data; name="file"; filename="test.csv"
         Content-Type: text/csv
         
-        report,disease,year
-        test1,HepB,2020
-        test2,Rubella,2021
-        --XXXX
-        Content-Disposition: form-data; name="git_branch"
-
-        test-branch
-        --XXXX
-        Content-Disposition: form-data; name="git_commit"
-
-        123abc
+        report
+        global
+        minimal
         --XXXX--
         """.trimIndent()
         val response = webRequestHelper.requestWithSessionCookie(
@@ -301,20 +288,58 @@ class WorkflowRunTests : IntegrationTest()
         val reports = JSONValidator.getData(response.text) as ArrayNode
         assertThat(reports.count()).isEqualTo(2)
         val report1 = reports[0]
-        assertThat(report1["name"].asText()).isEqualTo("test1")
-        assertThat(report1["params"]["disease"].asText()).isEqualTo("HepB")
-        assertThat(report1["params"]["year"].asText()).isEqualTo("2020")
+        assertThat(report1["name"].asText()).isEqualTo("global")
+        assertThat(report1["params"].isEmpty(null)).isTrue()
+
 
         val report2 = reports[1]
-        assertThat(report2["name"].asText()).isEqualTo("test2")
-        assertThat(report2["params"]["disease"].asText()).isEqualTo("Rubella")
-        assertThat(report2["params"]["year"].asText()).isEqualTo("2021")
+        assertThat(report2["name"].asText()).isEqualTo("minimal")
+        assertThat(report2["params"].isEmpty(null)).isTrue()
     }
 
     @Test
-    fun `returns workflow validation error`()
+    fun `validates workflow for non-default git branch and commit`()
     {
+        val branch = "other"
+        val commit = getGitBranchCommit(branch)
+
         val sessionCookie = webRequestHelper.webLoginWithMontagu(runReportsPerm)
+        val formData = """
+        --XXXX
+        Content-Disposition: form-data; name="file"; filename="test.csv"
+        Content-Type: text/csv
+        
+        report,nmin
+        other,1
+        other,2
+        --XXXX--
+        """.trimIndent()
+        val response = webRequestHelper.requestWithSessionCookie(
+                "/workflow/validate?branch=$branch&commit=$commit",
+                sessionCookie,
+                ContentTypes.json,
+                HttpMethod.post,
+                formData,
+                mapOf("Content-Type" to ContentTypes.multipart + ";boundary=XXXX")
+        )
+        assertSuccessful(response)
+        assertJsonContentType(response)
+
+        val reports = JSONValidator.getData(response.text) as ArrayNode
+        assertThat(reports.count()).isEqualTo(2)
+        val report1 = reports[0]
+        assertThat(report1["name"].asText()).isEqualTo("other")
+        assertThat(report1["params"]["nmin"].asText()).isEqualTo("1")
+
+        val report2 = reports[1]
+        assertThat(report2["name"].asText()).isEqualTo("other")
+        assertThat(report2["params"]["nmin"].asText()).isEqualTo("2")
+    }
+
+    @Test
+    fun `returns workflow header validation error`()
+    {
+       val sessionCookie = webRequestHelper.webLoginWithMontagu(runReportsPerm)
         val formData = """
         --XXXX
         Content-Disposition: form-data; name="file"; filename="test.csv"
@@ -322,14 +347,6 @@ class WorkflowRunTests : IntegrationTest()
         
         BADHEADER,disease,year
         test1,HepB,2020
-        --XXXX
-        Content-Disposition: form-data; name="git_branch"
-
-        test-branch
-        --XXXX
-        Content-Disposition: form-data; name="git_commit"
-
-        123abc
         --XXXX--
         """.trimIndent()
         val response = webRequestHelper.requestWithSessionCookie(
@@ -342,6 +359,45 @@ class WorkflowRunTests : IntegrationTest()
         )
         assertThat(response.statusCode).isEqualTo(400)
         JSONValidator.validateError(response.text, "bad-request", "First header must be 'report'")
+    }
+
+    @Test
+    fun `returns workflow report validation errors`()
+    {
+        val branch = "other"
+        val commit = getGitBranchCommit(branch)
+
+        val sessionCookie = webRequestHelper.webLoginWithMontagu(runReportsPerm)
+        val formData = """
+        --XXXX
+        Content-Disposition: form-data; name="file"; filename="test.csv"
+        Content-Type: text/csv
+        
+        report,nmin
+        other,1
+        other,
+        other,3,4
+        nonexistent,5
+        --XXXX--
+        """.trimIndent()
+        val response = webRequestHelper.requestWithSessionCookie(
+                "/workflow/validate?branch=$branch&commit=$commit",
+                sessionCookie,
+                ContentTypes.json,
+                HttpMethod.post,
+                formData,
+                mapOf("Content-Type" to ContentTypes.multipart + ";boundary=XXXX")
+        )
+
+        assertThat(response.statusCode).isEqualTo(400)
+        val errors = JsonLoader.fromString(response.text)["errors"] as ArrayNode
+        assertThat(errors.count()).isEqualTo(3)
+        assertThat(errors[0]["message"].asText()).isEqualTo("Report row 3 should contain 2 values, 3 values found")
+        assertThat(errors[0]["code"].asText()).isEqualTo("bad-request")
+        assertThat(errors[1]["message"].asText()).isEqualTo("Report row 2: required parameter 'nmin' was not provided for report 'other'")
+        assertThat(errors[1]["code"].asText()).isEqualTo("bad-request")
+        assertThat(errors[2]["message"].asText()).isEqualTo("Report row 4: report 'nonexistent' not found in Orderly")
+        assertThat(errors[2]["code"].asText()).isEqualTo("bad-request")
     }
 
     private fun addWorkflowRunExample()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/DirectActionContextTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/DirectActionContextTests.kt
@@ -10,6 +10,7 @@ import org.pac4j.core.profile.ProfileManager
 import org.pac4j.sparkjava.SparkWebContext
 import org.vaccineimpact.orderlyweb.DirectActionContext
 import org.vaccineimpact.orderlyweb.db.Config
+import org.vaccineimpact.orderlyweb.errors.BadRequest
 import org.vaccineimpact.orderlyweb.errors.MissingParameterError
 import org.vaccineimpact.orderlyweb.errors.MissingRequiredPermissionError
 import org.vaccineimpact.orderlyweb.models.Scope
@@ -319,6 +320,22 @@ class DirectActionContextTests
         assertThat(result).isEqualTo("MOCK")
     }
 
+    @Test
+    fun `getPartReader throws BadRequest when content is empty`()
+    {
+        val mockRequest = mock<Request>{
+            on { contentLength() } doReturn 0
+        }
+        val mockContext = mock<SparkWebContext> {
+            on { sparkRequest } doReturn mockRequest
+        }
+
+        val sut = DirectActionContext(mockContext)
+        assertThatThrownBy{ sut.getPartReader("file") }
+                .isInstanceOf(BadRequest::class.java)
+                .hasMessageContaining("No data provided")
+    }
+
     private fun getMockRequestForPart(): Request
     {
         val mockStream = IOUtils.toInputStream("MOCK", Charset.defaultCharset())
@@ -333,6 +350,7 @@ class DirectActionContextTests
 
         return mock<Request> {
             on { raw() } doReturn mockRaw
+            on { contentLength() } doReturn 10
         }
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
@@ -63,12 +63,13 @@ class OrderlyServerTests
     {
         val client = getHttpClient()
         val key = "report"
-        val queryParams: Map<String, String> = mapOf(key to "minimal")
+        val nullKey = "nullVal"
+        val queryParams: Map<String, String?> = mapOf(key to "minimal", nullKey to null)
         OrderlyServer(mockConfig, client).get("/some/path/", queryParams )
 
         verify(client).newCall(
                 check {
-                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/?report=minimal")
+                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/?report=minimal&nullVal")
                     assertThat(it.headers).isEqualTo(standardHeaders.toHeaders())
                 }
         )

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
@@ -63,13 +63,13 @@ class OrderlyServerTests
     {
         val client = getHttpClient()
         val key = "report"
-        val nullKey = "nullVal"
-        val queryParams: Map<String, String?> = mapOf(key to "minimal", nullKey to null)
+        val nullKey = "emptyVal"
+        val queryParams: Map<String, String> = mapOf(key to "minimal", nullKey to "")
         OrderlyServer(mockConfig, client).get("/some/path/", queryParams )
 
         verify(client).newCall(
                 check {
-                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/?report=minimal&nullVal")
+                    assertThat(it.url.toString()).isEqualTo("http://orderly/some/path/?report=minimal&emptyVal=")
                     assertThat(it.headers).isEqualTo(standardHeaders.toHeaders())
                 }
         )

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
@@ -16,6 +16,7 @@ import org.vaccineimpact.orderlyweb.OrderlyServerResponse
 import org.vaccineimpact.orderlyweb.db.Config
 import org.vaccineimpact.orderlyweb.errors.OrderlyServerError
 import org.vaccineimpact.orderlyweb.models.GitCommit
+import org.vaccineimpact.orderlyweb.models.Parameter
 
 class OrderlyServerTests
 {
@@ -391,6 +392,48 @@ class OrderlyServerTests
                 emptyMap()
             )
         }.isInstanceOf(OrderlyServerError::class.java)
+    }
+
+    @Test
+    fun `getRunnableReportNames does expected get`()
+    {
+        val mockResponse = """{"data": ["report1", "report2"], "errors": null, "status": "success"}"""
+        val mockQueryParams = mapOf("branch" to "testBranch", "commit" to "testCommit")
+        val client = getHttpClient(mockResponse)
+        val result = OrderlyServer(mockConfig, client).getRunnableReportNames(mockQueryParams)
+        assertThat(result).hasSameElementsAs(listOf("report1", "report2"))
+
+        verify(client).newCall(
+            check {
+                assertThat(it.url.toString()).isEqualTo("http://orderly/reports/source?branch=testBranch&commit=testCommit")
+                assertThat(it.headers).isEqualTo(standardHeaders.toHeaders())
+            }
+        )
+    }
+
+    @Test
+    fun `getReportParameters does expected get`()
+    {
+        val mockResponse = """{"data": [
+                {"name": "param1", "value": "1"},
+                {"name": "param2", "value": "2"}
+            ], 
+            "errors": null, "status": "success"}""".trimMargin()
+
+        val mockQueryParams = mapOf("commit" to "testCommit")
+        val client = getHttpClient(mockResponse)
+        val result = OrderlyServer(mockConfig, client).getReportParameters("report1", mockQueryParams)
+        assertThat(result).hasSameElementsAs(listOf(
+            Parameter("param1", "1"),
+            Parameter("param2", "2")
+        ))
+
+        verify(client).newCall(
+                check {
+                    assertThat(it.url.toString()).isEqualTo("http://orderly/reports/report1/parameters?commit=testCommit")
+                    assertThat(it.headers).isEqualTo(standardHeaders.toHeaders())
+                }
+        )
     }
 
     private fun getHttpClient(

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunReportTests.kt
@@ -119,9 +119,10 @@ class RunReportTests
     @Test
     fun `gets parameters for report as expected with commitId`()
     {
+        val mockQueryParameters = mapOf("commit" to "123")
         val mockContext: ActionContext = mock {
             on { params(":name") } doReturn "minimal"
-            on { queryParams("commit") } doReturn "123"
+            on { queryParams() } doReturn mockQueryParameters
         }
 
         val parameters = listOf(
@@ -130,8 +131,7 @@ class RunReportTests
         )
 
         val mockOrderlyServer: OrderlyServerAPI = mock {
-            on { get("/reports/minimal/parameters", mockContext) } doReturn
-                    OrderlyServerResponse(Serializer.instance.toResult(parameters), 200)
+            on { getReportParameters("minimal", mockQueryParameters) } doReturn parameters
         }
 
         val sut = ReportController(mockContext, mock(), mockOrderlyServer, mock(), mock())
@@ -143,8 +143,10 @@ class RunReportTests
     @Test
     fun `gets parameters for report as expected without commitId`()
     {
+        val mockQueryParameters: Map<String, String> = mapOf()
         val mockContext: ActionContext = mock {
             on { params(":name") } doReturn "minimal"
+            on { queryParams() } doReturn mockQueryParameters
         }
 
         val parameters = listOf(
@@ -153,13 +155,11 @@ class RunReportTests
         )
 
         val mockOrderlyServer: OrderlyServerAPI = mock {
-            on { get("/reports/minimal/parameters", mockContext) } doReturn
-                    OrderlyServerResponse(Serializer.instance.toResult(parameters), 200)
+            on { getReportParameters("minimal", mockQueryParameters) } doReturn parameters
         }
 
         val sut = ReportController(mockContext, mock(), mockOrderlyServer, mock(), mock())
         val result = sut.getReportParameters()
-
         Assertions.assertThat(result.count()).isEqualTo(2)
         Assertions.assertThat(result).isEqualTo(parameters)
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunnableReportsTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportControllerTests/RunnableReportsTests.kt
@@ -15,14 +15,16 @@ class RunnableReportsTests
     @Test
     fun `can list all reports`()
     {
-        val mockContext: ActionContext = mock()
+        val mockQueryParams: Map<String, String> = mapOf()
+        val mockContext: ActionContext = mock<ActionContext>{
+            on { queryParams() } doReturn mockQueryParams
+        }
         val reports = listOf(
             "report1",
             "report2"
         )
         val mockOrderlyServer: OrderlyServerAPI = mock {
-            on { get("/reports/source", mockContext) } doReturn
-                OrderlyServerResponse(Serializer.instance.toResult(reports), 200)
+            on { getRunnableReportNames(mockQueryParams) } doReturn reports
         }
         val date1 = Instant.now()
         val date2 = date1.minusSeconds(60)
@@ -46,17 +48,16 @@ class RunnableReportsTests
     @Test
     fun `can list reports for branch and commit`()
     {
+        val mockQueryParams = mapOf("branch" to "branch1", "commit" to "abcdef1")
         val mockContext: ActionContext = mock {
-            on { queryParams("branch") } doReturn "branch1"
-            on { queryParams("commit") } doReturn "abcdef1"
+            on { queryParams() } doReturn mockQueryParams
         }
         val reports = listOf(
             "report_that_has_been_run",
             "report_that_has_not_been_run"
         )
         val mockOrderlyServer: OrderlyServerAPI = mock {
-            on { get("/reports/source", mockContext) } doReturn
-                OrderlyServerResponse(Serializer.instance.toResult(reports), 200)
+            on { getRunnableReportNames(mockQueryParams) } doReturn reports
         }
         val now = Instant.now()
         val mockReportRepo: ReportRepository = mock {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
@@ -561,12 +561,11 @@ class WorkflowRunControllerTests
         }
 
         val mockResult = listOf(WorkflowReportWithParams("test", mapOf()))
-        val mockAPI = mock<OrderlyServerAPI>()
         val mockLogic = mock<WorkflowLogic> {
-            on { parseAndValidateWorkflowCSV(mockReader, "testBranch", "testCommit", mockAPI) } doReturn mockResult
+            on { parseAndValidateWorkflowCSV(mockReader, "testBranch", "testCommit") } doReturn mockResult
         }
 
-        val sut = WorkflowRunController(mockContext, mock(), mockAPI, mockLogic)
+        val sut = WorkflowRunController(mockContext, mock(), mock(), mockLogic)
         val result = sut.validateWorkflow()
 
         assertThat(result).isSameAs(mockResult)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
@@ -560,7 +560,7 @@ class WorkflowRunControllerTests
 
         val mockResult = listOf(WorkflowReportWithParams("test", mapOf()))
         val mockLogic = mock<WorkflowLogic> {
-            on { parseWorkflowCSV(mockReader) } doReturn mockResult
+            on { parseAndValidateWorkflowCSV(mockReader, "", "", mock()) } doReturn mockResult
         }
 
         val sut = WorkflowRunController(mockContext, mock(), mock(), mockLogic)

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
@@ -556,19 +556,20 @@ class WorkflowRunControllerTests
         val mockReader = mock<Reader>()
         val mockContext = mock<ActionContext> {
             on { getPartReader("file") } doReturn mockReader
+            on { queryParams("branch") } doReturn "testBranch"
+            on { queryParams("commit") } doReturn "testCommit"
         }
 
         val mockResult = listOf(WorkflowReportWithParams("test", mapOf()))
+        val mockAPI = mock<OrderlyServerAPI>()
         val mockLogic = mock<WorkflowLogic> {
-            on { parseAndValidateWorkflowCSV(mockReader, "", "", mock()) } doReturn mockResult
+            on { parseAndValidateWorkflowCSV(mockReader, "testBranch", "testCommit", mockAPI) } doReturn mockResult
         }
 
-        val sut = WorkflowRunController(mockContext, mock(), mock(), mockLogic)
+        val sut = WorkflowRunController(mockContext, mock(), mockAPI, mockLogic)
         val result = sut.validateWorkflow()
 
         assertThat(result).isSameAs(mockResult)
-        verify(mockContext).getPart("git_branch")
-        verify(mockContext).getPart("git_commit")
     }
 
     private fun getWorkflowRunRequestExample() =

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/GetByNameAndVersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/GetByNameAndVersionTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.reportControllerTests
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/MetadataTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/MetadataTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.reportControllerTests
 
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.doReturn

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/PinnedReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/PinnedReportTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.reportControllerTests
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/PublishReportsTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/PublishReportsTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.reportControllerTests
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/PublishTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/PublishTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.reportControllerTests
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/RunReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/RunReportTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.reportControllerTests
 
 import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/RunnableReportsTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/RunnableReportsTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.reportControllerTests
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/TagTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/reportControllerTests/TagTests.kt
@@ -1,4 +1,4 @@
-package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.ReportControllerTests
+package org.vaccineimpact.orderlyweb.tests.unit_tests.controllers.web.reportControllerTests
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.eq

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/errors/ExceptionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/errors/ExceptionTests.kt
@@ -34,4 +34,20 @@ class ExceptionTests
                 "It should have the form 'scope/name' where scope is either the global scope '*' " +
                 "or a specific scope identifier in the form 'prefix:id'")
     }
+
+    @Test
+    fun `can create BadRequest with list of errors`()
+    {
+        val sut = BadRequest(listOf("error1", "error2"))
+        Assertions.assertThat(sut.httpStatus).isEqualTo(400)
+        Assertions.assertThat(sut.message).isEqualTo("the following problems occurred:\nerror1\nerror2")
+    }
+
+    @Test
+    fun `can create BadRequest with single error`()
+    {
+        val sut = BadRequest("only error")
+        Assertions.assertThat(sut.httpStatus).isEqualTo(400)
+        Assertions.assertThat(sut.message).isEqualTo("the following problems occurred:\nonly error")
+    }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
@@ -18,7 +18,8 @@ class WorkflowLogicTests
     private val mockParams = listOf(Parameter("disease", "defaultDisuses"), Parameter("year", "2020"))
     private val commitOnlyQs = mapOf("commit" to testCommit)
     private val mockTestOrderlyAPI = mock<OrderlyServerAPI> {
-        on { getRunnableReportNames(eq(mapOf("branch" to testBranch, "commit" to testCommit))) } doReturn listOf("test1", "test2", "test3")
+        on { getRunnableReportNames(eq(mapOf("branch" to testBranch, "commit" to testCommit))) } doReturn listOf(
+                "test1", "test2", "test3")
         on { getReportParameters(eq("test1"), eq(commitOnlyQs)) } doReturn mockParams
         on { getReportParameters(eq("test2"), eq(commitOnlyQs)) } doReturn mockParams
         on { getReportParameters(eq("test3"), eq(commitOnlyQs)) } doReturn mockParams
@@ -53,7 +54,8 @@ class WorkflowLogicTests
             test2
         """.trimIndent().reader()
         val mockOrderlyAPI = mock<OrderlyServerAPI> {
-            on { getRunnableReportNames(eq(mapOf("branch" to testBranch, "commit" to testCommit))) } doReturn listOf("test1", "test2", "test3")
+            on { getRunnableReportNames(eq(mapOf("branch" to testBranch, "commit" to testCommit))) } doReturn listOf(
+                    "test1", "test2", "test3")
             on { getReportParameters(any(), eq(mapOf("commit" to testCommit))) } doReturn listOf<Parameter>()
         }
         val result = sut.parseAndValidateWorkflowCSV(csvReader, testBranch, testCommit, mockOrderlyAPI)
@@ -98,7 +100,8 @@ class WorkflowLogicTests
             test3,Rubella,
         """.trimIndent().reader()
         assertThatThrownBy{ sut.parseAndValidateWorkflowCSV(csvReader, testBranch, testCommit, mockTestOrderlyAPI) }
-                .isInstanceOf(BadRequest::class.java).hasMessageContaining("Report row 2 should contain 3 values, 4 values found")
+                .isInstanceOf(BadRequest::class.java).hasMessageContaining(
+                        "Report row 2 should contain 3 values, 4 values found")
     }
 
     @Test
@@ -111,7 +114,8 @@ class WorkflowLogicTests
             test3,Rubella
         """.trimIndent().reader()
         assertThatThrownBy{ sut.parseAndValidateWorkflowCSV(csvReader, testBranch, testCommit, mockTestOrderlyAPI) }
-                .isInstanceOf(BadRequest::class.java).hasMessageContaining("Report row 3 should contain 3 values, 2 values found")
+                .isInstanceOf(BadRequest::class.java).hasMessageContaining(
+                        "Report row 3 should contain 3 values, 2 values found")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
@@ -67,6 +67,26 @@ class WorkflowLogicTests
     }
 
     @Test
+    fun `validate method omits commit and branch parameters when null`()
+    {
+        val csvReader = """
+            report
+            test1
+        """.trimIndent().reader()
+        val mockOrderlyAPI = mock<OrderlyServerAPI> {
+            on { getRunnableReportNames(eq(mapOf())) } doReturn listOf("test1")
+            on { getReportParameters(eq("test1"), eq(mapOf())) } doReturn listOf<Parameter>()
+        }
+        val result = sut(mockOrderlyAPI).parseAndValidateWorkflowCSV(csvReader, null, null)
+        assertThat(result.count()).isEqualTo(1)
+        assertThat(result[0].name).isEqualTo("test1")
+        assertThat(result[0].params).isEqualTo(mapOf<String, String>())
+
+        verify(mockOrderlyAPI).getRunnableReportNames(eq(mapOf()))
+        verify(mockOrderlyAPI).getReportParameters(eq("test1"), eq(mapOf()))
+    }
+
+    @Test
     fun `throws expected error when parse CSV with no rows`()
     {
         val csvReader = "".reader()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
@@ -1,5 +1,6 @@
 package org.vaccineimpact.orderlyweb.tests.unit_tests.logic
 
+import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
@@ -19,7 +20,7 @@ class WorkflowLogicTests
             test2,,2021
             test3,Rubella,
         """.trimIndent().reader()
-        val result = sut.parseWorkflowCSV(csvReader)
+        val result = sut.parseAndValidateWorkflowCSV(csvReader, "", "", mock())
         assertThat(result.count()).isEqualTo(3)
         assertThat(result[0].name).isEqualTo("test1")
         assertThat(result[0].params).isEqualTo(mapOf("disease" to "HepB", "year" to "2020"))
@@ -37,7 +38,7 @@ class WorkflowLogicTests
             test1
             test2
         """.trimIndent().reader()
-        val result = sut.parseWorkflowCSV(csvReader)
+        val result = sut.parseAndValidateWorkflowCSV(csvReader, "", "", mock())
         assertThat(result.count()).isEqualTo(2)
         assertThat(result[0].name).isEqualTo("test1")
         assertThat(result[0].params).isEqualTo(mapOf<String, String>())
@@ -49,7 +50,7 @@ class WorkflowLogicTests
     fun `throws expected error when parse CSV with no rows`()
     {
         val csvReader = "".reader()
-        assertThatThrownBy{ sut.parseWorkflowCSV(csvReader) }
+        assertThatThrownBy{ sut.parseAndValidateWorkflowCSV(csvReader, "","", mock()) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining("File contains no rows")
     }
 
@@ -57,7 +58,7 @@ class WorkflowLogicTests
     fun `throws expected error when parse CSV with no reports`()
     {
         val csvReader = "report,param1".reader()
-        assertThatThrownBy{ sut.parseWorkflowCSV(csvReader) }
+        assertThatThrownBy{ sut.parseAndValidateWorkflowCSV(csvReader, "", "", mock()) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining("File contains no reports")
     }
 
@@ -65,7 +66,7 @@ class WorkflowLogicTests
     fun `throws expected error when parse CSV where incorrect first header`()
     {
         val csvReader = "report1,param1".reader()
-        assertThatThrownBy{ sut.parseWorkflowCSV(csvReader) }
+        assertThatThrownBy{ sut.parseAndValidateWorkflowCSV(csvReader, "", "", mock()) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining("First header must be 'report'")
     }
 
@@ -78,7 +79,7 @@ class WorkflowLogicTests
             test2,,2021,TOO_MANY
             test3,Rubella,
         """.trimIndent().reader()
-        assertThatThrownBy{ sut.parseWorkflowCSV(csvReader) }
+        assertThatThrownBy{ sut.parseAndValidateWorkflowCSV(csvReader, "", "", mock()) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining("Report row 2 should contain 3 values, 4 values found")
     }
 
@@ -91,7 +92,7 @@ class WorkflowLogicTests
             test2,,2021
             test3,Rubella
         """.trimIndent().reader()
-        assertThatThrownBy{ sut.parseWorkflowCSV(csvReader) }
+        assertThatThrownBy{ sut.parseAndValidateWorkflowCSV(csvReader, "", "", mock()) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining("Report row 3 should contain 3 values, 2 values found")
     }
 }


### PR DESCRIPTION
This branch:
- adds logic to `WorkflowLogic` to validate uploaded workflow csv rows against reports in Orderly as follows:
  - checks that report name exists
  - checks that all required parameters (those with no defaults) have been provided. A parameter value is considered to be provided if is not an empty string i.e. whitespace is ok. This is consistent with behaviour of run report form. 
  - checks that no unexpected parameters have been provided
- all report rows are checked, and all errors found are included in report, with indication of row number ('Report row number', counting from 1 i.e. excluding header - does that seem clear enough?) 
- Because this requires fetching report and parameter information from Orderly, helper methods have been added to `OrderlyServerAPI` to do this, which are also now used by the `ReportController` which fetches the same data for the front end. 
- changes `Parameter` model class to allow 'nulls' on parameters received from orderly, since this nulls are returned when parameters have no default (at least on local dev). 
- a new constructor has been added for `BadRequest` exception to allow including multiple error messages
 
In order to be consistent with other endpoints which pass git commit and branch through to orderly server, I have removed the assumption that these values will be provided in the multipart form payload. Instead, they should be provided as the query string parameters "branch" and "commit". These are passed through to orderly server when requesting the runnable reports and report parameters.

For some reason, Orderly's report names endpoint takes 'branch' and 'commit' parameters whereas the report parameters endpoint only takes 'commit', so the logic class accepts these separately and passes them to orderly accordingly, rather than just passing through all the query string on the context. 