### PR TITLE
mrc-2995 Update status schema and add missing github auth tests

### DIFF
--- a/docs/spec/Status.schema.json
+++ b/docs/spec/Status.schema.json
@@ -17,6 +17,16 @@
                 }
             ]
         },
+        "start_time": {
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
         "output": {
             "oneOf": [
                 {

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubAuthenticationTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubAuthenticationTests.kt
@@ -7,55 +7,115 @@ import org.junit.Test
 import org.vaccineimpact.orderlyweb.test_helpers.JSONValidator
 import org.vaccineimpact.orderlyweb.test_helpers.TestTokenHeader
 import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
+import org.vaccineimpact.orderlyweb.test_helpers.http.Response
 
 class GithubAuthenticationTests : CustomConfigTests()
 {
     val JSONValidator = JSONValidator()
-
-    @Before
-    fun start() {
-        startApp("auth.provider=github")
-    }
+    // this is a PAT for a test user who only has access to a test org with no repos
+    // reversed so GitHub doesn't spot it and invalidate it
+    val testUserPAT = "fcef1c6821f7561259ce45d4840965642607e5a4".reversed()
 
     @Test
     fun `authentication fails without Auth header`()
     {
+        startApp("auth.provider=github")
         val result = HttpClient.post(url)
-        assertThat(result.statusCode).isEqualTo(401)
-        JSONValidator.validateError(result.text,
-                expectedErrorCode = "github-token-invalid",
-                expectedErrorText = "GitHub token not supplied in Authorization header, or GitHub token was invalid")
+
+        assertAuthFailure(result)
     }
 
     @Test
     fun `authentication fails with malformed Auth header`()
     {
+        startApp("auth.provider=github")
         val result = HttpClient.post(url, auth = TestTokenHeader("token", "bearer"))
-        assertThat(result.statusCode).isEqualTo(401)
-        JSONValidator.validateError(result.text,
-                expectedErrorCode = "github-token-invalid",
-                expectedErrorText = "GitHub token not supplied in Authorization header, or GitHub token was invalid")
+
+        assertAuthFailure(result)
     }
 
     @Test
     fun `authentication fails with invalid github token`()
     {
+        startApp("auth.provider=github")
         val result = HttpClient.post(url, auth = TestTokenHeader("badtoken"))
-        assertThat(result.statusCode).isEqualTo(401)
-        JSONValidator.validateError(result.text,
-                expectedErrorCode = "github-token-invalid",
-                expectedErrorText = "GitHub token not supplied in Authorization header, or GitHub token was invalid")
+
+        assertAuthFailure(result)
     }
 
     @Test
     fun `authentication succeeds with well-formed Auth header`()
     {
+        startApp("auth.provider=github")
+
+        val result = HttpClient.post(url, auth = TestTokenHeader(testUserPAT))
+
+        assertAuthSuccess(result)
+    }
+
+    @Test
+    fun `authentication fails if token does not have email reading scope`()
+    {
+        startApp("auth.provider=github")
         // this is a PAT for a test user who only has access to a test org with no repos
         // reversed so GitHub doesn't spot it and invalidate it
-        val token = "fcef1c6821f7561259ce45d4840965642607e5a4".reversed()
+        val tokenWithoutEmailReadingScope = "e0182507b0c6ad077a3036fd181a6260c0376e1c".reversed()
 
-        val result = HttpClient.post(url, auth = TestTokenHeader(token))
+        val result = HttpClient.post(url, auth = TestTokenHeader(tokenWithoutEmailReadingScope))
 
+        assertAuthFailure(result)
+    }
+
+    @Test
+    fun `authentication fails if token does not have user reading scope`()
+    {
+        startApp("auth.provider=github")
+        // this is a PAT for a test user who only has access to a test org with no repos
+        // reversed so GitHub doesn't spot it and invalidate it
+        val tokenWithoutUserReadingScope = "285d9b1b6620ab4dfd6c403b29451d52aa38a158".reversed()
+
+        val result = HttpClient.post(url, auth = TestTokenHeader(tokenWithoutUserReadingScope))
+
+        assertAuthFailure(result)
+    }
+
+    @Test
+    fun `authentication fails if user is not in configured org`()
+    {
+        startApp("auth.provider=github\nauth.github_org=vimc")
+        val result = HttpClient.post(url, auth = TestTokenHeader(testUserPAT))
+
+        assertAuthFailure(result)
+    }
+
+    @Test
+    fun `authentication succeeds if user is in configured team`()
+    {
+        startApp("auth.provider=github\nauth.github_team=vimc-auth-team")
+        val result = HttpClient.post(url, auth = TestTokenHeader(testUserPAT))
+
+        assertAuthSuccess(result)
+    }
+
+    @Test
+    fun `authentication fails if user is not in configured team`()
+    {
+        startApp("auth.provider=github\nauth.github_team=vimc-auth-team2")
+        val result = HttpClient.post(url, auth = TestTokenHeader(testUserPAT))
+
+        assertAuthFailure(result)
+    }
+
+    @Test
+    fun `can get OPTIONS for authentication endpoint`()
+    {
+        startApp("auth.provider=github")
+        val result = HttpClient.options(url)
+        assertThat(result.statusCode).isEqualTo(200)
+    }
+
+    private fun assertAuthSuccess(result: Response)
+    {
         assertSuccessful(result)
 
         val json = JsonLoader.fromString(result.text)
@@ -64,41 +124,12 @@ class GithubAuthenticationTests : CustomConfigTests()
         assertThat(isLong(json["expires_in"].toString())).isTrue()
     }
 
-    @Test
-    fun `authentication fails if token does not have email reading scope`()
+    private fun assertAuthFailure(result: Response)
     {
-        // this is a PAT for a test user who only has access to a test org with no repos
-        // reversed so GitHub doesn't spot it and invalidate it
-        val tokenWithoutEmailReadingScope = "e0182507b0c6ad077a3036fd181a6260c0376e1c".reversed()
-
-        val result = HttpClient.post(url, auth = TestTokenHeader(tokenWithoutEmailReadingScope))
-
+        assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(result.text,
                 expectedErrorCode = "github-token-invalid",
                 expectedErrorText = "GitHub token not supplied in Authorization header, or GitHub token was invalid")
-
-    }
-
-    @Test
-    fun `authentication fails if token does not have user reading scope`()
-    {
-        // this is a PAT for a test user who only has access to a test org with no repos
-        // reversed so GitHub doesn't spot it and invalidate it
-        val tokenWithoutUserReadingScope = "285d9b1b6620ab4dfd6c403b29451d52aa38a158".reversed()
-
-        val result = HttpClient.post(url, auth = TestTokenHeader(tokenWithoutUserReadingScope))
-
-        JSONValidator.validateError(result.text,
-                expectedErrorCode = "github-token-invalid",
-                expectedErrorText = "GitHub token not supplied in Authorization header, or GitHub token was invalid")
-
-    }
-
-    @Test
-    fun `can get OPTIONS for authentication endpoint`()
-    {
-        val result = HttpClient.options(url)
-        assertThat(result.statusCode).isEqualTo(200)
     }
 
     private fun isLong(raw: String): Boolean

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubWebTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubWebTests.kt
@@ -91,4 +91,28 @@ class GithubWebTests : SeleniumTest()
         val authProvider = driver.findElement(By.cssSelector(".login-link"))
         assertThat(authProvider.getAttribute("href")).isEqualTo("${url}weblogin/external?requestedUrl=${url}")
     }
+
+    @Test
+    fun `user can log in if in configured team`()
+    {
+        startApp("auth.provider=github\nauth.github_team=vimc-auth-team")
+
+        login()
+
+        val header = driver.findElement(By.cssSelector(".reports-list"))
+        assertThat(header.text).isEqualTo("Find a report")
+    }
+
+    @Test
+    fun `user sees 401 page if not in configured team`()
+    {
+        startApp("auth.provider=github\nauth.github_team=vimc-auth-team2")
+
+        login()
+
+        val helpText = driver.findElements(By.cssSelector("p")).first()
+        assertThat(helpText.text)
+                .contains("We have not been able to successfully identify you as a member of the app's configured GitHub org")
+
+    }
 }

--- a/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
+++ b/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
@@ -1619,6 +1619,273 @@
           "X-Xss-Protection" : [ "1; mode=block" ]
         }
       }
+    }, {
+      "request" : {
+        "path" : [ {
+          "matcher" : "exact",
+          "value" : "/orgs/vimc-auth-test/teams"
+        } ],
+        "method" : [ {
+          "matcher" : "exact",
+          "value" : "GET"
+        } ],
+        "destination" : [ {
+          "matcher" : "exact",
+          "value" : "api.github.com"
+        } ],
+        "scheme" : [ {
+          "matcher" : "exact",
+          "value" : "https"
+        } ],
+        "query" : {
+          "page": [
+            {
+              "matcher": "exact",
+              "value": "1"
+            }
+          ],
+          "per_page": [
+            {
+              "matcher": "exact",
+              "value": "100"
+            }
+          ]
+        },
+        "body" : [ {
+          "matcher" : "exact",
+          "value" : ""
+        } ],
+        "headers" : {
+          "Accept" : [ {
+            "matcher" : "exact",
+            "value" : "application/vnd.github.beta+json"
+          } ],
+          "Authorization" : [ {
+            "matcher" : "exact",
+            "value" : "token notarealtoken"
+          } ],
+          "Connection" : [ {
+            "matcher" : "exact",
+            "value" : "keep-alive"
+          } ],
+          "User-Agent" : [ {
+            "matcher" : "regex",
+            "value" : ".*"
+          } ]
+        }
+      },
+      "response" : {
+        "status" : 200,
+        "body" : "[{\"id\": 4660231,\"node_id\": \"MDQ6VGVhbTE=\", \"url\": \"https://api.github.com/teams/4660231\", \"html_url\": \"https://github.com/orgs/vimc-auth-test/teams/vimc-auth-team\", \"name\": \"vimc-auth-team\", \"slug\": \"vimc-auth-team\", \"description\": \"\", \"privacy\": \"closed\",\"permission\": \"admin\", \"members_url\": \"https://api.github.com/teams/4660231/members/{member}\", \"repositories_url\": \"https://api.github.com/teams/4660231/repos\", \"parent\": null}, {\"id\": 4660232,\"node_id\": \"MDQ6VGVhbTF=\", \"url\": \"https://api.github.com/teams/4660232\", \"html_url\": \"https://github.com/orgs/vimc-auth-test/teams/vimc-auth-team2\", \"name\": \"vimc-auth-team2\", \"slug\": \"vimc-auth-team2\", \"description\": \"\", \"privacy\": \"closed\",\"permission\": \"admin\", \"members_url\": \"https://api.github.com/teams/4660232/members/{member}\", \"repositories_url\": \"https://api.github.com/teams/4660232/repos\", \"parent\": null}]",
+        "encodedBody" : false,
+        "templated" : false,
+        "headers" : {
+          "Access-Control-Allow-Origin" : [ "*" ],
+          "Access-Control-Expose-Headers" : [ "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type" ],
+          "Cache-Control" : [ "private, max-age=60, s-maxage=60" ],
+          "Content-Security-Policy" : [ "default-src 'none'" ],
+          "Content-Type" : [ "application/json; charset=utf-8" ],
+          "Date" : [ "Wed, 29 May 2019 15:52:41 GMT" ],
+          "Etag" : [ "W/\"0b5bf5b19e04af8a90f1b7f75550d2a8\"" ],
+          "Hoverfly" : [ "Was-Here" ],
+          "Last-Modified" : [ "Tue, 28 May 2019 09:46:42 GMT" ],
+          "Referrer-Policy" : [ "origin-when-cross-origin, strict-origin-when-cross-origin" ],
+          "Server" : [ "GitHub.com" ],
+          "Status" : [ "200 OK" ],
+          "Strict-Transport-Security" : [ "max-age=31536000; includeSubdomains; preload" ],
+          "Transfer-Encoding" : [ "chunked" ],
+          "Vary" : [ "Accept, Authorization, Cookie, X-GitHub-OTP" ],
+          "X-Accepted-Oauth-Scopes" : [ "" ],
+          "X-Content-Type-Options" : [ "nosniff" ],
+          "X-Frame-Options" : [ "deny" ],
+          "X-Github-Media-Type" : [ "unknown, github.v3" ],
+          "X-Github-Request-Id" : [ "C1CE:7278:5744:ADAB:5CEEAAC9" ],
+          "X-Oauth-Client-Id" : [ "6f32ad91d57a254341cb" ],
+          "X-Oauth-Scopes" : [ "read:user, read:org, user:email" ],
+          "X-Ratelimit-Limit" : [ "5000" ],
+          "X-Ratelimit-Remaining" : [ "4993" ],
+          "X-Ratelimit-Reset" : [ "1559148693" ],
+          "X-Xss-Protection" : [ "1; mode=block" ]
+        }
+      }
+    }, {
+      "request" : {
+        "path" : [ {
+          "matcher" : "exact",
+          "value" : "/teams/4660231/members"
+        } ],
+        "method" : [ {
+          "matcher" : "exact",
+          "value" : "GET"
+        } ],
+        "destination" : [ {
+          "matcher" : "exact",
+          "value" : "api.github.com"
+        } ],
+        "scheme" : [ {
+          "matcher" : "exact",
+          "value" : "https"
+        } ],
+        "query" : {
+          "page": [
+            {
+              "matcher": "exact",
+              "value": "1"
+            }
+          ],
+          "per_page": [
+            {
+              "matcher": "exact",
+              "value": "100"
+            }
+          ]
+        },
+        "body" : [ {
+          "matcher" : "exact",
+          "value" : ""
+        } ],
+        "headers" : {
+          "Accept" : [ {
+            "matcher" : "exact",
+            "value" : "application/vnd.github.beta+json"
+          } ],
+          "Authorization" : [ {
+            "matcher" : "exact",
+            "value" : "token notarealtoken"
+          } ],
+          "Connection" : [ {
+            "matcher" : "exact",
+            "value" : "keep-alive"
+          } ],
+          "User-Agent" : [ {
+            "matcher" : "regex",
+            "value" : ".*"
+          } ]
+        }
+      },
+      "response" : {
+        "status" : 200,
+        "body" : "[{\"login\": \"notarealuser\", \"id\": 1, \"node_id\": \"MDQ6VXNlcjE=\", \"avatar_url\": \"https://github.com/images/error/notarealuser.gif\", \"gravatar_id\": \"\", \"url\": \"https://api.github.com/users/notarealuser\", \"html_url\": \"https://github.com/notarealuser\", \"followers_url\": \"https://api.github.com/users/notarealuser/followers\", \"following_url\": \"https://api.github.com/users/notarealuser/following{/other_user}\", \"gists_url\": \"https://api.github.com/users/notarealuser/gists{/gist_id}\", \"starred_url\": \"https://api.github.com/users/notarealuser/starred{/owner}{/repo}\", \"subscriptions_url\": \"https://api.github.com/users/notarealuser/subscriptions\", \"organizations_url\": \"https://api.github.com/users/notarealuser/orgs\", \"repos_url\": \"https://api.github.com/users/notarealuser/repos\", \"events_url\": \"https://api.github.com/users/notarealuser/events{/privacy}\", \"received_events_url\": \"https://api.github.com/users/notarealuser/received_events\", \"type\": \"User\", \"site_admin\": false}]",
+        "encodedBody" : false,
+        "templated" : false,
+        "headers" : {
+          "Access-Control-Allow-Origin" : [ "*" ],
+          "Access-Control-Expose-Headers" : [ "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type" ],
+          "Cache-Control" : [ "private, max-age=60, s-maxage=60" ],
+          "Content-Security-Policy" : [ "default-src 'none'" ],
+          "Content-Type" : [ "application/json; charset=utf-8" ],
+          "Date" : [ "Wed, 29 May 2019 15:52:41 GMT" ],
+          "Etag" : [ "W/\"0b5bf5b19e04af8a90f1b7f75550d2a8\"" ],
+          "Hoverfly" : [ "Was-Here" ],
+          "Last-Modified" : [ "Tue, 28 May 2019 09:46:42 GMT" ],
+          "Referrer-Policy" : [ "origin-when-cross-origin, strict-origin-when-cross-origin" ],
+          "Server" : [ "GitHub.com" ],
+          "Status" : [ "200 OK" ],
+          "Strict-Transport-Security" : [ "max-age=31536000; includeSubdomains; preload" ],
+          "Transfer-Encoding" : [ "chunked" ],
+          "Vary" : [ "Accept, Authorization, Cookie, X-GitHub-OTP" ],
+          "X-Accepted-Oauth-Scopes" : [ "" ],
+          "X-Content-Type-Options" : [ "nosniff" ],
+          "X-Frame-Options" : [ "deny" ],
+          "X-Github-Media-Type" : [ "unknown, github.v3" ],
+          "X-Github-Request-Id" : [ "C1CE:7278:5744:ADAB:5CEEAAC9" ],
+          "X-Oauth-Client-Id" : [ "6f32ad91d57a254341cb" ],
+          "X-Oauth-Scopes" : [ "read:user, read:org, user:email" ],
+          "X-Ratelimit-Limit" : [ "5000" ],
+          "X-Ratelimit-Remaining" : [ "4993" ],
+          "X-Ratelimit-Reset" : [ "1559148693" ],
+          "X-Xss-Protection" : [ "1; mode=block" ]
+        }
+      }
+    }, {
+      "request" : {
+        "path" : [ {
+          "matcher" : "exact",
+          "value" : "/teams/4660232/members"
+        } ],
+        "method" : [ {
+          "matcher" : "exact",
+          "value" : "GET"
+        } ],
+        "destination" : [ {
+          "matcher" : "exact",
+          "value" : "api.github.com"
+        } ],
+        "scheme" : [ {
+          "matcher" : "exact",
+          "value" : "https"
+        } ],
+        "query" : {
+          "page": [
+            {
+              "matcher": "exact",
+              "value": "1"
+            }
+          ],
+          "per_page": [
+            {
+              "matcher": "exact",
+              "value": "100"
+            }
+          ]
+        },
+        "body" : [ {
+          "matcher" : "exact",
+          "value" : ""
+        } ],
+        "headers" : {
+          "Accept" : [ {
+            "matcher" : "exact",
+            "value" : "application/vnd.github.beta+json"
+          } ],
+          "Authorization" : [ {
+            "matcher" : "exact",
+            "value" : "token notarealtoken"
+          } ],
+          "Connection" : [ {
+            "matcher" : "exact",
+            "value" : "keep-alive"
+          } ],
+          "User-Agent" : [ {
+            "matcher" : "regex",
+            "value" : ".*"
+          } ]
+        }
+      },
+      "response" : {
+        "status" : 200,
+        "body" : "[{\"login\": \"anotheruser\", \"id\": 1, \"node_id\": \"MDQ6VXNlcjE=\", \"avatar_url\": \"https://github.com/images/error/anotheruser.gif\", \"gravatar_id\": \"\", \"url\": \"https://api.github.com/users/anotheruser\", \"html_url\": \"https://github.com/anotheruser\", \"followers_url\": \"https://api.github.com/users/anotheruser/followers\", \"following_url\": \"https://api.github.com/users/anotheruser/following{/other_user}\", \"gists_url\": \"https://api.github.com/users/anotheruser/gists{/gist_id}\", \"starred_url\": \"https://api.github.com/users/anotheruser/starred{/owner}{/repo}\", \"subscriptions_url\": \"https://api.github.com/users/anotheruser/subscriptions\", \"organizations_url\": \"https://api.github.com/users/anotheruser/orgs\", \"repos_url\": \"https://api.github.com/users/anotheruser/repos\", \"events_url\": \"https://api.github.com/users/anotheruser/events{/privacy}\", \"received_events_url\": \"https://api.github.com/users/anotheruser/received_events\", \"type\": \"User\", \"site_admin\": false}]",
+        "encodedBody" : false,
+        "templated" : false,
+        "headers" : {
+          "Access-Control-Allow-Origin" : [ "*" ],
+          "Access-Control-Expose-Headers" : [ "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type" ],
+          "Cache-Control" : [ "private, max-age=60, s-maxage=60" ],
+          "Content-Security-Policy" : [ "default-src 'none'" ],
+          "Content-Type" : [ "application/json; charset=utf-8" ],
+          "Date" : [ "Wed, 29 May 2019 15:52:41 GMT" ],
+          "Etag" : [ "W/\"0b5bf5b19e04af8a90f1b7f75550d2a8\"" ],
+          "Hoverfly" : [ "Was-Here" ],
+          "Last-Modified" : [ "Tue, 28 May 2019 09:46:42 GMT" ],
+          "Referrer-Policy" : [ "origin-when-cross-origin, strict-origin-when-cross-origin" ],
+          "Server" : [ "GitHub.com" ],
+          "Status" : [ "200 OK" ],
+          "Strict-Transport-Security" : [ "max-age=31536000; includeSubdomains; preload" ],
+          "Transfer-Encoding" : [ "chunked" ],
+          "Vary" : [ "Accept, Authorization, Cookie, X-GitHub-OTP" ],
+          "X-Accepted-Oauth-Scopes" : [ "" ],
+          "X-Content-Type-Options" : [ "nosniff" ],
+          "X-Frame-Options" : [ "deny" ],
+          "X-Github-Media-Type" : [ "unknown, github.v3" ],
+          "X-Github-Request-Id" : [ "C1CE:7278:5744:ADAB:5CEEAAC9" ],
+          "X-Oauth-Client-Id" : [ "6f32ad91d57a254341cb" ],
+          "X-Oauth-Scopes" : [ "read:user, read:org, user:email" ],
+          "X-Ratelimit-Limit" : [ "5000" ],
+          "X-Ratelimit-Remaining" : [ "4993" ],
+          "X-Ratelimit-Reset" : [ "1559148693" ],
+          "X-Xss-Protection" : [ "1; mode=block" ]
+        }
+      }
     } ],
     "globalActions" : {
       "delays" : [ ]


### PR DESCRIPTION
This branch reinstates changes which we want to retain from the mrc-2966 PR (which needed to be reverted), specifically:
- [Update to the Status schema](https://github.com/vimc/orderly-web/pull/439/files/f4f5f6f3c311b76a2024ecd8aa02ee6ae970b821..3a0435860cb87363a57515388598fb1cdf8fbd22#diff-8b491b3e219ed8963a25957d5dd54b91b9b30541ad6ffd3907927be12fc2d831R20) to reflect new response from Orderly Server. This prevents integration test failure.
-  [Add missing custom config tests](https://github.com/vimc/orderly-web/pull/439/files#diff-dabbbd38377cb364be9e9b8c54e4795eb0bd75c2a283d0dc24f9bb3b84435fb8R95) for case where user is required to be github team member (using web login), with required updates to the config for Hoverfly (which mocks Github API).

This branch also adds tests for GitHub auth with org/team membership for authenticating over the OrderlyWeb API.

Some unrelated custom config tests are still failing - these are being addressed in mrc-2973
