### PR TITLE
mrc-2822 Import csv validation errors use file row numbers and column numbers

### DIFF
--- a/css.Dockerfile
+++ b/css.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12
 
 RUN mkdir /static/ -p
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
@@ -51,12 +51,21 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
         val paramNames = headers.drop(1)
 
         val errors: MutableList<String> = mutableListOf()
-        val errorTemplate = { index: Int, msg: String -> "Report row $index: $msg" }
+        val errorTemplate = { row: Int, col: Int?, msg: String ->
+            if (col == null)
+            {
+                "Row $row: $msg"
+            }
+            else
+            {
+                "Row $row, column $col: $msg"
+            }
+        }
         val reports = rows.drop(1).mapIndexed { rowIdx, row ->
             val numCells = row.count()
             if (numCells != numCols)
             {
-                errors.add(errorTemplate(rowIdx + 1, "row should contain $numCols values, $numCells values found"))
+                errors.add(errorTemplate(rowIdx + 2, null,  "row should contain $numCols values, $numCells values found"))
             }
 
             val reportName = row[0]
@@ -67,7 +76,7 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
             WorkflowReportWithParams(reportName, parameters)
         }
 
-        errors += validateWorkflowReports(reports, branch, commit, errorTemplate)
+        errors += validateWorkflowReports(reports, branch, commit, rows[0].toList(), errorTemplate)
 
         if (errors.isNotEmpty())
         {
@@ -81,7 +90,8 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
         reports: List<WorkflowReportWithParams>,
         branch: String?,
         commit: String?,
-        errorTemplate: (index: Int, msg: String) -> String
+        headers: List<String>,
+        errorTemplate: (row: Int, col: Int?, msg: String) -> String
     ): List<String>
     {
         val reportsQsParams: MutableMap<String, String> = mutableMapOf()
@@ -100,11 +110,13 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
         val knownOrderlyReportParams: MutableMap<String, List<Parameter>> = mutableMapOf()
         val errors: MutableList<String> = mutableListOf()
 
+        val parameterHeaders = headers.drop(1)
+
         reports.forEachIndexed { index, report ->
-            val reportIdx = index + 1
+            val rowIdx = index + 2  // Row numbers in errors should be 1-indexed and include initial header column
             if (!runnableReports.contains(report.name))
             {
-                errors.add(errorTemplate(reportIdx, "report '${report.name}' not found in Orderly"))
+                errors.add(errorTemplate(rowIdx, 1, "report '${report.name}' not found in Orderly"))
             }
             else
             {
@@ -119,16 +131,29 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
                 val missingParameters = orderlyParams.values
                         .filter{ it.value == null && !report.params.keys.contains(it.name) }
                 missingParameters.forEach{
+                    // The missing parameter may or may not have a column in the file
+                    val paramIdx = parameterHeaders.indexOf(it.name)
+                    val col = if (paramIdx == -1)
+                    {
+                        null
+                    }
+                    else
+                    {
+                        paramIdx + 2 // Columns in errors should be 1-indexed and include initial report column
+                    }
+
                     errors.add(
-                            errorTemplate(reportIdx,
+                            errorTemplate(rowIdx, col,
                             "required parameter '${it.name}' was not provided for report '${report.name}'")
                     )
                 }
 
                 val unexpectedParameters = report.params.keys.filterNot{ orderlyParams.keys.contains(it) }
                 unexpectedParameters.forEach{
+                    val col = parameterHeaders.indexOf(it) + 2
                     errors.add(
-                            errorTemplate(reportIdx, "unexpected parameter '$it' provided for report '${report.name}'")
+                            errorTemplate(rowIdx, col,
+                                    "unexpected parameter '$it' provided for report '${report.name}'")
                     )
                 }
             }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
@@ -65,7 +65,8 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
             val numCells = row.count()
             if (numCells != numCols)
             {
-                errors.add(errorTemplate(rowIdx + 2, null,  "row should contain $numCols values, $numCells values found"))
+                errors.add(errorTemplate(rowIdx + 2, null,
+                        "row should contain $numCols values, $numCells values found"))
             }
 
             val reportName = row[0]
@@ -113,7 +114,7 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
         val parameterHeaders = headers.drop(1)
 
         reports.forEachIndexed { index, report ->
-            val rowIdx = index + 2  // Row numbers in errors should be 1-indexed and include initial header column
+            val rowIdx = index + 2 // Row numbers in errors should be 1-indexed and include initial header column
             if (!runnableReports.contains(report.name))
             {
                 errors.add(errorTemplate(rowIdx, 1, "report '${report.name}' not found in Orderly"))

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -401,11 +401,11 @@ class WorkflowRunTests : IntegrationTest()
         assertThat(response.statusCode).isEqualTo(400)
         val errors = JsonLoader.fromString(response.text)["errors"] as ArrayNode
         assertThat(errors.count()).isEqualTo(3)
-        assertThat(errors[0]["message"].asText()).isEqualTo("Report row 3: row should contain 2 values, 3 values found")
+        assertThat(errors[0]["message"].asText()).isEqualTo("Row 4: row should contain 2 values, 3 values found")
         assertThat(errors[0]["code"].asText()).isEqualTo("bad-request")
-        assertThat(errors[1]["message"].asText()).isEqualTo("Report row 2: required parameter 'nmin' was not provided for report 'other'")
+        assertThat(errors[1]["message"].asText()).isEqualTo("Row 3, column 2: required parameter 'nmin' was not provided for report 'other'")
         assertThat(errors[1]["code"].asText()).isEqualTo("bad-request")
-        assertThat(errors[2]["message"].asText()).isEqualTo("Report row 4: report 'nonexistent' not found in Orderly")
+        assertThat(errors[2]["message"].asText()).isEqualTo("Row 5, column 1: report 'nonexistent' not found in Orderly")
         assertThat(errors[2]["code"].asText()).isEqualTo("bad-request")
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
@@ -164,11 +164,14 @@ class WorkflowLogicTests
             TwoParamsOneDefault,,2021,
             TwoParamsOneDefault,Cholera,,5
             TwoParamsNoDefault,,,
+            ParamNotInFile,,,
         """.trimIndent().reader()
 
         val mockOrderlyAPI = mock<OrderlyServerAPI> {
             on { getRunnableReportNames(eq(mapOf("branch" to testBranch, "commit" to testCommit))) } doReturn listOf(
-                    "SingleDefaultParam", "SingleNoDefaultParam", "TwoParamsOneDefault", "TwoParamsNoDefault")
+                    "SingleDefaultParam", "SingleNoDefaultParam", "TwoParamsOneDefault", "TwoParamsNoDefault",
+                    "ParamNotInFile"
+            )
             on { getReportParameters(eq("SingleDefaultParam"), eq(commitOnlyQs)) } doReturn listOf(
                     Parameter("disease", "default"))
             on { getReportParameters(eq("SingleNoDefaultParam"), eq(commitOnlyQs)) } doReturn listOf(
@@ -179,6 +182,9 @@ class WorkflowLogicTests
             on { getReportParameters(eq("TwoParamsNoDefault"), eq(commitOnlyQs)) } doReturn listOf(
                     Parameter("year", null), Parameter("age", null)
             )
+            on { getReportParameters(eq("ParamNotInFile"), eq(commitOnlyQs)) } doReturn listOf(
+                    Parameter("notinfile", null)
+            )
         }
         assertThatThrownBy{ sut(mockOrderlyAPI).parseAndValidateWorkflowCSV(csvReader, testBranch, testCommit) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining("""
@@ -188,6 +194,7 @@ class WorkflowLogicTests
                     Row 6, column 3: required parameter 'year' was not provided for report 'TwoParamsOneDefault'
                     Row 6, column 2: unexpected parameter 'disease' provided for report 'TwoParamsOneDefault'
                     Row 7, column 3: required parameter 'year' was not provided for report 'TwoParamsNoDefault'
-                    Row 7, column 4: required parameter 'age' was not provided for report 'TwoParamsNoDefault'""".trimIndent())
+                    Row 7, column 4: required parameter 'age' was not provided for report 'TwoParamsNoDefault'
+                    Row 8: required parameter 'notinfile' was not provided for report 'ParamNotInFile'""".trimIndent())
     }
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
@@ -121,7 +121,7 @@ class WorkflowLogicTests
         """.trimIndent().reader()
         assertThatThrownBy{ sut(mockTestOrderlyAPI).parseAndValidateWorkflowCSV(csvReader, testBranch, testCommit) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining(
-                        "Report row 2: row should contain 3 values, 4 values found")
+                        "Row 3: row should contain 3 values, 4 values found")
     }
 
     @Test
@@ -135,7 +135,7 @@ class WorkflowLogicTests
         """.trimIndent().reader()
         assertThatThrownBy{ sut(mockTestOrderlyAPI).parseAndValidateWorkflowCSV(csvReader, testBranch, testCommit) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining(
-                        "Report row 3: row should contain 3 values, 2 values found")
+                        "Row 4: row should contain 3 values, 2 values found")
     }
 
     @Test
@@ -149,8 +149,8 @@ class WorkflowLogicTests
         """.trimIndent().reader()
         assertThatThrownBy{ sut(mockTestOrderlyAPI).parseAndValidateWorkflowCSV(csvReader, testBranch, testCommit) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining("""
-                    Report row 1: report 'nonexistent1' not found in Orderly
-                    Report row 3: report 'nonexistent2' not found in Orderly""".trimIndent())
+                    Row 2, column 1: report 'nonexistent1' not found in Orderly
+                    Row 4, column 1: report 'nonexistent2' not found in Orderly""".trimIndent())
     }
 
     @Test
@@ -182,12 +182,12 @@ class WorkflowLogicTests
         }
         assertThatThrownBy{ sut(mockOrderlyAPI).parseAndValidateWorkflowCSV(csvReader, testBranch, testCommit) }
                 .isInstanceOf(BadRequest::class.java).hasMessageContaining("""
-                    Report row 1: unexpected parameter 'year' provided for report 'SingleDefaultParam'
-                    Report row 1: unexpected parameter 'age' provided for report 'SingleDefaultParam'
-                    Report row 3: required parameter 'disease' was not provided for report 'SingleNoDefaultParam'
-                    Report row 5: required parameter 'year' was not provided for report 'TwoParamsOneDefault'
-                    Report row 5: unexpected parameter 'disease' provided for report 'TwoParamsOneDefault'
-                    Report row 6: required parameter 'year' was not provided for report 'TwoParamsNoDefault'
-                    Report row 6: required parameter 'age' was not provided for report 'TwoParamsNoDefault'""".trimIndent())
+                    Row 2, column 3: unexpected parameter 'year' provided for report 'SingleDefaultParam'
+                    Row 2, column 4: unexpected parameter 'age' provided for report 'SingleDefaultParam'
+                    Row 4, column 2: required parameter 'disease' was not provided for report 'SingleNoDefaultParam'
+                    Row 6, column 3: required parameter 'year' was not provided for report 'TwoParamsOneDefault'
+                    Row 6, column 2: unexpected parameter 'disease' provided for report 'TwoParamsOneDefault'
+                    Row 7, column 3: required parameter 'year' was not provided for report 'TwoParamsNoDefault'
+                    Row 7, column 4: required parameter 'age' was not provided for report 'TwoParamsNoDefault'""".trimIndent())
     }
 }


### PR DESCRIPTION
This branch uses file row number rather than 'report row numbers' (i.e. not including header rows) in import CSV workflow error messages, as suggested [in this PR](https://github.com/vimc/orderly-web/pull/399). Also adds column numbers where possible. 
