### PR TITLE
mrc-3137 Expect 200 status when user with perms kills non-existent report

### DIFF
--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/ReportTests.kt
@@ -81,7 +81,7 @@ class ReportTests : IntegrationTest()
         val permissions = setOf(ReifiedPermission("reports.run", Scope.Global()))
         val allowedChecker = APIPermissionChecker(url, permissions, ContentTypes.json, HttpMethod.delete)
         response = allowedChecker.requestWithPermissions(permissions)
-        assertThat(response.statusCode).isEqualTo(400)
+        assertThat(response.statusCode).isEqualTo(200)
     }
 
     @Test


### PR DESCRIPTION
Fixes the build failure caused by orderly server change: https://github.com/vimc/orderly.server/pull/98

When user attempts to kill a report with a non-existent key, OS now returns a 200 rather than a 400, but with a message indicating that the report did not exist. 

The test which was failing is primarily testing that the endpoint returns a 403 when user does not have permissions to kill reports - which is still the case - and contrasting that with the 400 previously returned for user with perms for non-existent jey. Because of this, it seems sufficient to just update the expected status code for the user with perms in this test. 