### PR TITLE
mrc-2829 Pass show_all flag to runnable reports endpoint for run workflow

### DIFF
--- a/src/app/static/src/js/components/runReport/gitUpdateReports.vue
+++ b/src/app/static/src/js/components/runReport/gitUpdateReports.vue
@@ -40,7 +40,8 @@
             "reportMetadata",
             "initialBranches",
             "initialBranch",
-            "initialCommitId"
+            "initialCommitId",
+            "showAllReports"
         ],
         components: {
             ErrorInfo
@@ -109,7 +110,8 @@
             },
             updateReports() {
                 this.reports = [];
-                const query = this.reportMetadata.git_supported ? `?branch=${this.selectedBranch}&commit=${this.selectedCommitId}` : '';
+                const showAllParam = this.showAllReports ? "&show_all=true" : "";
+                const query = this.reportMetadata.git_supported ? `?branch=${this.selectedBranch}&commit=${this.selectedCommitId}${showAllParam}` : '';
                 api.get(`/reports/runnable/${query}`)
                     .then(({data}) => {
                         this.reports = data.data;

--- a/src/app/static/src/js/components/runReport/runReport.vue
+++ b/src/app/static/src/js/components/runReport/runReport.vue
@@ -5,6 +5,7 @@
             <git-update-reports
                 :report-metadata="metadata"
                 :initial-branches="initialGitBranches"
+                :show-all-reports="false"
                 @branchSelected="branchSelected"
                 @commitSelected="commitSelected"
                 @reportsUpdate="updateReports"

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowReport.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowReport.vue
@@ -21,6 +21,7 @@
                         :initial-branch="workflowMetadata.git_branch"
                         :initial-commit-id="workflowMetadata.git_commit"
                         :initial-branches="initialBranches"
+                        :show-all-reports="true"
                         @branchSelected="branchSelected"
                         @commitSelected="commitSelected"
                         @reportsUpdate="updateAvailableReportsFromGit"

--- a/src/app/static/src/tests/components/runReport/gitUpdateReports.test.ts
+++ b/src/app/static/src/tests/components/runReport/gitUpdateReports.test.ts
@@ -26,6 +26,7 @@ describe("gitUpdateReports", () => {
     const initialBranches = ["master", "dev"];
     const initialBranch = "master";
     const initialCommitId = "abc123";
+    const showAllReports = false;
 
     const props = {
         reportMetadata: {
@@ -34,7 +35,8 @@ describe("gitUpdateReports", () => {
         },
         initialBranches,
         initialBranch,
-        initialCommitId
+        initialCommitId,
+        showAllReports
     };
 
     const getWrapper = (report = reports, propsData = props) => {
@@ -323,5 +325,45 @@ describe("gitUpdateReports", () => {
                 done();
             })
         })
+    });
+
+    it("gets reports with show_all flag when showAllReports prop is true", (done) => {
+        const url = 'http://app/reports/runnable/?branch=master&commit=abc123&show_all=true';
+        mockAxios.onGet(url)
+            .reply(200, {"data": [ reports[0] ]});
+        const wrapper = shallowMount(GitUpdateReports, {
+            propsData: {
+                reportMetadata: {git_supported: true, instances_supported: false},
+                initialBranches,
+                initialBranch,
+                initialCommitId,
+                showAllReports: true
+            }
+        });
+        setTimeout(() => {
+            const getHistory = mockAxios.history.get;
+            expect(getHistory[getHistory.length - 1].url).toBe(url);
+            expect(wrapper.emitted("reportsUpdate")![0][0]).toStrictEqual([reports[0]]);
+            done();
+        });
+    });
+
+    it("gets reports without show_all flag when showAllReports prop is true but git_supported is false", (done) => {
+        const url = 'http://app/reports/runnable/';
+        mockAxios.onGet(url)
+            .reply(200, {"data": [ reports[0] ]});
+        const wrapper = shallowMount(GitUpdateReports, {
+            propsData: {
+                reportMetadata: {git_supported: false, instances_supported: false},
+                initiatBranches: null,
+                showAllReports: true
+            }
+        });
+        setTimeout(() => {
+            const getHistory = mockAxios.history.get;
+            expect(getHistory[getHistory.length - 1].url).toBe(url);
+            expect(wrapper.emitted("reportsUpdate")![0][0]).toStrictEqual([reports[0]]);
+            done();
+        });
     });
 });

--- a/src/app/static/src/tests/components/runReport/runReport.test.ts
+++ b/src/app/static/src/tests/components/runReport/runReport.test.ts
@@ -61,6 +61,7 @@ describe("runReport", () => {
         const gitUpdateReports = wrapper.findComponent(GitUpdateReports);
         expect(gitUpdateReports.props("reportMetadata")).toBe(props.metadata);
         expect(gitUpdateReports.props("initialBranches")).toBe(initialGitBranches);
+        expect(gitUpdateReports.props("showAllReports")).toBe(false);
     });
 
     it("selects branch when event emitted from gitUpdateReports", async () => {

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
@@ -73,6 +73,7 @@ describe(`runWorkflowReport`, () => {
             expect(git.props("initialBranches")).toStrictEqual(mockRunReportMetadata().git_branches);
             expect(git.props("initialBranch")).toBe("master");
             expect(git.props("initialCommitId")).toBe("abc123");
+            expect(git.props("showAllReports")).toBe(true);
 
             const error = wrapper.findComponent(ErrorInfo);
             expect(error.props("apiError")).toBe("");

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport_validation.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport_validation.test.ts
@@ -24,7 +24,7 @@ describe("runWorkflowReport validation", () => {
 
         mockAxios.onGet('http://app/git/branch/master/commits/')
             .reply(200, {"data": gitCommits});
-        mockAxios.onGet('http://app/reports/runnable/?branch=master&commit=abcdef')
+        mockAxios.onGet('http://app/reports/runnable/?branch=master&commit=abcdef&show_all=true')
             .reply(200, {"data": reports});
     });
 
@@ -244,7 +244,7 @@ describe("runWorkflowReport validation", () => {
     });
 
     it("emits valid true when commit change removes report which was invalid", (done) => {
-        mockAxios.onGet('http://app/reports/runnable/?branch=master&commit=abc123')
+        mockAxios.onGet('http://app/reports/runnable/?branch=master&commit=abc123&show_all=true')
             .reply(200, {"data": [{ name: "minimal", date: null }]});
 
         mockAxios.onGet('http://app/report/minimal/config/parameters/?commit=abc123')
@@ -279,7 +279,7 @@ describe("runWorkflowReport validation", () => {
             .reply(200, {data: [{name: "p1", value: null}]});
 
         //Responses for newly selected commit
-        mockAxios.onGet('http://app/reports/runnable/?branch=master&commit=abc123')
+        mockAxios.onGet('http://app/reports/runnable/?branch=master&commit=abc123&show_all=true')
             .reply(200, {"data": [
                 { name: "minimal", date: null },
                 { name: "global", date: null }
@@ -322,7 +322,7 @@ describe("runWorkflowReport validation", () => {
 
 
         //Responses for newly selected commit
-        mockAxios.onGet('http://app/reports/runnable/?branch=master&commit=abc123')
+        mockAxios.onGet('http://app/reports/runnable/?branch=master&commit=abc123&show_all=true')
             .reply(200, {"data": [
                     { name: "minimal", date: null },
                     { name: "global", date: null }

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
@@ -150,14 +150,15 @@ class RunWorkflowTests : SeleniumTest()
     fun `can change branch and see resulting workflow change`()
     {
         createWorkflow()
-        addReport("minimal")
+        changeToOtherBranch()
+        addReport("other")
 
         //Expect report to be removed from workflow when change to a branch where report does not exist
-        changeToOtherBranch()
+        changeToMasterBranch()
         assertThat(driver.findElements(By.id("workflow-report-0")).isEmpty()).isTrue()
         assertThat(driver.findElement(By.cssSelector(".alert")).text).contains(
                 "The following items are not present in this git commit and have been removed from the workflow:\n" +
-                "Report 'minimal'")
+                "Report 'other'")
     }
 
     @Test
@@ -216,18 +217,28 @@ class RunWorkflowTests : SeleniumTest()
         wait.until(ExpectedConditions.presenceOfElementLocated(By.id("git-branch")))
     }
 
+    private fun changeToMasterBranch()
+    {
+        changeToBranch(0, "master", "other")
+    }
+
     private fun changeToOtherBranch()
     {
+        changeToBranch(1, "other", "master")
+    }
+
+    private fun changeToBranch(newBranchIndex: Int, newBranch: String, expectedCurrentBranch: String)
+    {
         val branchSelect = driver.findElement(By.id("git-branch"))
-        assertThat(branchSelect.getAttribute("value")).isEqualTo("master")
+        assertThat(branchSelect.getAttribute("value")).isEqualTo(expectedCurrentBranch)
         val commitSelect = driver.findElement(By.id("git-commit"))
         val commitValue = commitSelect.getAttribute("value")
         assertThat(commitValue).isNotBlank()
 
         //Select a git branch
-        Select(branchSelect).selectByIndex(1)
+        Select(branchSelect).selectByIndex(newBranchIndex)
         wait.until(not(ExpectedConditions.attributeToBe(commitSelect, "value", commitValue)))
-        assertThat(branchSelect.getAttribute("value")).isEqualTo("other")
+        assertThat(branchSelect.getAttribute("value")).isEqualTo(newBranch)
         assertThat(commitSelect.getAttribute("value")).isNotBlank()
     }
 

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
@@ -198,6 +198,18 @@ class RunWorkflowTests : SeleniumTest()
         tmpFile.delete()
     }
 
+    @Test
+    fun `can see all reports in non-master branch`()
+    {
+        // Available reports should include those which are unchanged from master branch i.e. 'minimal' and 'global', as
+        // well as branch-only reports e.g. 'other'
+        createWorkflow()
+        changeToOtherBranch()
+        addReport("minimal")
+        addReport("global")
+        addReport("other")
+    }
+
     private fun addReport(reportName: String)
     {
         driver.findElement(By.cssSelector("#workflow-report input")).sendKeys(reportName)


### PR DESCRIPTION
This branch uses the new `show_all` flag for the runnable reports endpoint, when called from the run workflow component (but not from the run single report endpoint). 

Setting the `show_all` flag means that all reports available in the branch are returned, not just the ones which have changes in the branch. Getting branch-specific reports only is useful for Run report, since user will only be interested in reports with changes - however, in Run workflow, the user is also likely to want to run dependencies which may not have changed. 

Can be tested manually with the orderly demo - on 'other' branch, the master branch reports 'global' and 'minimal' were previously not displayed in Run workflow, but they are with these changes. They are still absent in 'other' branch in Run report. 
