### PR TITLE
mrc-3033 save and return execution order of workflow reports

### DIFF
--- a/config/orderly_server_version
+++ b/config/orderly_server_version
@@ -1,1 +1,1 @@
-master
+mrc-3033

--- a/config/orderly_server_version
+++ b/config/orderly_server_version
@@ -1,1 +1,1 @@
-mrc-3033
+master

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
@@ -75,7 +75,7 @@ class WorkflowRunController(
                                              val key: String,
                                              @SerializedName(value = "execution_order")
                                              val executionOrder: Int,
-                                             val params: Map<String, String>)
+                                             val params: Map<String, String>?)
 
     internal data class WorkflowRunResponse(
             @SerializedName(value = "workflow_key")
@@ -136,7 +136,7 @@ class WorkflowRunController(
                                         it.key,
                                         it.executionOrder,
                                         it.name,
-                                        it.params
+                                        it.params ?: mapOf()
                                 )
                             },
                             workflowRunRequest.instances ?: emptyMap(),

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/WorkflowRunController.kt
@@ -71,9 +71,11 @@ class WorkflowRunController(
         return WorkflowSummary(reports, summary.ref, summary.missingDependencies)
     }
 
-    internal data class WorkflowQueuedReport(val key: String,
+    internal data class WorkflowQueuedReport(val name: String,
+                                             val key: String,
                                              @SerializedName(value = "execution_order")
-                                             val executionOrder: Int)
+                                             val executionOrder: Int,
+                                             val params: Map<String, String>)
 
     internal data class WorkflowRunResponse(
             @SerializedName(value = "workflow_key")
@@ -128,13 +130,13 @@ class WorkflowRunController(
                             @Suppress("UnsafeCallOnNullableType")
                             context.userProfile!!.id,
                             Instant.now(),
-                            workflowRunRequest.reports.zip(workflowRun.reports) { report, queuedReport ->
+                            workflowRun.reports.map {
                                 WorkflowRunReport(
                                         workflowRun.key,
-                                        queuedReport.key,
-                                        queuedReport.executionOrder,
-                                        report.name,
-                                        report.params
+                                        it.key,
+                                        it.executionOrder,
+                                        it.name,
+                                        it.params
                                 )
                             },
                             workflowRunRequest.instances ?: emptyMap(),

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/WorkflowRunRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/WorkflowRunRepository.kt
@@ -76,6 +76,7 @@ class OrderlyWebWorkflowRunRepository : WorkflowRunRepository
             val resultForReports = it.dsl.select(
                     ORDERLYWEB_WORKFLOW_RUN_REPORTS.WORKFLOW_KEY,
                     ORDERLYWEB_WORKFLOW_RUN_REPORTS.KEY,
+                    ORDERLYWEB_WORKFLOW_RUN_REPORTS.EXECUTION_ORDER,
                     ORDERLYWEB_WORKFLOW_RUN_REPORTS.REPORT,
                     ORDERLYWEB_WORKFLOW_RUN_REPORTS.PARAMS
             )

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/WorkflowRunRepository.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/db/repositories/WorkflowRunRepository.kt
@@ -15,9 +15,11 @@ import java.sql.Timestamp
 interface WorkflowRunRepository
 {
     fun addWorkflowRun(workflowRun: WorkflowRun)
+
     @Throws(UnknownObjectError::class)
     fun getWorkflowRunDetails(key: String): WorkflowRun
     fun getWorkflowRunSummaries(email: String? = null, namePrefix: String? = null): List<WorkflowRunSummary>
+
     @Throws(UnknownObjectError::class)
     fun updateWorkflowRun(key: String, status: String)
 }
@@ -32,22 +34,23 @@ class OrderlyWebWorkflowRunRepository : WorkflowRunRepository
                 val dsl = using(config)
 
                 dsl.insertInto(ORDERLYWEB_WORKFLOW_RUN)
-                    .set(ORDERLYWEB_WORKFLOW_RUN.NAME, workflowRun.name)
-                    .set(ORDERLYWEB_WORKFLOW_RUN.KEY, workflowRun.key)
-                    .set(ORDERLYWEB_WORKFLOW_RUN.EMAIL, workflowRun.email)
-                    .set(ORDERLYWEB_WORKFLOW_RUN.DATE, Timestamp.from(workflowRun.date))
-                    .set(ORDERLYWEB_WORKFLOW_RUN.INSTANCES, Gson().toJson(workflowRun.instances))
-                    .set(ORDERLYWEB_WORKFLOW_RUN.GIT_BRANCH, workflowRun.gitBranch)
-                    .set(ORDERLYWEB_WORKFLOW_RUN.GIT_COMMIT, workflowRun.gitCommit)
-                    .execute()
+                        .set(ORDERLYWEB_WORKFLOW_RUN.NAME, workflowRun.name)
+                        .set(ORDERLYWEB_WORKFLOW_RUN.KEY, workflowRun.key)
+                        .set(ORDERLYWEB_WORKFLOW_RUN.EMAIL, workflowRun.email)
+                        .set(ORDERLYWEB_WORKFLOW_RUN.DATE, Timestamp.from(workflowRun.date))
+                        .set(ORDERLYWEB_WORKFLOW_RUN.INSTANCES, Gson().toJson(workflowRun.instances))
+                        .set(ORDERLYWEB_WORKFLOW_RUN.GIT_BRANCH, workflowRun.gitBranch)
+                        .set(ORDERLYWEB_WORKFLOW_RUN.GIT_COMMIT, workflowRun.gitCommit)
+                        .execute()
 
                 workflowRun.reports.forEach { report ->
                     dsl.insertInto(ORDERLYWEB_WORKFLOW_RUN_REPORTS)
-                        .set(ORDERLYWEB_WORKFLOW_RUN_REPORTS.WORKFLOW_KEY, report.workflowKey)
-                        .set(ORDERLYWEB_WORKFLOW_RUN_REPORTS.KEY, report.key)
-                        .set(ORDERLYWEB_WORKFLOW_RUN_REPORTS.REPORT, report.report)
-                        .set(ORDERLYWEB_WORKFLOW_RUN_REPORTS.PARAMS, Gson().toJson(report.params))
-                        .execute()
+                            .set(ORDERLYWEB_WORKFLOW_RUN_REPORTS.WORKFLOW_KEY, report.workflowKey)
+                            .set(ORDERLYWEB_WORKFLOW_RUN_REPORTS.KEY, report.key)
+                            .set(ORDERLYWEB_WORKFLOW_RUN_REPORTS.EXECUTION_ORDER, report.executionOrder)
+                            .set(ORDERLYWEB_WORKFLOW_RUN_REPORTS.REPORT, report.report)
+                            .set(ORDERLYWEB_WORKFLOW_RUN_REPORTS.PARAMS, Gson().toJson(report.params))
+                            .execute()
                 }
             }
         }
@@ -57,47 +60,48 @@ class OrderlyWebWorkflowRunRepository : WorkflowRunRepository
     {
         JooqContext().use {
             val result = it.dsl.select(
-                ORDERLYWEB_WORKFLOW_RUN.NAME,
-                ORDERLYWEB_WORKFLOW_RUN.KEY,
-                ORDERLYWEB_WORKFLOW_RUN.EMAIL,
-                ORDERLYWEB_WORKFLOW_RUN.DATE,
-                ORDERLYWEB_WORKFLOW_RUN.INSTANCES,
-                ORDERLYWEB_WORKFLOW_RUN.GIT_BRANCH,
-                ORDERLYWEB_WORKFLOW_RUN.GIT_COMMIT
+                    ORDERLYWEB_WORKFLOW_RUN.NAME,
+                    ORDERLYWEB_WORKFLOW_RUN.KEY,
+                    ORDERLYWEB_WORKFLOW_RUN.EMAIL,
+                    ORDERLYWEB_WORKFLOW_RUN.DATE,
+                    ORDERLYWEB_WORKFLOW_RUN.INSTANCES,
+                    ORDERLYWEB_WORKFLOW_RUN.GIT_BRANCH,
+                    ORDERLYWEB_WORKFLOW_RUN.GIT_COMMIT
             )
-                .from(ORDERLYWEB_WORKFLOW_RUN)
-                .where(ORDERLYWEB_WORKFLOW_RUN.KEY.eq(key))
-                .singleOrNull()
-                ?: throw UnknownObjectError(key, "workflow")
+                    .from(ORDERLYWEB_WORKFLOW_RUN)
+                    .where(ORDERLYWEB_WORKFLOW_RUN.KEY.eq(key))
+                    .singleOrNull()
+                    ?: throw UnknownObjectError(key, "workflow")
 
             val resultForReports = it.dsl.select(
-                ORDERLYWEB_WORKFLOW_RUN_REPORTS.WORKFLOW_KEY,
-                ORDERLYWEB_WORKFLOW_RUN_REPORTS.KEY,
-                ORDERLYWEB_WORKFLOW_RUN_REPORTS.REPORT,
-                ORDERLYWEB_WORKFLOW_RUN_REPORTS.PARAMS
+                    ORDERLYWEB_WORKFLOW_RUN_REPORTS.WORKFLOW_KEY,
+                    ORDERLYWEB_WORKFLOW_RUN_REPORTS.KEY,
+                    ORDERLYWEB_WORKFLOW_RUN_REPORTS.REPORT,
+                    ORDERLYWEB_WORKFLOW_RUN_REPORTS.PARAMS
             )
-                .from(ORDERLYWEB_WORKFLOW_RUN)
-                .join(ORDERLYWEB_WORKFLOW_RUN_REPORTS)
-                .on(ORDERLYWEB_WORKFLOW_RUN.KEY.eq(ORDERLYWEB_WORKFLOW_RUN_REPORTS.WORKFLOW_KEY))
-                .where(ORDERLYWEB_WORKFLOW_RUN.KEY.eq(key))
-                .fetch()
+                    .from(ORDERLYWEB_WORKFLOW_RUN)
+                    .join(ORDERLYWEB_WORKFLOW_RUN_REPORTS)
+                    .on(ORDERLYWEB_WORKFLOW_RUN.KEY.eq(ORDERLYWEB_WORKFLOW_RUN_REPORTS.WORKFLOW_KEY))
+                    .where(ORDERLYWEB_WORKFLOW_RUN.KEY.eq(key))
+                    .fetch()
 
             return WorkflowRun(
-                result[ORDERLYWEB_WORKFLOW_RUN.NAME],
-                result[ORDERLYWEB_WORKFLOW_RUN.KEY],
-                result[ORDERLYWEB_WORKFLOW_RUN.EMAIL],
-                result[ORDERLYWEB_WORKFLOW_RUN.DATE].toInstant(),
-                resultForReports.map { report ->
-                    WorkflowRunReport(
-                        report[ORDERLYWEB_WORKFLOW_RUN_REPORTS.WORKFLOW_KEY],
-                        report[ORDERLYWEB_WORKFLOW_RUN_REPORTS.KEY],
-                        report[ORDERLYWEB_WORKFLOW_RUN_REPORTS.REPORT],
-                        jsonToStringMap(report[ORDERLYWEB_WORKFLOW_RUN_REPORTS.PARAMS])
-                    )
-                },
-                jsonToStringMap(result[ORDERLYWEB_WORKFLOW_RUN.INSTANCES]),
-                result[ORDERLYWEB_WORKFLOW_RUN.GIT_BRANCH],
-                result[ORDERLYWEB_WORKFLOW_RUN.GIT_COMMIT]
+                    result[ORDERLYWEB_WORKFLOW_RUN.NAME],
+                    result[ORDERLYWEB_WORKFLOW_RUN.KEY],
+                    result[ORDERLYWEB_WORKFLOW_RUN.EMAIL],
+                    result[ORDERLYWEB_WORKFLOW_RUN.DATE].toInstant(),
+                    resultForReports.map { report ->
+                        WorkflowRunReport(
+                                report[ORDERLYWEB_WORKFLOW_RUN_REPORTS.WORKFLOW_KEY],
+                                report[ORDERLYWEB_WORKFLOW_RUN_REPORTS.KEY],
+                                report[ORDERLYWEB_WORKFLOW_RUN_REPORTS.EXECUTION_ORDER],
+                                report[ORDERLYWEB_WORKFLOW_RUN_REPORTS.REPORT],
+                                jsonToStringMap(report[ORDERLYWEB_WORKFLOW_RUN_REPORTS.PARAMS])
+                        )
+                    },
+                    jsonToStringMap(result[ORDERLYWEB_WORKFLOW_RUN.INSTANCES]),
+                    result[ORDERLYWEB_WORKFLOW_RUN.GIT_BRANCH],
+                    result[ORDERLYWEB_WORKFLOW_RUN.GIT_COMMIT]
             )
         }
     }
@@ -106,33 +110,33 @@ class OrderlyWebWorkflowRunRepository : WorkflowRunRepository
     {
         JooqContext().use {
             val result = it.dsl.select(
-                ORDERLYWEB_WORKFLOW_RUN.NAME,
-                ORDERLYWEB_WORKFLOW_RUN.KEY,
-                ORDERLYWEB_WORKFLOW_RUN.EMAIL,
-                ORDERLYWEB_WORKFLOW_RUN.DATE
+                    ORDERLYWEB_WORKFLOW_RUN.NAME,
+                    ORDERLYWEB_WORKFLOW_RUN.KEY,
+                    ORDERLYWEB_WORKFLOW_RUN.EMAIL,
+                    ORDERLYWEB_WORKFLOW_RUN.DATE
             )
-                .from(ORDERLYWEB_WORKFLOW_RUN)
-                .where(
-                    if (email != null)
-                    {
-                        ORDERLYWEB_WORKFLOW_RUN.EMAIL.eq(email)
-                    }
-                    else
-                    {
-                        noCondition()
-                    }
-                )
-                .and(
-                    if (namePrefix != null)
-                    {
-                        lower(ORDERLYWEB_WORKFLOW_RUN.NAME).startsWith(namePrefix.toLowerCase())
-                    }
-                    else
-                    {
-                        noCondition()
-                    }
-                )
-                .orderBy(ORDERLYWEB_WORKFLOW_RUN.DATE.desc())
+                    .from(ORDERLYWEB_WORKFLOW_RUN)
+                    .where(
+                            if (email != null)
+                            {
+                                ORDERLYWEB_WORKFLOW_RUN.EMAIL.eq(email)
+                            }
+                            else
+                            {
+                                noCondition()
+                            }
+                    )
+                    .and(
+                            if (namePrefix != null)
+                            {
+                                lower(ORDERLYWEB_WORKFLOW_RUN.NAME).startsWith(namePrefix.toLowerCase())
+                            }
+                            else
+                            {
+                                noCondition()
+                            }
+                    )
+                    .orderBy(ORDERLYWEB_WORKFLOW_RUN.DATE.desc())
 
             return result.fetchInto(WorkflowRunSummary::class.java)
         }
@@ -142,9 +146,9 @@ class OrderlyWebWorkflowRunRepository : WorkflowRunRepository
     {
         JooqContext().use {
             val result = it.dsl.update(ORDERLYWEB_WORKFLOW_RUN)
-                .set(ORDERLYWEB_WORKFLOW_RUN.STATUS, status)
-                .where(ORDERLYWEB_WORKFLOW_RUN.KEY.eq(key))
-                .execute()
+                    .set(ORDERLYWEB_WORKFLOW_RUN.STATUS, status)
+                    .where(ORDERLYWEB_WORKFLOW_RUN.KEY.eq(key))
+                    .execute()
             if (result == 0)
             {
                 throw UnknownObjectError(key, "workflow")

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/WorkflowRun.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/WorkflowRun.kt
@@ -55,6 +55,7 @@ data class WorkflowRunSummary(
 data class WorkflowRunReport(
         val workflowKey: String,
         val key: String,
+        val executionOrder: Int,
         val report: String,
         val params: Map<String, String>
 )

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -550,7 +550,7 @@ class WorkflowRunTests : IntegrationTest()
 
         assertSuccessful(response)
         assertJsonContentType(response)
-    //    JSONValidator.validateAgainstOrderlySchema(response.text, "WorkflowRunResponse")
+        JSONValidator.validateAgainstOrderlySchema(response.text, "WorkflowRunResponse")
 
         val workflowRunResponse = Serializer.instance.gson.fromJson(
                 JSONValidator.getData(response.text).toString(),

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -226,7 +226,7 @@ class WorkflowRunTests : IntegrationTest()
         val runResponse = runExampleWorkflow(sessionCookie)
         val runResponseJson = JSONValidator.getData(runResponse.text)
         val workflowKey = runResponseJson["workflow_key"].textValue()
-        val reportKey = runResponseJson["reports"][0].textValue()
+        val reportKey = runResponseJson["reports"][0]["key"].textValue()
 
         val url = "/running/$reportKey/logs?workflow=$workflowKey"
         val logsResponse = webRequestHelper.requestWithSessionCookie(
@@ -550,7 +550,7 @@ class WorkflowRunTests : IntegrationTest()
 
         assertSuccessful(response)
         assertJsonContentType(response)
-        JSONValidator.validateAgainstOrderlySchema(response.text, "WorkflowRunResponse")
+    //    JSONValidator.validateAgainstOrderlySchema(response.text, "WorkflowRunResponse")
 
         val workflowRunResponse = Serializer.instance.gson.fromJson(
                 JSONValidator.getData(response.text).toString(),

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
@@ -7,7 +7,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
 import org.pac4j.core.profile.CommonProfile
-import org.vaccineimpact.orderlyweb.*
+import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.OrderlyServerAPI
+import org.vaccineimpact.orderlyweb.OrderlyServerResponse
+import org.vaccineimpact.orderlyweb.Serializer
 import org.vaccineimpact.orderlyweb.controllers.web.WorkflowRunController
 import org.vaccineimpact.orderlyweb.db.repositories.WorkflowRunRepository
 import org.vaccineimpact.orderlyweb.errors.BadRequest
@@ -20,7 +23,6 @@ import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 import java.io.File
 import java.io.Reader
 import java.time.Instant
-import org.vaccineimpact.orderlyweb.models.Result
 
 class WorkflowRunControllerTests
 {
@@ -121,12 +123,14 @@ class WorkflowRunControllerTests
                         WorkflowRunReport(
                                 "adventurous_aardvark",
                                 "adventurous_key",
+                                1,
                                 "report one",
                                 mapOf("param1" to "one", "param1" to "one", "param2" to "two")
                         ),
                         WorkflowRunReport(
                                 "adventurous_aardvark",
                                 "adventurous_key2",
+                                2,
                                 "report two",
                                 mapOf("param1" to "one", "param2" to "three")
                         )
@@ -202,7 +206,7 @@ class WorkflowRunControllerTests
 
         assertThat(validateAgainstSchema(json)).isTrue()
 
-        var workflowRunRequest = Serializer.instance.gson.fromJson(json, WorkflowRunRequest::class.java)
+        val workflowRunRequest = Serializer.instance.gson.fromJson(json, WorkflowRunRequest::class.java)
         assertThat(workflowRunRequest).isEqualTo(getWorkflowRunRequestExample())
     }
 
@@ -260,7 +264,10 @@ class WorkflowRunControllerTests
                         WorkflowRunController.WorkflowRunResponse::class.java
                 )
         ).isEqualTo(
-                WorkflowRunController.WorkflowRunResponse("workflow_key1", listOf("report_key1", "report_key2"))
+                WorkflowRunController.WorkflowRunResponse("workflow_key1",
+                        listOf(WorkflowRunController.WorkflowQueuedReport("report_key1", 1),
+                                WorkflowRunController.WorkflowQueuedReport("report_key2", 2))
+                )
         )
 
         verify(repo).addWorkflowRun(check {
@@ -275,12 +282,14 @@ class WorkflowRunControllerTests
                             WorkflowRunReport(
                                     "workflow_key1",
                                     "report_key1",
+                                    1,
                                     workflowRunRequest.reports[0].name,
                                     workflowRunRequest.reports[0].params
                             ),
                             WorkflowRunReport(
                                     "workflow_key1",
                                     "report_key2",
+                                    2,
                                     workflowRunRequest.reports[1].name,
                                     workflowRunRequest.reports[1].params
                             )
@@ -404,18 +413,21 @@ class WorkflowRunControllerTests
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "preterrestrial_andeancockoftherock",
+                                1,
                                 "Report A",
                                 emptyMap()
                         ),
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "hygienic_mammoth",
+                                2,
                                 "Report B",
                                 emptyMap()
                         ),
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "supercurious_woodlouse",
+                                3,
                                 "Report C",
                                 emptyMap()
                         )
@@ -502,18 +514,21 @@ class WorkflowRunControllerTests
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "preterrestrial_andeancockoftherock",
+                                1,
                                 "Report A",
                                 emptyMap()
                         ),
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "hygienic_mammoth",
+                                2,
                                 "Report B",
                                 emptyMap()
                         ),
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "supercurious_woodlouse",
+                                3,
                                 "Report C",
                                 emptyMap()
                         )

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
@@ -265,8 +265,10 @@ class WorkflowRunControllerTests
                 )
         ).isEqualTo(
                 WorkflowRunController.WorkflowRunResponse("workflow_key1",
-                        listOf(WorkflowRunController.WorkflowQueuedReport("report_key1", 1),
-                                WorkflowRunController.WorkflowQueuedReport("report_key2", 2))
+                        listOf(WorkflowRunController.WorkflowQueuedReport(workflowRunRequest.reports[0].name,
+                                "report_key1", 1, workflowRunRequest.reports[0].params),
+                                WorkflowRunController.WorkflowQueuedReport(workflowRunRequest.reports[1].name,
+                                        "report_key2", 2, workflowRunRequest.reports[1].params))
                 )
         )
 
@@ -397,7 +399,7 @@ class WorkflowRunControllerTests
     }
 
     @Test
-    fun `can get the status of a workflow`()
+    fun `can get the status of a workflow, ordered by execution order`()
     {
         val context = mock<ActionContext> {
             on { params(":key") } doReturn "workflow_key1"
@@ -420,14 +422,14 @@ class WorkflowRunControllerTests
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "hygienic_mammoth",
-                                2,
+                                3,
                                 "Report B",
                                 emptyMap()
                         ),
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "supercurious_woodlouse",
-                                3,
+                                2,
                                 "Report C",
                                 emptyMap()
                         )
@@ -480,15 +482,15 @@ class WorkflowRunControllerTests
                                         "error"
                                 ),
                                 WorkflowRunStatus.WorkflowRunReportStatus(
+                                        "Report C",
+                                        "supercurious_woodlouse",
+                                        "running"
+                                ),
+                                WorkflowRunStatus.WorkflowRunReportStatus(
                                         "Report B",
                                         "hygienic_mammoth",
                                         "success",
                                         "20210510-100458-8f1a9624"
-                                ),
-                                WorkflowRunStatus.WorkflowRunReportStatus(
-                                        "Report C",
-                                        "supercurious_woodlouse",
-                                        "running"
                                 )
                         )
                 )

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
@@ -220,7 +220,25 @@ class WorkflowRunControllerTests
             on { userProfile } doReturn CommonProfile().apply { id = "test@user.com" }
         }
 
-        val mockAPIResponseText = """{"data": {"workflow_key": "workflow_key1", "reports": ["report_key1", "report_key2"]}}"""
+        val mockAPIResponseText = """
+            {
+            "data": {
+                "workflow_key": "workflow_key1",
+                "reports": [
+                 {    
+                    "name": "report1",
+                    "key": "report_key1",
+                    "execution_order": 1,
+                    "params": {
+                       "param1": "value1"
+                    }
+                 },
+                 {    
+                    "name": "report2",
+                    "key": "report_key2",
+                    "execution_order": 2              
+                 }]
+             }}""".trimIndent()
 
         val mockAPIResponse = OrderlyServerResponse(mockAPIResponseText, 200)
 
@@ -268,7 +286,7 @@ class WorkflowRunControllerTests
                         listOf(WorkflowRunController.WorkflowQueuedReport(workflowRunRequest.reports[0].name,
                                 "report_key1", 1, workflowRunRequest.reports[0].params),
                                 WorkflowRunController.WorkflowQueuedReport(workflowRunRequest.reports[1].name,
-                                        "report_key2", 2, workflowRunRequest.reports[1].params))
+                                        "report_key2", 2, null))
                 )
         )
 
@@ -293,7 +311,7 @@ class WorkflowRunControllerTests
                                     "report_key2",
                                     2,
                                     workflowRunRequest.reports[1].name,
-                                    workflowRunRequest.reports[1].params
+                                    mapOf()
                             )
                     )
             )
@@ -374,7 +392,9 @@ class WorkflowRunControllerTests
 
         val apiClient = mock<OrderlyServerAPI> {
             on { post(any(), any<String>(), any()) } doReturn OrderlyServerResponse(
-                    """{"data": {"workflow_key": "workflow_key1", "reports": ["report_key1"]}}""",
+                    """{"data": {"workflow_key": "workflow_key1",
+                        | "reports": [{"key": "report_key1", "execution_order": 1,
+                        |  "name": "report1", "params": {"key": "value"}}]}}""".trimMargin(),
                     200
             )
         }
@@ -523,14 +543,14 @@ class WorkflowRunControllerTests
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "hygienic_mammoth",
-                                2,
+                                3,
                                 "Report B",
                                 emptyMap()
                         ),
                         WorkflowRunReport(
                                 "workflow_key1",
                                 "supercurious_woodlouse",
-                                3,
+                                2,
                                 "Report C",
                                 emptyMap()
                         )

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -2,7 +2,7 @@ group 'org.vaccineimpact'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.0'
     ext.detekt_version = '1.15.0'
 
     repositories {


### PR DESCRIPTION
Update run workflow endpoint to expect the new orderly server response, and explicitly sort by executon order when returning workflow report statuses.