### PR TITLE
test workflows summary params

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -478,11 +478,11 @@ class WorkflowRunTests : IntegrationTest()
         val json = JsonLoader.fromString(response.text)
         val data = json["data"]
         val reports = data["reports"] as ArrayNode
-        assertThat(reports.count()).isEqualTo(1)
+        assertThat(reports.count()).isEqualTo(2)
         assertThat((reports[0]["name"] as TextNode).textValue()).isEqualTo("global")
-        assertThat(reports[0]["params"].count()).isEqualTo(2)
-        assertThat(reports[0]["params"][0]["nmin"].asText()).isEqualTo("20")
-        assertThat(reports[0]["params"][1]["nmin"].asText()).isEqualTo("10")
+        assertThat(reports[0]["params"]["nmin"].asText()).isEqualTo("20")
+        assertThat((reports[1]["name"] as TextNode).textValue()).isEqualTo("global")
+        assertThat(reports[1]["params"]["nmin"].asText()).isEqualTo("10")
         assertThat((data["missing_dependencies"]["global"] as ArrayNode).count()).isEqualTo(0)
 
         JSONValidator.validateAgainstOrderlySchema(response.text, "WorkflowSummaryResponse")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -271,7 +271,7 @@ class WorkflowRunTests : IntegrationTest()
         validateWorkflowWithDefaultBranchAncCommit("/workflow/validate?branch&commit")
     }
 
-    fun validateWorkflowWithDefaultBranchAncCommit(url: String)
+    private fun validateWorkflowWithDefaultBranchAncCommit(url: String)
     {
         val sessionCookie = webRequestHelper.webLoginWithMontagu(runReportsPerm)
         val formData = """
@@ -465,7 +465,7 @@ class WorkflowRunTests : IntegrationTest()
                 sessionCookie,
                 ContentTypes.json,
                 HttpMethod.post,
-                """{"ref": "$ref", "reports": [{"name": "global", "params": {}}]}"""
+                """{"ref": "$ref", "reports": [{"name": "global", "params": {"nmin", "20"}}]}"""
         )
 
         assertSuccessful(response)
@@ -475,6 +475,7 @@ class WorkflowRunTests : IntegrationTest()
         val reports = data["reports"] as ArrayNode
         assertThat(reports.count()).isEqualTo(1)
         assertThat((reports[0]["name"] as TextNode).textValue()).isEqualTo("global")
+        assertThat(reports[0]["params"]["nmin"].asText()).isEqualTo("20")
         assertThat((data["missing_dependencies"]["global"] as ArrayNode).count()).isEqualTo(0)
 
         JSONValidator.validateAgainstOrderlySchema(response.text, "WorkflowSummaryResponse")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -461,11 +461,16 @@ class WorkflowRunTests : IntegrationTest()
         val ref = getGitBranchCommit("master")
         val sessionCookie = webRequestHelper.webLoginWithMontagu(runReportsPerm)
         val response = webRequestHelper.requestWithSessionCookie(
-                "/workflows/summary",
-                sessionCookie,
-                ContentTypes.json,
-                HttpMethod.post,
-                """{"ref": "$ref", "reports": [{"name": "global", "params": {"nmin", "20"}}]}"""
+            "/workflows/summary",
+            sessionCookie,
+            ContentTypes.json,
+            HttpMethod.post,
+            """{
+                "ref": "$ref", 
+                "reports": [
+                {"name": "global", "params": {"nmin", "20"}},
+                {"name": "global", "params": {"nmin", "10"}}
+                ]}""".trimIndent()
         )
 
         assertSuccessful(response)
@@ -475,7 +480,9 @@ class WorkflowRunTests : IntegrationTest()
         val reports = data["reports"] as ArrayNode
         assertThat(reports.count()).isEqualTo(1)
         assertThat((reports[0]["name"] as TextNode).textValue()).isEqualTo("global")
-        assertThat(reports[0]["params"]["nmin"].asText()).isEqualTo("20")
+        assertThat(reports[0]["params"].count()).isEqualTo(2)
+        assertThat(reports[0]["params"][0]["nmin"].asText()).isEqualTo("20")
+        assertThat(reports[0]["params"][1]["nmin"].asText()).isEqualTo("10")
         assertThat((data["missing_dependencies"]["global"] as ArrayNode).count()).isEqualTo(0)
 
         JSONValidator.validateAgainstOrderlySchema(response.text, "WorkflowSummaryResponse")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
@@ -60,7 +60,7 @@ class WorkflowRunControllerTests
     @Test
     fun `can get workflow run summary`()
     {
-        val requestBody = """{"ref": "18f6c5267c08bf017b521a21493771c6d3e774a5", "reports": [{"name": "missing"}]}"""
+        val requestBody = """{"ref": "18f6c5267c08bf017b521a21493771c6d3e774a5", "reports": [{"name": "missing", "params":{"key", "value"} }]}"""
         val context = mock<ActionContext> {
             on { getRequestBody() } doReturn requestBody
         }
@@ -74,7 +74,6 @@ class WorkflowRunControllerTests
         val repo = mock<WorkflowRunRepository>()
         val sut = WorkflowRunController(context, repo, apiClient, mock())
         val result = sut.getWorkflowRunSummary()
-        
         assertThat(result).isEqualTo(mockAPIResponse.text)
     }
 


### PR DESCRIPTION
POST `workflows/summary` endpoint accepts report: {ref: "", name: "", params: {"key": "value"}} object etc as queryParams and is meant to return report object along other response data but params was missing, which has now been resolved in hintr and test is now added in this ticket.