### PR TITLE
fix vue test warnings

### DIFF
--- a/src/app/static/src/tests/components/admin/addUserToRole.test.js
+++ b/src/app/static/src/tests/components/admin/addUserToRole.test.js
@@ -25,8 +25,8 @@ describe("addUserToRole", () => {
         expect(wrapper.find('input').attributes("type")).toBe("search");
         expect(wrapper.find('button').text()).toBe("Add user");
 
-        expect(wrapper.find(ErrorInfo).props().apiError).toBe("");
-        expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("");
+        expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe("");
+        expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("");
     });
 
     it('renders as expected with error', async () => {
@@ -39,8 +39,8 @@ describe("addUserToRole", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(ErrorInfo).props().apiError).toBe("test error");
-        expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("default error");
+        expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe("test error");
+        expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("default error");
 
     });
 
@@ -60,8 +60,8 @@ describe("addUserToRole", () => {
         setTimeout(() => {
             expect(mockAxios.history.post.length).toBe(1);
 
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("could not add user");
-            expect(wrapper.find(ErrorInfo).props().apiError.response.data).toStrictEqual(testError);
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("could not add user");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError.response.data).toStrictEqual(testError);
             expect(wrapper.emitted().added).toBeUndefined();
             done();
         });

--- a/src/app/static/src/tests/components/admin/adminApp.test.js
+++ b/src/app/static/src/tests/components/admin/adminApp.test.js
@@ -64,10 +64,10 @@ describe("adminApp", () => {
         });
 
         await Vue.nextTick();
-        expect(wrapper.find(ManageRoles).props().roles).toBe(mockRoles);
-        expect(wrapper.find(ManageUserPermissions).props().allUsers).toBe(mockUsers);
-        expect(wrapper.find(ManageRolePermissions).props().roles).toBe(mockRoles);
-        expect(wrapper.findAll(Settings).length).toBe(1);
+        expect(wrapper.findComponent(ManageRoles).props().roles).toBe(mockRoles);
+        expect(wrapper.findComponent(ManageUserPermissions).props().allUsers).toBe(mockUsers);
+        expect(wrapper.findComponent(ManageRolePermissions).props().roles).toBe(mockRoles);
+        expect(wrapper.findAllComponents(Settings).length).toBe(1);
     });
 
     it('fetches roles and users on mount', async (done) => {
@@ -86,7 +86,7 @@ describe("adminApp", () => {
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(2);
 
-            wrapper.find(ManageRolePermissions).vm.$emit("changed");
+            wrapper.findComponent(ManageRolePermissions).vm.$emit("changed");
 
             setTimeout(() => {
                 expect(mockAxios.history.get.length).toBe(4);
@@ -102,7 +102,7 @@ describe("adminApp", () => {
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(2);
 
-            wrapper.find(ManageRoles).vm.$emit("changed");
+            wrapper.findComponent(ManageRoles).vm.$emit("changed");
 
             setTimeout(() => {
                 expect(mockAxios.history.get.length).toBe(4);
@@ -118,7 +118,7 @@ describe("adminApp", () => {
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(2);
 
-            wrapper.find(ManageUserPermissions).vm.$emit("changed");
+            wrapper.findComponent(ManageUserPermissions).vm.$emit("changed");
 
             setTimeout(() => {
                 expect(mockAxios.history.get.length).toBe(3);
@@ -131,6 +131,6 @@ describe("adminApp", () => {
     it('does not render settings if cannot allow guest', () => {
         window.canAllowGuest = false;
         const wrapper = shallowMount(AdminApp);
-        expect(wrapper.findAll(Settings).length).toBe(0);
+        expect(wrapper.findAllComponents(Settings).length).toBe(0);
     });
 });

--- a/src/app/static/src/tests/components/admin/manageRolePermisisons.test.js
+++ b/src/app/static/src/tests/components/admin/manageRolePermisisons.test.js
@@ -37,15 +37,16 @@ describe("manageRolePermissions", () => {
         const wrapper = getWrapper();
 
         const listItems = wrapper.findAll("li");
+        const permissionLists = wrapper.findAllComponents(PermissionList);
         expect(listItems.length).toBe(2);
+        expect(permissionLists.length).toBe(2);
         expect(listItems.at(0).find('span').text()).toBe("Funders");
-        expect(listItems.at(0).find(PermissionList).props().permissions).toBe(mockRoles[0].permissions);
-        expect(listItems.at(0).find(PermissionList).props().userGroup).toBe("Funders");
+        expect(permissionLists.at(0).props().permissions).toBe(mockRoles[0].permissions);
+        expect(permissionLists.at(0).props().userGroup).toBe("Funders");
 
         expect(listItems.at(1).find('span').text()).toBe("Science");
-        expect(listItems.at(1).findAll(PermissionList).length).toBe(1);
-        expect(listItems.at(1).find(PermissionList).props().permissions.length).toBe(0);
-        expect(listItems.at(1).find(PermissionList).props().canEdit).toBe(true);
+        expect(permissionLists.at(1).props().permissions.length).toBe(0);
+        expect(permissionLists.at(1).props().canEdit).toBe(true);
 
     });
 
@@ -58,9 +59,9 @@ describe("manageRolePermissions", () => {
             }
         });
 
-        const listItems = wrapper.findAll("li");
+        const listItems = wrapper.findAllComponents(PermissionList);
         expect(listItems.length).toBe(1);
-        expect(listItems.at(0).find(PermissionList).props().canEdit).toBe(false);
+        expect(listItems.at(0).props().canEdit).toBe(false);
     });
 
     it('renders with error', async () => {
@@ -72,8 +73,8 @@ describe("manageRolePermissions", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(ErrorInfo).props().apiError).toBe("TEST ERROR");
-        expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("TEST DEFAULT")
+        expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe("TEST ERROR");
+        expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("TEST DEFAULT")
     });
 
     it('toggles list item', async () => {
@@ -101,7 +102,7 @@ describe("manageRolePermissions", () => {
         mockAxios.onDelete(url)
             .reply(200);
 
-        wrapper.find(PermissionList).vm.$emit("removed", mockRoles[0].permissions[0], "Funders");
+        wrapper.findComponent(PermissionList).vm.$emit("removed", mockRoles[0].permissions[0], "Funders");
         setTimeout(() => {
             expect(mockAxios.history.delete.length).toBe(1);
             expect(mockAxios.history.delete[0].url).toBe(url);
@@ -123,7 +124,7 @@ describe("manageRolePermissions", () => {
         mockAxios.onDelete(url)
             .reply(500, "TEST API ERROR");
 
-        wrapper.find(PermissionList).vm.$emit("removed", mockRoles[0].permissions[0], "Funders");
+        wrapper.findComponent(PermissionList).vm.$emit("removed", mockRoles[0].permissions[0], "Funders");
         setTimeout(() => {
             expect(mockAxios.history.delete.length).toBe(1);
             expect(mockAxios.history.delete[0].url).toBe(url);
@@ -147,7 +148,7 @@ describe("manageRolePermissions", () => {
             propsData: {roles: [scopedRole]}
         });
 
-        wrapper.find(PermissionList).vm.$emit("removed", scopedRole.permissions[0], "ScopedRole");
+        wrapper.findComponent(PermissionList).vm.$emit("removed", scopedRole.permissions[0], "ScopedRole");
         setTimeout(() => {
             expect(mockAxios.history.delete.length).toBe(1);
             const url = "http://app/roles/ScopedRole/permissions/test.perm/?scopePrefix=report&scopeId=r1";
@@ -169,12 +170,12 @@ describe("manageRolePermissions", () => {
         mockAxios.onPost(url)
             .reply(200);
 
-        wrapper.find(PermissionList).vm.$emit("added", "reports.review");
+        wrapper.findComponent(PermissionList).vm.$emit("added", "reports.review");
         setTimeout(() => {
             expect(mockAxios.history.post.length).toBe(1);
             expect(mockAxios.history.post[0].url).toBe(url);
 
-            expect(wrapper.find(ErrorInfo).props().apiError).toBeNull();
+            expect(wrapper.findComponent(ErrorInfo).props().apiError).toBeNull();
             expect(wrapper.emitted().changed.length).toBe(1);
             done();
         });
@@ -193,15 +194,15 @@ describe("manageRolePermissions", () => {
         mockAxios.onPost(url)
             .reply(500);
 
-        wrapper.find(PermissionList).vm.$emit("added", "reports.review");
+        wrapper.findComponent(PermissionList).vm.$emit("added", "reports.review");
 
         setTimeout(() => {
             expect(mockAxios.history.post.length).toBe(1);
             expect(mockAxios.history.post[0].url).toBe(url);
 
             expect(wrapper.emitted().changed).toBeUndefined();
-            expect(wrapper.find(ErrorInfo).props().apiError).not.toBeNull();
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("could not add reports.review to Funders");            done();
+            expect(wrapper.findComponent(ErrorInfo).props().apiError).not.toBeNull();
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("could not add reports.review to Funders");            done();
         });
     });
 });

--- a/src/app/static/src/tests/components/admin/manageRoles.test.js
+++ b/src/app/static/src/tests/components/admin/manageRoles.test.js
@@ -40,10 +40,10 @@ describe("manageRoles", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
-        expect(wrapper.find(RoleList).props().canRemoveRoles).toBe(true);
-        expect(wrapper.find(RoleList).props().canRemoveMembers).toBe(true);
-        expect(wrapper.find(RoleList).props().canAddMembers).toBe(true);
+        expect(wrapper.findComponent(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
+        expect(wrapper.findComponent(RoleList).props().canRemoveRoles).toBe(true);
+        expect(wrapper.findComponent(RoleList).props().canRemoveMembers).toBe(true);
+        expect(wrapper.findComponent(RoleList).props().canAddMembers).toBe(true);
 
     });
 
@@ -51,7 +51,7 @@ describe("manageRoles", () => {
         const wrapper = mount(ManageRoles, {
             propsData: {roles: mockRoles}
         });
-        expect(wrapper.findAll(AddRole).length).toBe(1);
+        expect(wrapper.findAllComponents(AddRole).length).toBe(1);
     });
 
     it('renders errorInfo', async () => {
@@ -63,8 +63,8 @@ describe("manageRoles", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(ErrorInfo).props().apiError).toBe("test-error");
-        expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("test-default");
+        expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe("test-error");
+        expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("test-default");
     });
 
     it(`shows modal if showModal is true`, async () => {
@@ -103,7 +103,7 @@ describe("manageRoles", () => {
         });
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(1);
-            expect(wrapper.find(RoleList).props().availableUsers).toEqual(expect.arrayContaining(mockEmails));
+            expect(wrapper.findComponent(RoleList).props().availableUsers).toEqual(expect.arrayContaining(mockEmails));
             done();
         });
     });
@@ -112,7 +112,7 @@ describe("manageRoles", () => {
         const wrapper = mount(ManageRoles, {
             propsData: {roles: mockRoles}
         });
-        wrapper.find(RoleList).vm.$emit("removedMember");
+        wrapper.findComponent(RoleList).vm.$emit("removedMember");
         expect(wrapper.emitted().changed.length).toBe(1);
     });
 
@@ -120,7 +120,7 @@ describe("manageRoles", () => {
         const wrapper = mount(ManageRoles, {
             propsData: {roles: mockRoles}
         });
-        wrapper.find(RoleList).vm.$emit("removed", "Funders");
+        wrapper.findComponent(RoleList).vm.$emit("removed", "Funders");
 
         await Vue.nextTick();
 
@@ -134,7 +134,7 @@ describe("manageRoles", () => {
         const wrapper = mount(ManageRoles, {
             propsData: {roles: mockRoles}
         });
-        wrapper.find(RoleList).vm.$emit("added");
+        wrapper.findComponent(RoleList).vm.$emit("added");
         expect(wrapper.emitted().changed.length).toBe(1);
     });
 
@@ -225,7 +225,7 @@ describe("manageRoles", () => {
             propsData: {roles: mockRoles}
         });
         setTimeout(() => {
-            wrapper.find(AddRole).vm.$emit("added", "NewRole");
+            wrapper.findComponent(AddRole).vm.$emit("added", "NewRole");
             setTimeout(() => {
                 expect(mockAxios.history.post.length).toBe(1);
                 expect(mockAxios.history.post[0].url).toBe("http://app/roles/");
@@ -252,7 +252,7 @@ describe("manageRoles", () => {
             propsData: {roles: mockRoles}
         });
         setTimeout(() => {
-            wrapper.find(AddRole).vm.$emit("added", "NewRole");
+            wrapper.findComponent(AddRole).vm.$emit("added", "NewRole");
             setTimeout(() => {
                 expect(wrapper.emitted().changed).toBeUndefined();
 

--- a/src/app/static/src/tests/components/admin/manageUserPermissions.test.js
+++ b/src/app/static/src/tests/components/admin/manageUserPermissions.test.js
@@ -103,9 +103,9 @@ describe("manage users", () => {
         await Vue.nextTick();
 
         expect(rendered.findAll("li").length).toBe(2);
-        expect(rendered.findAll(PermissionList).length).toBe(2);
+        expect(rendered.findAllComponents(PermissionList).length).toBe(2);
 
-        expect(rendered.find(PermissionList).props().canEdit).toBe(true);
+        expect(rendered.findComponent(PermissionList).props().canEdit).toBe(true);
 
         expect(rendered.findAll("li").at(0).classes("has-children")).toBe(true);
         expect(rendered.findAll("li").at(1).classes("has-children")).toBe(true);
@@ -118,8 +118,8 @@ describe("manage users", () => {
 
         await Vue.nextTick();
 
-        expect(rendered.findAll(PermissionList).at(0).props("permissions")).toStrictEqual([]);
-        expect(rendered.findAll(PermissionList).at(1).props("permissions")).toStrictEqual(
+        expect(rendered.findAllComponents(PermissionList).at(0).props("permissions")).toStrictEqual([]);
+        expect(rendered.findAllComponents(PermissionList).at(1).props("permissions")).toStrictEqual(
             [{
                 name: "reports.read",
                 scope_id: "",
@@ -141,13 +141,13 @@ describe("manage users", () => {
         await Vue.nextTick();
 
         expect(rendered.find("li").classes()).not.toContain("open");
-        expect(rendered.find(PermissionList).isVisible()).toBe(false);
+        expect(rendered.findComponent(PermissionList).isVisible()).toBe(false);
         rendered.find(".expander").trigger("click");
 
         await Vue.nextTick();
 
         expect(rendered.find("li").classes()).toContain("open");
-        expect(rendered.find(PermissionList).isVisible()).toBe(true);
+        expect(rendered.findComponent(PermissionList).isVisible()).toBe(true);
     });
 
     it("can remove permission", async (done) => {

--- a/src/app/static/src/tests/components/admin/permissionList.test.js
+++ b/src/app/static/src/tests/components/admin/permissionList.test.js
@@ -96,7 +96,7 @@ describe("permission list", () => {
 
         await Vue.nextTick();
 
-        expect(rendered.find(AddPermission).props().availablePermissions)
+        expect(rendered.findComponent(AddPermission).props().availablePermissions)
             .toStrictEqual(["reports.read", "users.manage"])
     });
 
@@ -208,6 +208,6 @@ describe("permission list", () => {
 
     it("permissions cannot be added if canEdit is false", () => {
         const rendered = getWrapper({canEdit: false});
-        expect(rendered.findAll(AddPermission).length).toBe(0);
+        expect(rendered.findAllComponents(AddPermission).length).toBe(0);
     });
 });

--- a/src/app/static/src/tests/components/admin/settings.test.js
+++ b/src/app/static/src/tests/components/admin/settings.test.js
@@ -18,8 +18,8 @@ describe("settings", () => {
             expect(mockAxios.history.get.length).toBe(1);
             expect(mockAxios.history.get[0].url).toBe(url);
             expect(wrapper.find("input").attr("checked")).toBe(true);
-            expect(wrapper.find(ErrorInfo).props().error).toBe(null);
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("");
+            expect(wrapper.findComponent(ErrorInfo).props().error).toBe(null);
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("");
             done();
         });
     });
@@ -34,8 +34,8 @@ describe("settings", () => {
             expect(mockAxios.history.post.length).toBe(1);
             expect(mockAxios.history.post[0].url).toBe(url);
             expect(mockAxios.history.post[0].data).toBe(false);
-            expect(wrapper.find(ErrorInfo).props().error).toBe(null);
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("");
+            expect(wrapper.findComponent(ErrorInfo).props().error).toBe(null);
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("");
             done();
         });
     });
@@ -45,8 +45,8 @@ describe("settings", () => {
             .reply(500, "TEST ERROR");
         const wrapper = shallowMount(Settings);
         setTimeout(() => {
-            expect(wrapper.find(ErrorInfo).props().error.response.data).toBe("TEST ERROR");
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("could not get allow guest user");
+            expect(wrapper.findComponent(ErrorInfo).props().error.response.data).toBe("TEST ERROR");
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("could not get allow guest user");
             done();
         });
     });
@@ -57,8 +57,8 @@ describe("settings", () => {
         const wrapper = shallowMount(Settings);
         wrapper.vm.setAuthAllowGuest();
         setTimeout(() => {
-            expect(wrapper.find(ErrorInfo).props().error.response.data).toBe("TEST ERROR");
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("could not get allow guest user");
+            expect(wrapper.findComponent(ErrorInfo).props().error.response.data).toBe("TEST ERROR");
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("could not get allow guest user");
             done();
         });
     });

--- a/src/app/static/src/tests/components/documents/documentList.test.js
+++ b/src/app/static/src/tests/components/documents/documentList.test.js
@@ -1,99 +1,80 @@
 import Vue from "vue";
-import {shallowMount} from '@vue/test-utils';
+import {shallowMount, mount} from '@vue/test-utils';
 import DocumentList from "../../../js/components/documents/documentList.vue";
 import File from "../../../js/components/documents/file.vue";
 import WebLink from "../../../js/components/documents/webLink.vue";
 
 describe("document list", () => {
 
-    function getWrapper() {
-        return shallowMount(DocumentList, {
-            propsData: {
-                docs: [{
-                    display_name: "folder",
-                    path: "path",
-                    url: "url",
-                    children: [{
-                        display_name: "file",
-                        path: "filepath",
-                        url: "fileurl",
-                        children: [],
-                        is_file: true
-                    }],
-                    is_file: false
-                },
-                    {
-                        display_name: "toplevelfile",
-                        path: "toplevelfilepath",
-                        url: "toplevelfileurl",
-                        children: [],
-                        is_file: true,
-                        external: false
-                    },
-                    {
-                        display_name: "toplevelexternal",
-                        path: "toplevelexternalpath",
-                        url: "toplevelexternalurl",
-                        children: [],
-                        is_file: true,
-                        external: true
-                    }]
-            }
-        });
+    const propsData = {
+        docs: [
+            {
+                display_name: "folder",
+                path: "path",
+                url: "url",
+                children: [{
+                    display_name: "file",
+                    path: "filepath",
+                    url: "fileurl",
+                    children: [],
+                    is_file: true
+                }],
+                is_file: false
+            },
+            {
+                display_name: "toplevelfile",
+                path: "toplevelfilepath",
+                url: "toplevelfileurl",
+                children: [],
+                is_file: true,
+                external: false
+            },
+            {
+                display_name: "toplevelexternal",
+                path: "toplevelexternalpath",
+                url: "toplevelexternalurl",
+                children: [],
+                is_file: true,
+                external: true
+            }]
     }
 
     it("renders folder", () => {
-        const wrapper = getWrapper();
-
+        const wrapper = shallowMount(DocumentList, {propsData});
         const folderListItem = wrapper.find("li#path");
         expect(folderListItem.classes()).toContain("has-children");
         expect(folderListItem.find("span.folder-name").text()).toBe("folder");
         expect(folderListItem.findAll(".expander").length).toBe(1);
-        expect(folderListItem.findAll(File).length).toBe(0);
-        expect(folderListItem.findAll(DocumentList).length).toBe(1);
+        expect(folderListItem.findAll("file-stub").length).toBe(0);
+        expect(folderListItem.findAll("document-list-stub").length).toBe(1);
     });
 
     it("renders file", () => {
-        const wrapper = getWrapper();
+        const wrapper = mount(DocumentList, {propsData});
 
         const folderListItem = wrapper.find("li#toplevelfilepath");
         expect(folderListItem.classes()).not.toContain("has-children");
         expect(folderListItem.findAll("span.folder-name").length).toBe(0);
         expect(folderListItem.findAll(".expander").length).toBe(0);
-        expect(folderListItem.findAll(File).length).toBe(1);
-        expect(folderListItem.find(File).vm.$props.doc).toEqual({
-            display_name: "toplevelfile",
-            path: "toplevelfilepath",
-            url: "toplevelfileurl",
-            children: [],
-            is_file: true,
-            external: false
-        });
+        expect(folderListItem.findAll("a").length).toBe(1);
+        expect(folderListItem.find("a").attributes("href")).toBe("toplevelfileurl");
+        expect(folderListItem.find("a").text()).toBe("download");
     });
 
     it("renders web link", () => {
-        const wrapper = getWrapper();
+        const wrapper = mount(DocumentList, {propsData});
 
         const folderListItem = wrapper.find("li#toplevelexternalpath");
         expect(folderListItem.classes()).not.toContain("has-children");
         expect(folderListItem.findAll("span.folder-name").length).toBe(0);
         expect(folderListItem.findAll(".expander").length).toBe(0);
-        expect(folderListItem.findAll(WebLink).length).toBe(1);
-        expect(folderListItem.find(WebLink).vm.$props.doc).toEqual({
-            display_name: "toplevelexternal",
-            path: "toplevelexternalpath",
-            url: "toplevelexternalurl",
-            children: [],
-            is_file: true,
-            external: true
-        });
+        expect(folderListItem.find("a").attributes("href")).toBe("toplevelexternalurl");
+        expect(folderListItem.find("a").text()).toBe("toplevelexternal");
     });
 
     it("renders children", () => {
-        const wrapper = getWrapper();
-
-        const folderListItem = wrapper.find("li#path");
-        expect(folderListItem.find(DocumentList).vm.$props.docs).toEqual([{
+        const wrapper = shallowMount(DocumentList, {propsData});
+        expect(wrapper.findAllComponents(DocumentList).at(1).vm.$props.docs).toEqual([{
             display_name: "file",
             path: "filepath",
             url: "fileurl",
@@ -103,17 +84,17 @@ describe("document list", () => {
     });
 
     it("can toggle folder", async () => {
-        const wrapper = getWrapper();
+        const wrapper = shallowMount(DocumentList, {propsData});
 
         const folderListItem = wrapper.find("li#path");
         expect(folderListItem.classes()).not.toContain("open");
-        expect(folderListItem.find(DocumentList).isVisible()).toBe(false);
+        expect(wrapper.findAllComponents(DocumentList).at(1).isVisible()).toBe(false);
 
         folderListItem.find(".expander").trigger("click");
         await Vue.nextTick();
 
         expect(folderListItem.classes()).toContain("open");
-        expect(folderListItem.find(DocumentList).isVisible()).toBe(true);
+        expect(wrapper.findAllComponents(DocumentList).at(1).isVisible()).toBe(true);
     });
 
 });

--- a/src/app/static/src/tests/components/documents/documentPage.test.js
+++ b/src/app/static/src/tests/components/documents/documentPage.test.js
@@ -59,12 +59,12 @@ describe("document page", () => {
 
     it("includes refresh documents widget if canManage is true", () => {
         const wrapper = getWrapper(true);
-        expect(wrapper.findAll(RefreshDocuments).length).toBe(1);
+        expect(wrapper.findAllComponents(RefreshDocuments).length).toBe(1);
     });
 
     it("does not include refresh documents widget if canManage is false", () => {
         const wrapper = getWrapper(false);
-        expect(wrapper.findAll(RefreshDocuments).length).toBe(0);
+        expect(wrapper.findAllComponents(RefreshDocuments).length).toBe(0);
     });
 
     it("fetches documents on load", async () => {
@@ -78,7 +78,7 @@ describe("document page", () => {
         await Vue.nextTick();
         await Vue.nextTick();
 
-        expect(wrapper.find(DocumentList).vm.$props.docs).toEqual(getDocs())
+        expect(wrapper.findComponent(DocumentList).vm.$props.docs).toEqual(getDocs())
     });
 
     it("fetches documents after refresh", async () => {
@@ -91,14 +91,14 @@ describe("document page", () => {
         await Vue.nextTick();
         await Vue.nextTick();
 
-        expect(wrapper.find(DocumentList).vm.$props.docs).toEqual(getDocs());
+        expect(wrapper.findComponent(DocumentList).vm.$props.docs).toEqual(getDocs());
 
         mockAxios.onGet("http://app/documents/")
             .reply(200, {
                 "data": []
             });
 
-        wrapper.find(RefreshDocuments).vm.$emit("refreshed");
+        wrapper.findComponent(RefreshDocuments).vm.$emit("refreshed");
 
         await Vue.nextTick();
 
@@ -107,7 +107,7 @@ describe("document page", () => {
         await Vue.nextTick();
         await Vue.nextTick();
 
-        expect(wrapper.find(DocumentList).vm.$props.docs).toEqual([]);
+        expect(wrapper.findComponent(DocumentList).vm.$props.docs).toEqual([]);
     });
 
 });

--- a/src/app/static/src/tests/components/documents/file.test.js
+++ b/src/app/static/src/tests/components/documents/file.test.js
@@ -40,7 +40,7 @@ describe("file", () => {
             }
         });
 
-        expect(rendered.findAll(fileIcon).length).toBe(1);
+        expect(rendered.findAllComponents(fileIcon).length).toBe(1);
     });
 
     it("does not render open link when can_open is false", () => {

--- a/src/app/static/src/tests/components/documents/webLink.test.js
+++ b/src/app/static/src/tests/components/documents/webLink.test.js
@@ -40,8 +40,8 @@ describe("webLink", () => {
             }
         });
 
-        expect(rendered.findAll(fileIcon).length).toBe(0);
-        expect(rendered.findAll(webIcon).length).toBe(1);
+        expect(rendered.findAllComponents(fileIcon).length).toBe(0);
+        expect(rendered.findAllComponents(webIcon).length).toBe(1);
     });
 
 });

--- a/src/app/static/src/tests/components/permissions/addReportReader.test.js
+++ b/src/app/static/src/tests/components/permissions/addReportReader.test.js
@@ -49,8 +49,8 @@ describe("addReportReader", () => {
         setTimeout(() => {
             expect(mockAxios.history.post.length).toBe(1);
 
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("could not add user");
-            expect(wrapper.find(ErrorInfo).props().apiError.response.data).toStrictEqual(testError);
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("could not add user");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError.response.data).toStrictEqual(testError);
             expect(wrapper.emitted().added).toBeUndefined();
             done();
         });
@@ -94,8 +94,8 @@ describe("addReportReader", () => {
             expect(wrapper.find('input').attributes("placeholder")).toBe("email");
             expect(wrapper.find('button').text()).toBe("Add user");
 
-            expect(wrapper.find(ErrorInfo).props().apiError).toBe("test error");
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("default error");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe("test error");
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("default error");
 
         });
 
@@ -132,8 +132,8 @@ describe("addReportReader", () => {
             expect(wrapper.find('input').attributes("placeholder")).toBe("role name");
             expect(wrapper.find('button').text()).toBe("Add role");
 
-            expect(wrapper.find(ErrorInfo).props().apiError).toBe("test error");
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("default error");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe("test error");
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("default error");
 
         });
 

--- a/src/app/static/src/tests/components/permissions/roleList.test.js
+++ b/src/app/static/src/tests/components/permissions/roleList.test.js
@@ -49,7 +49,7 @@ describe("roleList", () => {
                 }
             });
 
-        const userLists = wrapper.findAll(UserList);
+        const userLists = wrapper.findAllComponents(UserList);
         expect(userLists.length).toBe(1);
 
         expect(userLists.at(0).props().users).toEqual(expect.arrayContaining(mockRoles[0].members));
@@ -65,7 +65,7 @@ describe("roleList", () => {
             }
         });
 
-        const userLists = wrapper.findAll(UserList);
+        const userLists = wrapper.findAllComponents(UserList);
 
         expect(userLists.length).toBe(1);
         expect(userLists.at(0).props().canRemove).toBe(true);
@@ -82,13 +82,13 @@ describe("roleList", () => {
         });
 
         //don't expect the add user control to appear unless a role is epanded
-        expect(wrapper.findAll(AddUserToRole).length).toBe(0);
+        expect(wrapper.findAllComponents(AddUserToRole).length).toBe(0);
 
         wrapper.find('.expander').trigger("click");
         await Vue.nextTick();
 
-        expect(wrapper.findAll(AddUserToRole).length).toBe(1);
-        const addUser = wrapper.find(AddUserToRole);
+        expect(wrapper.findAllComponents(AddUserToRole).length).toBe(1);
+        const addUser = wrapper.findComponent(AddUserToRole);
         expect(addUser.props().role).toBe("Funders");
         //should have filtered to available users not already in role
         expect(addUser.props().availableUsers).toStrictEqual(["user2@example.com", "user3@example.com"]);
@@ -106,7 +106,7 @@ describe("roleList", () => {
         wrapper.find('.expander').trigger("click");
         await Vue.nextTick();
 
-        expect(wrapper.findAll(AddUserToRole).length).toBe(0);
+        expect(wrapper.findAllComponents(AddUserToRole).length).toBe(0);
     });
 
     it('renders removable roles', () => {
@@ -150,7 +150,7 @@ describe("roleList", () => {
             }
         });
 
-        wrapper.find(UserList).vm.$emit("removed", "bob");
+        wrapper.findComponent(UserList).vm.$emit("removed", "bob");
 
         setTimeout(() => {
             expect(wrapper.emitted().removedMember[0]).toStrictEqual(["Funders", "bob"]);
@@ -171,11 +171,11 @@ describe("roleList", () => {
             }
         });
 
-        wrapper.find(UserList).vm.$emit("removed", "bob");
+        wrapper.findComponent(UserList).vm.$emit("removed", "bob");
 
         setTimeout(() => {
-            expect(wrapper.find(ErrorInfo).props("apiError")).toBeDefined();
-            expect(wrapper.find(ErrorInfo).props("defaultMessage")).toBe("could not remove bob from Funders");
+            expect(wrapper.findComponent(ErrorInfo).props("apiError")).toBeDefined();
+            expect(wrapper.findComponent(ErrorInfo).props("defaultMessage")).toBe("could not remove bob from Funders");
             done();
         });
 
@@ -195,7 +195,7 @@ describe("roleList", () => {
         wrapper.find('.expander').trigger("click");
         await Vue.nextTick();
 
-        const addUser = wrapper.find(AddUserToRole);
+        const addUser = wrapper.findComponent(AddUserToRole);
         addUser.vm.$emit("added");
 
         expect(wrapper.emitted()["added"].length).toBe(1);
@@ -229,7 +229,7 @@ describe("roleList", () => {
         const roleWithMembers = roles.at(0);
         expect(roleWithMembers.classes("has-children")).toBe(true);
 
-        const membersList = roleWithMembers.find(UserList);
+        const membersList = wrapper.findAllComponents(UserList).at(0);
 
         expect(membersList.isVisible()).toBe(false);
         expect(roleWithMembers.classes("open")).toBe(false);
@@ -259,7 +259,7 @@ describe("roleList", () => {
 
         const roles = wrapper.findAll("ul.roles > li");
         const roleWithoutMembers = roles.at(1);
-        expect(roleWithoutMembers.findAll(UserList).length).toBe(0);
+        expect(roleWithoutMembers.findAll("user-list").length).toBe(0);
         expect(roleWithoutMembers.classes("has-children")).toBe(false);
     });
 

--- a/src/app/static/src/tests/components/permissions/userList.test.js
+++ b/src/app/static/src/tests/components/permissions/userList.test.js
@@ -35,13 +35,13 @@ describe("userList", () => {
 
         expect(wrapper.classes()).toContain("removable-users-list");
 
-        const firstUserProps = wrapper.findAll(User).at(0).props();
+        const firstUserProps = wrapper.findAllComponents(User).at(0).props();
 
         expect(firstUserProps.displayName).toBe("Test User");
         expect(firstUserProps.email).toBe("test.user@example.com");
         expect(firstUserProps.canRemove).toBe(true);
 
-        const secondUserProps = wrapper.findAll(User).at(1).props();
+        const secondUserProps = wrapper.findAllComponents(User).at(1).props();
 
         expect(secondUserProps.displayName).toBe("Another User");
         expect(secondUserProps.email).toBe("another.user@example.com");
@@ -75,13 +75,13 @@ describe("userList", () => {
 
         expect(wrapper.classes()).toContain("removable-users-list");
 
-        const firstUserProps = wrapper.findAll(User).at(0).props();
+        const firstUserProps = wrapper.findAllComponents(User).at(0).props();
 
         expect(firstUserProps.displayName).toBe("Test User");
         expect(firstUserProps.email).toBe("test.user@example.com");
         expect(firstUserProps.canRemove).toBe(false);
 
-        const secondUserProps = wrapper.findAll(User).at(1).props();
+        const secondUserProps = wrapper.findAllComponents(User).at(1).props();
 
         expect(secondUserProps.displayName).toBe("Another User");
         expect(secondUserProps.email).toBe("another.user@example.com");
@@ -98,7 +98,7 @@ describe("userList", () => {
             }
         });
 
-        wrapper.findAll(User).at(0).vm.$emit("removed", "bob");
+        wrapper.findAllComponents(User).at(0).vm.$emit("removed", "bob");
         expect(wrapper.emitted().removed[0]).toStrictEqual(["bob"])
     });
 

--- a/src/app/static/src/tests/components/publishReports/dateGroup.test.js
+++ b/src/app/static/src/tests/components/publishReports/dateGroup.test.js
@@ -41,7 +41,7 @@ describe("dateGroup", () => {
                 selectedDates: {}
             }
         });
-        const drafts = rendered.findAll(reportDraft);
+        const drafts = rendered.findAllComponents(reportDraft);
         expect(drafts.length).toBe(2);
         expect(drafts.at(0).props("draft")).toEqual(testDateGroup.drafts[0]);
         expect(drafts.at(1).props("draft")).toEqual(testDateGroup.drafts[1]);
@@ -107,7 +107,7 @@ describe("dateGroup", () => {
             }
         });
 
-        rendered.find(reportDraft).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: false});
+        rendered.findComponent(reportDraft).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: false});
         expect(rendered.emitted("select-group")[0][0])
             .toEqual({date: "Sat Jul 27 2019", value: false});
         expect(rendered.emitted("select-draft")[0][0])
@@ -124,7 +124,7 @@ describe("dateGroup", () => {
             }
         });
 
-        rendered.find(reportDraft).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: true});
+        rendered.findComponent(reportDraft).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: true});
         expect(rendered.emitted("select-group")).toBeUndefined();
         expect(rendered.emitted("select-draft")[0][0])
             .toEqual({id: "20190727-123215-97e39008", value: true});

--- a/src/app/static/src/tests/components/publishReports/publishReports.test.js
+++ b/src/app/static/src/tests/components/publishReports/publishReports.test.js
@@ -65,7 +65,7 @@ describe("publishReports", () => {
         await Vue.nextTick(); // once for date to update
         await Vue.nextTick();
         expect(mockAxios.history.get.length).toBe(1);
-        expect(rendered.findAll(report).length).toBe(2);
+        expect(rendered.findAllComponents(report).length).toBe(2);
     });
 
     it("displays reports", async () => {
@@ -73,7 +73,7 @@ describe("publishReports", () => {
         await Vue.nextTick();
         await Vue.nextTick();
         await Vue.nextTick();
-        const reports = rendered.findAll(report);
+        const reports = rendered.findAllComponents(report);
         expect(reports.length).toBe(2);
         expect(reports.at(0).props()).toEqual({
             report: testReportsWithDrafts[0],
@@ -128,13 +128,13 @@ describe("publishReports", () => {
         const rendered = shallowMount(publishReports);
         rendered.setData({reportsWithDrafts: testReportsWithDrafts});
         await Vue.nextTick();
-        let reports = rendered.findAll(report);
+        let reports = rendered.findAllComponents(report);
         expect(reports.length).toBe(2);
         rendered.find("input").setChecked(true);
 
         await Vue.nextTick();
 
-        reports = rendered.findAll(report);
+        reports = rendered.findAllComponents(report);
         expect(reports.length).toBe(1);
         expect(reports.at(0).props("report")).toEqual(testReportsWithDrafts[0]);
     });
@@ -144,9 +144,9 @@ describe("publishReports", () => {
         rendered.setData({reportsWithDrafts: testReportsWithDrafts});
         await Vue.nextTick();
 
-        rendered.find(report).vm.$emit("select-draft", {id: "20190824-161244-6e9b57d4", value: true});
+        rendered.findComponent(report).vm.$emit("select-draft", {id: "20190824-161244-6e9b57d4", value: true});
         expect(rendered.vm.$data["selectedIds"]["20190824-161244-6e9b57d4"]).toBe(true);
-        rendered.find(report).vm.$emit("select-group", {date: "Sat Jul 27 2019", value: true});
+        rendered.findComponent(report).vm.$emit("select-group", {date: "Sat Jul 27 2019", value: true});
         expect(rendered.vm.$data["selectedDates"]["Sat Jul 27 2019"]).toBe(true);
 
         rendered.find("input").setChecked(true);
@@ -161,7 +161,7 @@ describe("publishReports", () => {
         const rendered = shallowMount(publishReports);
         rendered.setData({reportsWithDrafts: testReportsWithDrafts});
         await Vue.nextTick();
-        rendered.find(report).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: true});
+        rendered.findComponent(report).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: true});
         expect(rendered.vm.$data["selectedIds"]["20190727-123215-97e39008"]).toBe(true);
     });
 
@@ -169,7 +169,7 @@ describe("publishReports", () => {
         const rendered = shallowMount(publishReports);
         rendered.setData({reportsWithDrafts: testReportsWithDrafts});
         await Vue.nextTick();
-        rendered.find(report).vm.$emit("select-draft",
+        rendered.findComponent(report).vm.$emit("select-draft",
             {
                 ids: ["20190727-123215-97e39008", "20190727-201131-d320fa9e"],
                 value: true
@@ -182,7 +182,7 @@ describe("publishReports", () => {
         const rendered = shallowMount(publishReports);
         rendered.setData({reportsWithDrafts: testReportsWithDrafts});
         await Vue.nextTick();
-        rendered.find(report).vm.$emit("select-group", {date: "Sat Jul 27 2019", value: true});
+        rendered.findComponent(report).vm.$emit("select-group", {date: "Sat Jul 27 2019", value: true});
         expect(rendered.vm.$data["selectedDates"]["Sat Jul 27 2019"]).toBe(true);
     });
 
@@ -190,7 +190,7 @@ describe("publishReports", () => {
         const rendered = shallowMount(publishReports);
         rendered.setData({reportsWithDrafts: testReportsWithDrafts});
         await Vue.nextTick();
-        rendered.find(report).vm.$emit("select-group",
+        rendered.findComponent(report).vm.$emit("select-group",
             {
                 dates: ["Sat Jul 27 2019", "Sun Jul 28 2019"],
                 value: true
@@ -203,7 +203,7 @@ describe("publishReports", () => {
         const rendered = shallowMount(publishReports);
         rendered.setData({reportsWithDrafts: testReportsWithDrafts});
         await Vue.nextTick();
-        rendered.find(report).vm.$emit("select-draft",
+        rendered.findComponent(report).vm.$emit("select-draft",
             {
                 id: "20190824-161244-6e9b57d4",
                 value: true
@@ -241,8 +241,8 @@ describe("publishReports", () => {
         await Vue.nextTick(); // once for props to update
         await Vue.nextTick();
 
-        expect(rendered.find(errorInfo).props().apiError.response.data).toBe("TEST ERROR")
-        expect(rendered.find(errorInfo).props().defaultMessage)
+        expect(rendered.findComponent(errorInfo).props().apiError.response.data).toBe("TEST ERROR")
+        expect(rendered.findComponent(errorInfo).props().defaultMessage)
             .toBe("Something went wrong. Please try again or contact support.");
 
         // error should be cleared after a successful publish
@@ -255,7 +255,7 @@ describe("publishReports", () => {
         await Vue.nextTick();
         await Vue.nextTick();
 
-        expect(rendered.find(errorInfo).props()).toEqual({
+        expect(rendered.findComponent(errorInfo).props()).toEqual({
             apiError: null,
             defaultMessage: "Something went wrong. Please try again or contact support."
         });

--- a/src/app/static/src/tests/components/publishReports/report.test.js
+++ b/src/app/static/src/tests/components/publishReports/report.test.js
@@ -33,7 +33,7 @@ describe("report component", () => {
 
     it("displays date groups", async () => {
         const rendered = shallowMount(report, {propsData: {report: testReport}});
-        const groups = rendered.findAll(dateGroup);
+        const groups = rendered.findAllComponents(dateGroup);
 
         expect(groups.length).toBe(2);
         expect(groups.at(0).props("date")).toBe("Sat Jul 27 2019");
@@ -80,7 +80,7 @@ describe("report component", () => {
         const rendered = shallowMount(report, {propsData: {report: testReport}});
         rendered.find("input").setChecked(true);
 
-        rendered.find(dateGroup).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: false});
+        rendered.findComponent(dateGroup).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: false});
 
         expect(rendered.emitted("select-draft")[1][0])
             .toEqual({id: "20190727-123215-97e39008", value: false});
@@ -91,7 +91,7 @@ describe("report component", () => {
     it("passes select-draft event on if any child is selected", () => {
         const rendered = shallowMount(report, {propsData: {report: testReport}});
 
-        rendered.find(dateGroup).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: true});
+        rendered.findComponent(dateGroup).vm.$emit("select-draft", {id: "20190727-123215-97e39008", value: true});
         expect(rendered.emitted("select-group")).toBeUndefined();
         expect(rendered.emitted("select-draft")[0][0])
             .toEqual({id: "20190727-123215-97e39008", value: true});
@@ -100,7 +100,7 @@ describe("report component", () => {
     it("passes select-group event on if any child is selected", () => {
         const rendered = shallowMount(report, {propsData: {report: testReport}});
 
-        rendered.find(dateGroup).vm.$emit("select-group", {date: "Sat Jul 27 2019", value: true});
+        rendered.findComponent(dateGroup).vm.$emit("select-group", {date: "Sat Jul 27 2019", value: true});
         expect(rendered.emitted("select-group")[0][0])
             .toEqual({date: "Sat Jul 27 2019", value: true});
     });

--- a/src/app/static/src/tests/components/reportLog/runningReportDetails.test.ts
+++ b/src/app/static/src/tests/components/reportLog/runningReportDetails.test.ts
@@ -183,8 +183,8 @@ describe(`runningReportDetails`, () => {
             .reply(500, "Error");
 
         realSetTimeout(() => {
-            expect(wrapper.find(ErrorInfo).props("apiError").response.data).toBe("Error")
-            expect(wrapper.find(ErrorInfo).props("defaultMessage"))
+            expect(wrapper.findComponent(ErrorInfo).props("apiError").response.data).toBe("Error")
+            expect(wrapper.findComponent(ErrorInfo).props("defaultMessage"))
                 .toBe("An error occurred when fetching logs")
             done()
         })

--- a/src/app/static/src/tests/components/reports/globalReaderRolesList.test.js
+++ b/src/app/static/src/tests/components/reports/globalReaderRolesList.test.js
@@ -39,9 +39,9 @@ describe("globalReaderRolesList", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
-        expect(wrapper.find(RoleList).props().canRemoveRoles).toBe(false);
-        expect(wrapper.find(RoleList).props().canRemoveMembers).toBe(false);
+        expect(wrapper.findComponent(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
+        expect(wrapper.findComponent(RoleList).props().canRemoveRoles).toBe(false);
+        expect(wrapper.findComponent(RoleList).props().canRemoveMembers).toBe(false);
 
     });
 
@@ -51,7 +51,7 @@ describe("globalReaderRolesList", () => {
 
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(1);
-            expect(wrapper.find(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
+            expect(wrapper.findComponent(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
             done();
         });
     });

--- a/src/app/static/src/tests/components/reports/globalReportReadersList.test.js
+++ b/src/app/static/src/tests/components/reports/globalReportReadersList.test.js
@@ -26,7 +26,7 @@ describe("globalReportReadersList", () => {
     ];
 
     function expectWrapperToHaveRenderedReaders(wrapper) {
-        const listItems = wrapper.find(UserList);
+        const listItems = wrapper.findComponent(UserList);
         expect(listItems.props().users).toEqual(expect.arrayContaining(reportReaders));
     }
 
@@ -41,9 +41,9 @@ describe("globalReportReadersList", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(UserList).props().canRemove).toBe(false);
-        expect(wrapper.find(ErrorInfo).props().apiError).toBe("test error");
-        expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("default error");
+        expect(wrapper.findComponent(UserList).props().canRemove).toBe(false);
+        expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe("test error");
+        expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("default error");
 
         expectWrapperToHaveRenderedReaders(wrapper);
     });
@@ -73,9 +73,9 @@ describe("globalReportReadersList", () => {
 
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(1);
-            expect(wrapper.find(UserList).props().users.length).toBe(0);
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("could not fetch list of users");
-            expect(wrapper.find(ErrorInfo).props().apiError.response.data).toStrictEqual(testError);
+            expect(wrapper.findComponent(UserList).props().users.length).toBe(0);
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("could not fetch list of users");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError.response.data).toStrictEqual(testError);
 
             done();
         });

--- a/src/app/static/src/tests/components/reports/reportDependencies.test.js
+++ b/src/app/static/src/tests/components/reports/reportDependencies.test.js
@@ -90,7 +90,7 @@ describe("reportDependencies", () => {
             expect(errorInfo.props("defaultMessage")).toBe("Could not load report dependencies");
             expect(wrapper.find("hr").exists()).toBe(true);
             expect(wrapper.find("h4").exists()).toBe(false);
-            expect(wrapper.find(ReportDependencyList).exists()).toBe(false);
+            expect(wrapper.findComponent(ReportDependencyList).exists()).toBe(false);
             done();
         });
     });

--- a/src/app/static/src/tests/components/reports/reportReadersList.test.js
+++ b/src/app/static/src/tests/components/reports/reportReadersList.test.js
@@ -34,7 +34,7 @@ describe("reportReadersList", () => {
     ];
 
     function expectWrapperToHaveRenderedReaders(wrapper) {
-        const listItems = wrapper.find(UserList);
+        const listItems = wrapper.findComponent(UserList);
         expect(listItems.props().users).toEqual(expect.arrayContaining(reportReaders));
     }
 
@@ -63,10 +63,10 @@ describe("reportReadersList", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(AddReportReader).props().type).toBe("user");
-        expect(wrapper.find(UserList).props().canRemove).toBe(true);
-        expect(wrapper.find(ErrorInfo).props().apiError).toBe("test error");
-        expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("default error");
+        expect(wrapper.findComponent(AddReportReader).props().type).toBe("user");
+        expect(wrapper.findComponent(UserList).props().canRemove).toBe(true);
+        expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe("test error");
+        expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("default error");
 
         expectWrapperToHaveRenderedReaders(wrapper);
     });
@@ -85,7 +85,7 @@ describe("reportReadersList", () => {
 
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(2);
-            expect(wrapper.find(AddReportReader).props().availableUserGroups)
+            expect(wrapper.findComponent(AddReportReader).props().availableUserGroups)
                 .toEqual(expect.arrayContaining(userEmails));
 
             expectWrapperToHaveRenderedReaders(wrapper);
@@ -110,9 +110,9 @@ describe("reportReadersList", () => {
 
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(2);
-            expect(wrapper.find(UserList).props().users.length).toBe(0);
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("could not fetch list of users");
-            expect(wrapper.find(ErrorInfo).props().apiError.response.data).toStrictEqual(testError);
+            expect(wrapper.findComponent(UserList).props().users.length).toBe(0);
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("could not fetch list of users");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError.response.data).toStrictEqual(testError);
 
             done();
         });
@@ -172,7 +172,7 @@ describe("reportReadersList", () => {
         });
 
         setTimeout(() => {
-            wrapper.find(UserList).vm.$emit("removed", "bob");
+            wrapper.findComponent(UserList).vm.$emit("removed", "bob");
 
             setTimeout(() => {
 
@@ -203,11 +203,11 @@ describe("reportReadersList", () => {
         });
 
         setTimeout(() => {
-            wrapper.find(UserList).vm.$emit("removed", "bob");
+            wrapper.findComponent(UserList).vm.$emit("removed", "bob");
 
             setTimeout(() => {
-                expect(wrapper.find(ErrorInfo).props("apiError")).toBeDefined();
-                expect(wrapper.find(ErrorInfo).props("defaultMessage")).toBe("could not remove bob");
+                expect(wrapper.findComponent(ErrorInfo).props("apiError")).toBeDefined();
+                expect(wrapper.findComponent(ErrorInfo).props("defaultMessage")).toBe("could not remove bob");
                 done();
             });
         });
@@ -241,8 +241,8 @@ describe("reportReadersList", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(AddReportReader).props().availableUserGroups.length).toBe(1);
-        expect(wrapper.find(AddReportReader).props().availableUserGroups[0]).toBe("another.user@example.com");
+        expect(wrapper.findComponent(AddReportReader).props().availableUserGroups.length).toBe(1);
+        expect(wrapper.findComponent(AddReportReader).props().availableUserGroups[0]).toBe("another.user@example.com");
     });
 
 });

--- a/src/app/static/src/tests/components/reports/reportTags.test.js
+++ b/src/app/static/src/tests/components/reports/reportTags.test.js
@@ -128,7 +128,7 @@ describe("reportTags", () => {
         const modal = wrapper.find("#edit-tags");
         expect(modal.classes().indexOf("modal-show")).toBeGreaterThan(-1);
 
-        const tagLists = modal.findAll(TagList);
+        const tagLists = wrapper.findAllComponents(TagList);
         expect(tagLists.length).toBe(3);
         const versionTags = tagLists.at(0);
         expect(versionTags.props().header).toBe("Report Version Tags");
@@ -238,8 +238,8 @@ describe("reportTags", () => {
             expect(wrapper.vm.$data.defaultMessage).toBe("An error occurred updating tags");
             expect(wrapper.vm.$data.error.response.data).toBe("TEST ERROR");
 
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("An error occurred updating tags");
-            expect(wrapper.find(ErrorInfo).props().apiError.response.data).toBe("TEST ERROR");
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("An error occurred updating tags");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError.response.data).toBe("TEST ERROR");
 
             done();
         });
@@ -270,8 +270,8 @@ describe("reportTags", () => {
             expect(wrapper.vm.$data.defaultMessage).toBe("An error occurred fetching tags");
             expect(wrapper.vm.$data.error.response.data).toBe("TEST ERROR");
 
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("An error occurred fetching tags");
-            expect(wrapper.find(ErrorInfo).props().apiError.response.data).toBe("TEST ERROR");
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("An error occurred fetching tags");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError.response.data).toBe("TEST ERROR");
 
             done();
         });

--- a/src/app/static/src/tests/components/reports/scopedReaderRolesList.test.js
+++ b/src/app/static/src/tests/components/reports/scopedReaderRolesList.test.js
@@ -63,10 +63,10 @@ describe("scopedReaderRolesList", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
-        expect(wrapper.find(RoleList).props().canRemoveRoles).toBe(true);
-        expect(wrapper.find(RoleList).props().canRemoveMembers).toBe(false);
-        expect(wrapper.find(RoleList).props().permission).toStrictEqual({
+        expect(wrapper.findComponent(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
+        expect(wrapper.findComponent(RoleList).props().canRemoveRoles).toBe(true);
+        expect(wrapper.findComponent(RoleList).props().canRemoveMembers).toBe(false);
+        expect(wrapper.findComponent(RoleList).props().permission).toStrictEqual({
             name: "reports.read",
             scope_id : "report1",
             scope_prefix: "report"
@@ -90,8 +90,8 @@ describe("scopedReaderRolesList", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(ErrorInfo).props().apiError).toBe("test-error");
-        expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("test-default");
+        expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe("test-error");
+        expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("test-default");
     });
 
     it('renders add report reader component', async () => {
@@ -105,10 +105,10 @@ describe("scopedReaderRolesList", () => {
 
         await Vue.nextTick();
 
-        expect(wrapper.find(AddReportReader).props().type).toBe("role");
-        expect(wrapper.find(AddReportReader).props().reportName).toBe("report1");
-        expect(wrapper.find(AddReportReader).props().availableUserGroups.length).toBe(2);
-        expect(wrapper.find(AddReportReader).props().availableUserGroups)
+        expect(wrapper.findComponent(AddReportReader).props().type).toBe("role");
+        expect(wrapper.findComponent(AddReportReader).props().reportName).toBe("report1");
+        expect(wrapper.findComponent(AddReportReader).props().availableUserGroups.length).toBe(2);
+        expect(wrapper.findComponent(AddReportReader).props().availableUserGroups)
             .toEqual(expect.arrayContaining(["Tech", "Admin"]));
 
     });
@@ -149,8 +149,8 @@ describe("scopedReaderRolesList", () => {
 
         setTimeout(() => {
             expect(mockAxios.history.get.length).toBe(2);
-            expect(wrapper.find(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
-            expect(wrapper.find(AddReportReader).props().availableUserGroups)
+            expect(wrapper.findComponent(RoleList).props().roles).toEqual(expect.arrayContaining(mockRoles));
+            expect(wrapper.findComponent(AddReportReader).props().availableUserGroups)
                 .toEqual(expect.arrayContaining(["Tech", "Admin"]));
 
             done();
@@ -169,7 +169,7 @@ describe("scopedReaderRolesList", () => {
 
         expect(mockAxios.history.get.length).toBe(2);
 
-        wrapper.find(RoleList).vm.$emit("removed", "Funders");
+        wrapper.findComponent(RoleList).vm.$emit("removed", "Funders");
 
         setTimeout(() => {
             expect(mockAxios.history.delete.length).toBe(1);
@@ -189,7 +189,7 @@ describe("scopedReaderRolesList", () => {
 
         const wrapper = getSut();
 
-        wrapper.find(RoleList).vm.$emit("removed", "Funders");
+        wrapper.findComponent(RoleList).vm.$emit("removed", "Funders");
 
         setTimeout(() => {
 

--- a/src/app/static/src/tests/components/reports/setGlobalPinnedReports.test.js
+++ b/src/app/static/src/tests/components/reports/setGlobalPinnedReports.test.js
@@ -68,12 +68,12 @@ describe("setGlobalPinnedReports", () => {
         expect(li.at(1).find(".name").text()).toBe("r2 display");
         expect(li.at(1).find(".name").attributes().id).toBe("r2");
 
-        expect(wrapper.find(Typeahead).props().data).toStrictEqual(["r3 display"]);
+        expect(wrapper.findComponent(Typeahead).props().data).toStrictEqual(["r3 display"]);
         expect(wrapper.find("#pinned-report-buttons button[type='submit']").text()).toBe("Save changes");
         expect(wrapper.find(".btn-default").text()).toBe("Cancel");
 
-        expect(wrapper.find(ErrorInfo).props().apiError).toBe(null);
-        expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("");
+        expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe(null);
+        expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("");
     });
 
     it("can remove pinned report", async () => {
@@ -125,8 +125,8 @@ describe("setGlobalPinnedReports", () => {
 
             expect(mockReload.mock.calls.length).toBe(1);
 
-            expect(wrapper.find(ErrorInfo).props().apiError).toBe(null);
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError).toBe(null);
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("");
 
             done();
         });
@@ -148,8 +148,8 @@ describe("setGlobalPinnedReports", () => {
 
             expect(mockReload.mock.calls.length).toBe(0);
 
-            expect(wrapper.find(ErrorInfo).props().apiError.response.data).toBe("TEST ERROR");
-            expect(wrapper.find(ErrorInfo).props().defaultMessage).toBe("could not save pinned reports");
+            expect(wrapper.findComponent(ErrorInfo).props().apiError.response.data).toBe("TEST ERROR");
+            expect(wrapper.findComponent(ErrorInfo).props().defaultMessage).toBe("could not save pinned reports");
 
             done();
         });

--- a/src/app/static/src/tests/components/runReport/changeLog.test.ts
+++ b/src/app/static/src/tests/components/runReport/changeLog.test.ts
@@ -68,8 +68,8 @@ describe(`changeLog`, () => {
         const label = ["col-form-label", "col-sm-2", "text-right"]
         const control = ["col-sm-6"]
 
-        const changelogMessage = wrapper.find(ChangeLog).find("#changelog-message")
-        const changelogType= wrapper.find(ChangeLog).find("#changelog-type")
+        const changelogMessage = wrapper.findComponent(ChangeLog).find("#changelog-message")
+        const changelogType= wrapper.findComponent(ChangeLog).find("#changelog-type")
 
         expect(changelogMessage.find("label").classes()).toEqual(label)
         expect(changelogMessage.find("#change-message-control").classes()).toEqual(control)

--- a/src/app/static/src/tests/components/runReport/gitUpdateReports.test.ts
+++ b/src/app/static/src/tests/components/runReport/gitUpdateReports.test.ts
@@ -177,8 +177,8 @@ describe("gitUpdateReports", () => {
 
                 expect(wrapper.vm.$data.selectedCommitId).toBe("bcdefg");
 
-                expect(wrapper.find(ErrorInfo).props("apiError")).toBe("");
-                expect(wrapper.find(ErrorInfo).props("defaultMessage")).toBe("");
+                expect(wrapper.findComponent(ErrorInfo).props("apiError")).toBe("");
+                expect(wrapper.findComponent(ErrorInfo).props("defaultMessage")).toBe("");
 
                 expect(wrapper.emitted("branchSelected")![1][0]).toBe("dev");
                 expect(wrapper.emitted("commitSelected")![1][0]).toBe("bcdefg");
@@ -220,8 +220,8 @@ describe("gitUpdateReports", () => {
         });
 
         setTimeout(() => {
-            expect(wrapper.find(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
-            expect(wrapper.find(ErrorInfo).props("defaultMessage")).toBe("An error occurred fetching Git commits");
+            expect(wrapper.findComponent(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
+            expect(wrapper.findComponent(ErrorInfo).props("defaultMessage")).toBe("An error occurred fetching Git commits");
             done();
         })
     });
@@ -238,8 +238,8 @@ describe("gitUpdateReports", () => {
         });
 
         setTimeout(() => {
-            expect(wrapper.find(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
-            expect(wrapper.find(ErrorInfo).props("defaultMessage")).toBe("An error occurred fetching reports");
+            expect(wrapper.findComponent(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
+            expect(wrapper.findComponent(ErrorInfo).props("defaultMessage")).toBe("An error occurred fetching reports");
             done();
         });
     });
@@ -318,8 +318,8 @@ describe("gitUpdateReports", () => {
                 expect(button.attributes("disabled")).toBeUndefined();
                 expect(wrapper.vm.$data.error.response.data).toBe("TEST ERROR");
                 expect(wrapper.vm.$data.defaultMessage).toBe("An error occurred refreshing Git");
-                expect(wrapper.find(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
-                expect(wrapper.find(ErrorInfo).props("defaultMessage")).toBe("An error occurred refreshing Git");
+                expect(wrapper.findComponent(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
+                expect(wrapper.findComponent(ErrorInfo).props("defaultMessage")).toBe("An error occurred refreshing Git");
                 done();
             })
         })

--- a/src/app/static/src/tests/components/runReport/runReport.test.ts
+++ b/src/app/static/src/tests/components/runReport/runReport.test.ts
@@ -102,10 +102,10 @@ describe("runReport", () => {
 
         await Vue.nextTick();
 
-        await wrapper.find(ReportList).find("li").trigger("mousedown");
+        await wrapper.findComponent(ReportList).find("li").trigger("mousedown");
         expect(wrapper.vm.$data["selectedReport"]).toBe(global);
 
-        await wrapper.find(ReportList).find("button").trigger("click");
+        await wrapper.findComponent(ReportList).find("button").trigger("click");
         expect(wrapper.vm.$data["selectedReport"]).toBe(null);
     });
 
@@ -118,7 +118,7 @@ describe("runReport", () => {
         await Vue.nextTick();
         await Vue.nextTick();
         await Vue.nextTick();
-        expect(wrapper.find(ReportList).props("selectedReport")).toBe(minimal);
+        expect(wrapper.findComponent(ReportList).props("selectedReport")).toBe(minimal);
     });
 
     it("shows instances if instances supported", async() => {
@@ -195,11 +195,11 @@ describe("runReport", () => {
         });
 
         expect(wrapper.find("#parameters").exists()).toBe(true);
-        const labels = wrapper.find(ParameterList).findAll("label")
+        const labels = wrapper.findComponent(ParameterList).findAll("label")
         expect(labels.at(0).text()).toBe("global");
         expect(labels.at(1).text()).toBe("minimal");
 
-        const inputs = wrapper.find(ParameterList).findAll("input")
+        const inputs = wrapper.findComponent(ParameterList).findAll("input")
         inputs.at(0).setValue("Set new value");
         inputs.at(1).setValue("Set new value 2");
 
@@ -223,7 +223,7 @@ describe("runReport", () => {
             }
         });
         expect(wrapper.find("#parameters").exists()).toBe(false);
-        expect(wrapper.find(ParameterList).exists()).toBe(false);
+        expect(wrapper.findComponent(ParameterList).exists()).toBe(false);
     });
 
     it("parameters endpoint can get data successfully", (done) => {
@@ -292,7 +292,7 @@ describe("runReport", () => {
             }
         });
         expect(wrapper.find("#parameters").exists()).toBe(false);
-        expect(wrapper.find(ParameterList).exists()).toBe(false);
+        expect(wrapper.findComponent(ParameterList).exists()).toBe(false);
     });
 
     it("renders run button group if there is a selected report", async () => {
@@ -342,8 +342,8 @@ describe("runReport", () => {
             }
         });
 
-        expect(wrapper.find(Instances).emitted().selectedValues.length).toBe(1)
-        expect(wrapper.find(Instances).emitted().selectedValues[0][0]).toEqual({"annexe": "a1", "source": "uat"})
+        expect(wrapper.findComponent(Instances).emitted().selectedValues.length).toBe(1)
+        expect(wrapper.findComponent(Instances).emitted().selectedValues[0][0]).toEqual({"annexe": "a1", "source": "uat"})
         setTimeout(async () => { //give the wrapper time to fetch reports
             wrapper.setData({
                 selectedReport: {name: "test-report"},
@@ -352,9 +352,9 @@ describe("runReport", () => {
                 defaultMessage: "test-msg"
             });
             await Vue.nextTick()
-            wrapper.find(Instances).setData({selectedInstances: {source: "science", annexe: "a1"}})
-            expect(wrapper.find(Instances).emitted().selectedValues.length).toBe(1)
-            expect(wrapper.find(Instances).emitted().selectedValues[0][0]).toEqual({"annexe": "a1", "source": "science"})
+            wrapper.findComponent(Instances).setData({selectedInstances: {source: "science", annexe: "a1"}})
+            expect(wrapper.findComponent(Instances).emitted().selectedValues.length).toBe(1)
+            expect(wrapper.findComponent(Instances).emitted().selectedValues[0][0]).toEqual({"annexe": "a1", "source": "science"})
             wrapper.setData({
                 parameterValues: [{name: "minimal", value: "test"}, {name: "global", value: "random_39id"}],
             })
@@ -625,8 +625,8 @@ describe("runReport", () => {
         await wrapper.find("#changelogMessage").setValue("New message")
         expect(wrapper.vm.$data.changelog.message).toBe("New message")
 
-        const changelogMessage = wrapper.find(changeLog).find("#changelog-message")
-        const changelogType= wrapper.find(changeLog).find("#changelog-type")
+        const changelogMessage = wrapper.findComponent(changeLog).find("#changelog-message")
+        const changelogType= wrapper.findComponent(changeLog).find("#changelog-type")
 
         expect(changelogMessage.find("label").classes()).toEqual(label)
         expect(changelogMessage.find("#change-message-control").classes()).toEqual(control)

--- a/src/app/static/src/tests/components/runReport/runReportTabs.test.ts
+++ b/src/app/static/src/tests/components/runReport/runReportTabs.test.ts
@@ -78,7 +78,7 @@ describe("runReportTabs", () => {
         Storage.prototype.setItem = jest.fn();
         const spySetStorage = jest.spyOn(Storage.prototype, 'setItem').mock;
         const wrapper = getWrapper();
-        const runReport = wrapper.find(RunReport);
+        const runReport = wrapper.findComponent(RunReport);
         runReport.vm.$emit("update:key", "emittedKey");
         expect(wrapper.vm.$data.selectedRunningReportKey).toBe("emittedKey");
         expect(spySetStorage.calls[0][0]).toBe("selectedRunningReportKey");
@@ -87,7 +87,7 @@ describe("runReportTabs", () => {
 
     it("switches to the reportLogs tab when reportRun emits change tab event", async () => {
         const wrapper = getWrapper();
-        const runReport = wrapper.find(RunReport);
+        const runReport = wrapper.findComponent(RunReport);
         runReport.vm.$emit("update:key", "emittedKey");
         runReport.vm.$emit("changeTab");
         await Vue.nextTick();

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflow.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflow.test.ts
@@ -62,14 +62,14 @@ describe(`runWorkflow`, () => {
 
     it(`does not start workflow wizard when run workflow is rendered`, async () => {
         const wrapper = getWrapper()
-        expect(wrapper.find(workflowWizard).exists()).toBe(false)
+        expect(wrapper.findComponent(workflowWizard).exists()).toBe(false)
     })
 
     it(`can cancel workflow wizard`, async () => {
         const wrapper = getWrapper()
 
         //Enables rerun and clone buttons
-        await wrapper.find(runWorkflowCreate).setData(
+        await wrapper.findComponent(runWorkflowCreate).setData(
             {
                 selectedWorkflow: selectedWorkflow,
                 runWorkflowMetadata: workflowMetadata
@@ -116,7 +116,7 @@ describe(`runWorkflow`, () => {
     it(`can start and cancel workflow wizard correctly when starting a workflow wizard from re-run`, async () => {
         const wrapper = getWrapper()
         //Enables rerun button
-        await wrapper.find(runWorkflowCreate).setData(
+        await wrapper.findComponent(runWorkflowCreate).setData(
             {
                 selectedWorkflow: selectedWorkflow,
                 runWorkflowMetadata: workflowMetadata

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowCreate.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowCreate.test.ts
@@ -101,7 +101,7 @@ describe(`runWorkflowCreate`, () => {
             expect(wrapper.vm.$data.defaultMessage).toStrictEqual("")
             expect(wrapper.vm.$data.workflows).toStrictEqual(workflowSummaryMetadata)
 
-            const vueSelect = wrapper.find(VueSelect)
+            const vueSelect = wrapper.findComponent(VueSelect)
             vueSelect.vm.$emit("input", selectedWorkflow)
             expect(vueSelect.find("input").attributes("placeholder")).toBe("Search by name or user...")
             await wrapper.setData({runWorkflowMetadata: workflowMetadata})
@@ -123,7 +123,7 @@ describe(`runWorkflowCreate`, () => {
             expect(wrapper.vm.$data.defaultMessage).toStrictEqual("")
             expect(wrapper.vm.$data.workflows).toStrictEqual(workflowSummaryMetadata)
 
-            const vueSelect = wrapper.find(VueSelect)
+            const vueSelect = wrapper.findComponent(VueSelect)
             vueSelect.vm.$emit("input", selectedWorkflow)
             expect(vueSelect.find("input").attributes("placeholder")).toBe("Search by name or user...")
             await wrapper.setData({runWorkflowMetadata: workflowMetadata})

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowProgress.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowProgress.test.ts
@@ -244,8 +244,8 @@ describe(`runWorkflowProgress`, () => {
         setTimeout(() => {
             wrapper.find("#rerun").trigger("click");
             setTimeout(() => {
-                expect(wrapper.find(errorInfo).props("apiError").response.data).toBe("TEST ERROR");
-                expect(wrapper.find(errorInfo).props("defaultMessage")).toBe("An error occurred fetching workflow details");
+                expect(wrapper.findComponent(errorInfo).props("apiError").response.data).toBe("TEST ERROR");
+                expect(wrapper.findComponent(errorInfo).props("defaultMessage")).toBe("An error occurred fetching workflow details");
                 expect(wrapper.emitted("rerun")).toBeUndefined();
                 done();
             });

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
@@ -101,9 +101,9 @@ describe(`runWorkflowReport`, () => {
 
     it("does not render content until run report metadata is set", (done) => {
         const wrapper = getWrapper();
-        expect(wrapper.find(GitUpdateReports).exists()).toBe(false);
+        expect(wrapper.findComponent(GitUpdateReports).exists()).toBe(false);
         setTimeout(async () => {
-            expect(wrapper.find(GitUpdateReports).exists()).toBe(true);
+            expect(wrapper.findComponent(GitUpdateReports).exists()).toBe(true);
             done();
         });
     });

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowRun.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowRun.test.ts
@@ -370,8 +370,8 @@ describe(`runWorkflowRun`, () => {
         });
 
         setTimeout(() => {
-            expect(wrapper.find(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
-            expect(wrapper.find(ErrorInfo).props("defaultMessage")).toBe("An error occurred while retrieving previously run workflows");
+            expect(wrapper.findComponent(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
+            expect(wrapper.findComponent(ErrorInfo).props("defaultMessage")).toBe("An error occurred while retrieving previously run workflows");
             done();
         })
     });
@@ -387,8 +387,8 @@ describe(`runWorkflowRun`, () => {
         });
 
         setTimeout(() => {
-            expect(wrapper.find(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
-            expect(wrapper.find(ErrorInfo).props("defaultMessage")).toBe("An error occurred while retrieving data");
+            expect(wrapper.findComponent(ErrorInfo).props("apiError").response.data).toBe("TEST ERROR");
+            expect(wrapper.findComponent(ErrorInfo).props("defaultMessage")).toBe("An error occurred while retrieving data");
             done();
         })
     });

--- a/src/app/static/src/tests/components/typeahead/typeahead.test.js
+++ b/src/app/static/src/tests/components/typeahead/typeahead.test.js
@@ -24,7 +24,7 @@ describe('VueBootstrapTypeahead', () => {
     })
 
     it('Should mount and render a hidden typeahead list', () => {
-        let child = wrapper.find(VueBootstrapTypeaheadList)
+        let child = wrapper.findComponent(VueBootstrapTypeaheadList)
         expect(child).toBeTruthy()
         expect(child.isVisible()).toBe(false)
     })
@@ -51,7 +51,7 @@ describe('VueBootstrapTypeahead', () => {
     })
 
     it('Show the list when given a query and focused', async () => {
-        let child = wrapper.find(VueBootstrapTypeaheadList)
+        let child = wrapper.findComponent(VueBootstrapTypeaheadList)
         wrapper.find('input').setValue('Can')
         await Vue.nextTick();
         expect(child.isVisible()).toBe(false)
@@ -61,7 +61,7 @@ describe('VueBootstrapTypeahead', () => {
     })
 
     it('Hides the list when blurred', async () => {
-        let child = wrapper.find(VueBootstrapTypeaheadList)
+        let child = wrapper.findComponent(VueBootstrapTypeaheadList)
         wrapper.setData({inputValue: 'Can'})
         await Vue.nextTick();
         wrapper.find('input').trigger('focus')

--- a/src/app/static/src/tests/components/typeahead/typeaheadList.test.js
+++ b/src/app/static/src/tests/components/typeahead/typeaheadList.test.js
@@ -38,7 +38,7 @@ describe('VueBootstrapTypeaheadList', () => {
     })
 
     it('Mounts and renders a list-group div', () => {
-        expect(wrapper.is('div')).toBe(true)
+        expect(wrapper.element.tagName).toBe("DIV")
         expect(wrapper.classes()).toContain('list-group')
     })
 
@@ -49,13 +49,13 @@ describe('VueBootstrapTypeaheadList', () => {
         })
         await Vue.nextTick();
         expect(wrapper.vm.matchedItems.length).toBe(2)
-        expect(wrapper.findAll(VueBootstrapTypeaheadListItem).length).toBe(2)
+        expect(wrapper.findAllComponents(VueBootstrapTypeaheadListItem).length).toBe(2)
         wrapper.setProps({
             query: 'Canada'
         })
         await Vue.nextTick();
         expect(wrapper.vm.matchedItems.length).toBe(1)
-        expect(wrapper.findAll(VueBootstrapTypeaheadListItem).length).toBe(1)
+        expect(wrapper.findAllComponents(VueBootstrapTypeaheadListItem).length).toBe(1)
     })
 
     it('Limits the number of matches with maxMatches', async () => {
@@ -77,7 +77,7 @@ describe('VueBootstrapTypeaheadList', () => {
             minMatchingChars: 1
         })
         await Vue.nextTick();
-        expect(wrapper.findAll(VueBootstrapTypeaheadListItem).length).toBe(3)
+        expect(wrapper.findAllComponents(VueBootstrapTypeaheadListItem).length).toBe(3)
     })
 
     it('Highlights text matches properly', async () => {
@@ -85,7 +85,7 @@ describe('VueBootstrapTypeaheadList', () => {
             query: 'Canada'
         })
         await Vue.nextTick();
-        expect(wrapper.find(VueBootstrapTypeaheadListItem).vm.htmlText).toBe('<strong>Canada</strong>')
+        expect(wrapper.findComponent(VueBootstrapTypeaheadListItem).vm.htmlText).toBe('<strong>Canada</strong>')
     })
 
     it('Resets the active list item', async () => {

--- a/src/app/static/src/tests/components/typeahead/typeaheadListItem.test.js
+++ b/src/app/static/src/tests/components/typeahead/typeaheadListItem.test.js
@@ -10,7 +10,7 @@ describe('VueBootstrapTypeaheadListItem.vue', () => {
 
     it('Mounts and renders an <a> tag', () => {
         expect(wrapper.exists()).toBe(true)
-        expect(wrapper.contains('a')).toBe(true)
+        expect(wrapper.find('a').exists()).toBe(true)
     })
 
     it('Renders textVariant classes properly', async () => {

--- a/src/app/static/src/tests/components/workflowWizard/workflowWizard.test.ts
+++ b/src/app/static/src/tests/components/workflowWizard/workflowWizard.test.ts
@@ -44,15 +44,15 @@ describe(`workflowWizard`, () => {
     it(`can render first step, component and buttons correctly`, async () => {
         const wrapper = getWrapper()
         await wrapper.setData({activeStep: 0})
-        const getSteps = wrapper.findAll(step)
+        const getSteps = wrapper.findAllComponents(step)
         const mockButtonVisibility = {back: false}
-        expect(getSteps.at(0).find(runWorkflowReport).exists()).toBe(true)
+        expect(getSteps.at(0).findComponent(runWorkflowReport).exists()).toBe(true)
         expect(getSteps.at(0).props("buttonOptions")).toMatchObject(mockButtonVisibility)
     });
 
     it(`can render final step component and buttons correctly`, async () => {
         const wrapper = getWrapper()
-        const finalStepIndex = steps.length-1
+        const finalStepIndex = steps.length - 1
         await wrapper.setData({activeStep: finalStepIndex})
 
         const buttons = wrapper.findAll("button")
@@ -61,8 +61,8 @@ describe(`workflowWizard`, () => {
         expect(buttons.at(1).text()).toBe("Back")
         expect(buttons.at(2).text()).toBe("Submit")
 
-        const getSteps = wrapper.findAll(step)
-        expect(getSteps.at(finalStepIndex).find(runWorkflowRun).exists()).toBe(true)
+        const getSteps = wrapper.findAllComponents(step)
+        expect(getSteps.at(finalStepIndex).findComponent(runWorkflowRun).exists()).toBe(true)
     })
 
     it(`can render final step, component and buttons correctly when re-running a workflow`, async () => {
@@ -75,13 +75,13 @@ describe(`workflowWizard`, () => {
         expect(buttons.at(0).text()).toBe("Cancel")
         expect(buttons.at(1).text()).toBe("Submit")
 
-        const getSteps = wrapper.findAll(step)
-        expect(getSteps.at(mockStep.length-1).find(runWorkflowRun).exists()).toBe(true)
+        const getSteps = wrapper.findAllComponents(step)
+        expect(getSteps.at(mockStep.length - 1).findComponent(runWorkflowRun).exists()).toBe(true)
     })
 
     it(`can render default propsData on steps correctly`, async () => {
 
-        const wrapper =  shallowMount(workflowWizard, {
+        const wrapper = shallowMount(workflowWizard, {
             propsData: {
                 initialRunWorkflowMetadata: {placeholder: "testdata"},
                 steps: steps
@@ -93,19 +93,19 @@ describe(`workflowWizard`, () => {
             }
         })
 
-        const getSteps = wrapper.findAll(step)
+        const getSteps = wrapper.findAllComponents(step)
         expect(getSteps.length).toBe(2)
 
         await Vue.nextTick()
 
         //first step
         expect(getSteps.at(0).props().buttonOptions).toMatchObject({back: false})
-        expect(getSteps.at(0).find(runWorkflowReport).props().workflowMetadata)
+        expect(getSteps.at(0).findComponent(runWorkflowReport).props().workflowMetadata)
             .toMatchObject({"placeholder": "testdata"})
 
         //Final step
         expect(getSteps.at(1).props().buttonOptions).toMatchObject({back: true})
-        expect(getSteps.at(1).find(runWorkflowRun).props().workflowMetadata)
+        expect(getSteps.at(1).findComponent(runWorkflowRun).props().workflowMetadata)
             .toMatchObject({"placeholder": "testdata"})
     })
 
@@ -123,11 +123,11 @@ describe(`workflowWizard`, () => {
         });
     })
 
-    it(`can render run component`, async() => {
+    it(`can render run component`, async () => {
         const wrapper = getWrapper()
 
         //run step is usually the final step
-        const finalStepIndex = steps.length-1
+        const finalStepIndex = steps.length - 1
         await wrapper.setData({activeStep: finalStepIndex})
 
         expect(wrapper.find("#run-header").text()).toBe("Run workflow")
@@ -141,7 +141,7 @@ describe(`workflowWizard`, () => {
     it(`can go to the next step`, async () => {
         const wrapper = getWrapper()
         await wrapper.setData({activeStep: 0})
-        await wrapper.find(runWorkflowReport).vm.$emit("valid", true)
+        await wrapper.findComponent(runWorkflowReport).vm.$emit("valid", true)
         const buttons = wrapper.findAll("button")
 
         expect(buttons.length).toBe(4)
@@ -204,11 +204,13 @@ describe(`workflowWizard`, () => {
         ]
 
         const mockHasVisibility = {back: true}
-        const wrapper =  shallowMount(workflowWizard, {
+        const wrapper = shallowMount(workflowWizard, {
             propsData: {
+                initialRunWorkflowMetadata: mockRunWorkflowMetadata(),
                 runWorkflowMetadata: {placeholder: "testdata"},
                 steps: newSteps,
             },
+            stubs: {"testComponent": {template: "<div id='test'></div>"}},
             data() {
                 return {
                     activeStep: 0,
@@ -217,12 +219,12 @@ describe(`workflowWizard`, () => {
             }
         })
 
-        const getSteps = wrapper.findAll(step)
+        const getSteps = wrapper.findAllComponents(step)
         expect(getSteps.length).toBe(3)
 
         //newly added step
         expect(getSteps.at(1).props().buttonOptions).toMatchObject(mockHasVisibility)
-        expect(getSteps.at(1).find("testComponent").exists()).toBe(true)
+        expect(getSteps.at(1).find("#test").exists()).toBe(true)
     })
 
     it(`can toggle final step button`, async () => {
@@ -236,15 +238,15 @@ describe(`workflowWizard`, () => {
         expect(buttons.at(0).text()).toBe("Cancel")
         expect(buttons.at(1).text()).toBe("Any name")
 
-        const getSteps = wrapper.findAll(step)
-        expect(getSteps.at(mockStep.length-1).find(runWorkflowRun).exists()).toBe(true)
+        const getSteps = wrapper.findAllComponents(step)
+        expect(getSteps.at(mockStep.length - 1).findComponent(runWorkflowRun).exists()).toBe(true)
     })
 
     it(`handles metadata update event from step component and emits upwards`, async () => {
         const wrapper = getWrapper();
         await wrapper.setData({activeStep: 0});
 
-        wrapper.find(runWorkflowReport).vm.$emit("update", {newProp: "newVal"})
+        wrapper.findComponent(runWorkflowReport).vm.$emit("update", {newProp: "newVal"})
         await Vue.nextTick();
 
         const runWorkflowMetadata = {...mockRunWorkflowMetadata(), newProp: "newVal"}


### PR DESCRIPTION
Removes almost all warnings from front-end tests. Mostly just a case of replacing `find` with `findComponent` in a bunch of places, and then a bit of re-jigging needed to avoid illegal chaining of `find` and `findComponent`. The only remaining warning, involving `runworkflowReport.test.ts`, is less trivial to fix.