### PR TITLE
mrc-2825 Support dereferencing in JSONValidator

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.orderlyweb.tests.integration_tests.tests.web
 
 import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.TextNode
 import com.github.fge.jackson.JsonLoader
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.AssertionsForClassTypes
@@ -470,10 +471,20 @@ class WorkflowRunTests : IntegrationTest()
 
         assertSuccessful(response)
         assertJsonContentType(response)
-        val json = JsonLoader.fromString(response.text)
-        val data =  json["data"].toString()
-        AssertionsForClassTypes.assertThat("missing_dependencies" in data)
-                .isEqualTo(true)
+
+        val test = """{ "data": {  "reports": [{"name": "report1", "instance": "instance1"}], "missing_dependencies": {}, "ref": "123"  }, "errors": [], "status": "success"}"""
+        JSONValidator.validateAgainstOrderlySchema(test, "WorkflowSummaryResponse")
+
+        //val json = JsonLoader.fromString(response.text)
+        //val data = json["data"]
+        //val reports = data["reports"] as ArrayNode
+        //assertThat(reports.count()).isEqualTo(1)
+        //assertThat((reports[0]["name"] as TextNode).textValue()).isEqualTo("global")
+        //assertThat((data["missing_dependencies"]["global"] as ArrayNode).count()).isEqualTo(0)
+
+        //val data =  json["data"].toString()
+        //AssertionsForClassTypes.assertThat("missing_dependencies" in data)
+         //       .isEqualTo(true)
     }
 
     private fun addWorkflowRunExample()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.node.TextNode
 import com.github.fge.jackson.JsonLoader
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jetty.http.HttpStatus
-import org.jooq.JSON
 import org.jsoup.Jsoup
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ContentTypes

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.TextNode
 import com.github.fge.jackson.JsonLoader
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.jetty.http.HttpStatus
+import org.jooq.JSON
 import org.jsoup.Jsoup
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.ContentTypes
@@ -465,7 +466,7 @@ class WorkflowRunTests : IntegrationTest()
                 sessionCookie,
                 ContentTypes.json,
                 HttpMethod.post,
-                """{"ref": "$ref", "reports": [{"name": "global", "params": {}}]}""".trimIndent()
+                """{"ref": "$ref", "reports": [{"name": "global", "params": {}}]}"""
         )
 
         assertSuccessful(response)
@@ -476,6 +477,8 @@ class WorkflowRunTests : IntegrationTest()
         assertThat(reports.count()).isEqualTo(1)
         assertThat((reports[0]["name"] as TextNode).textValue()).isEqualTo("global")
         assertThat((data["missing_dependencies"]["global"] as ArrayNode).count()).isEqualTo(0)
+
+        JSONValidator.validateAgainstOrderlySchema(response.text, "WorkflowSummaryResponse")
     }
 
     private fun addWorkflowRunExample()

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/JSONValidator.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/JSONValidator.kt
@@ -3,8 +3,9 @@ package org.vaccineimpact.orderlyweb.test_helpers
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jackson.JsonLoader
+import com.github.fge.jsonschema.core.load.Dereferencing
+import com.github.fge.jsonschema.core.load.configuration.LoadingConfiguration
 import com.github.fge.jsonschema.main.JsonSchemaFactory
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import java.io.File
@@ -95,7 +96,12 @@ class JSONValidator
 
     private fun makeSchemaFactory(): JsonSchemaFactory
     {
-        return JsonSchemaFactory.byDefault()
+        val loadingConfig = LoadingConfiguration.newBuilder()
+                .dereferencing(Dereferencing.INLINE)
+                .freeze()
+        return JsonSchemaFactory.newBuilder()
+                .setLoadingConfiguration(loadingConfig)
+                .freeze()
     }
 
     private fun parseJson(jsonAsString: String): JsonNode


### PR DESCRIPTION
Using JSONValidator with schema containing `$ref` was failing - this branch adds inline dereferencing to the schema factory config to support this, and adds a validation check to the workflow summary integration test to check that this works (this check would fail on master)
