### PR TITLE
Validate workflow CSV against all available reports

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/logic/WorkflowLogic.kt
@@ -95,7 +95,7 @@ class OrderlyWebWorkflowLogic(private val orderly: OrderlyServerAPI) : WorkflowL
         errorTemplate: (row: Int, col: Int?, msg: String) -> String
     ): List<String>
     {
-        val reportsQsParams: MutableMap<String, String> = mutableMapOf()
+        val reportsQsParams: MutableMap<String, String> = mutableMapOf("show_all" to "true")
         val parametersQsParams: MutableMap<String, String> = mutableMapOf()
         if (commit != null)
         {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -293,7 +293,7 @@ class WorkflowRunTests : IntegrationTest()
         --XXXX
         Content-Disposition: form-data; name="file"; filename="test.csv"
         Content-Type: text/csv
-        
+
         report
         global
         minimal
@@ -333,10 +333,11 @@ class WorkflowRunTests : IntegrationTest()
         --XXXX
         Content-Disposition: form-data; name="file"; filename="test.csv"
         Content-Type: text/csv
-        
+
         report,nmin
         other,1
         other,2
+        minimal,
         --XXXX--
         """.trimIndent()
         val response = webRequestHelper.requestWithSessionCookie(
@@ -351,7 +352,7 @@ class WorkflowRunTests : IntegrationTest()
         assertJsonContentType(response)
 
         val reports = JSONValidator.getData(response.text) as ArrayNode
-        assertThat(reports.count()).isEqualTo(2)
+        assertThat(reports.count()).isEqualTo(3)
         val report1 = reports[0]
         assertThat(report1["name"].asText()).isEqualTo("other")
         assertThat(report1["params"]["nmin"].asText()).isEqualTo("1")
@@ -359,6 +360,10 @@ class WorkflowRunTests : IntegrationTest()
         val report2 = reports[1]
         assertThat(report2["name"].asText()).isEqualTo("other")
         assertThat(report2["params"]["nmin"].asText()).isEqualTo("2")
+
+        val report3 = reports[2]
+        assertThat(report3["name"].asText()).isEqualTo("minimal")
+        assertThat(report3["params"].isEmpty(null)).isTrue()
     }
 
     @Test
@@ -369,7 +374,7 @@ class WorkflowRunTests : IntegrationTest()
         --XXXX
         Content-Disposition: form-data; name="file"; filename="test.csv"
         Content-Type: text/csv
-        
+
         BADHEADER,disease,year
         test1,HepB,2020
         --XXXX--
@@ -397,7 +402,7 @@ class WorkflowRunTests : IntegrationTest()
         --XXXX
         Content-Disposition: form-data; name="file"; filename="test.csv"
         Content-Type: text/csv
-        
+
         report,nmin
         other,1
         other,
@@ -482,7 +487,7 @@ class WorkflowRunTests : IntegrationTest()
                 ContentTypes.json,
                 HttpMethod.post,
                 """{
-                "ref": "$ref", 
+                "ref": "$ref",
                 "reports": [
                 {"name": "global", "params": {"nmin": "20"}},
                 {"name": "global", "params": {"nmin": "10"}}

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/OrderlyServerTests.kt
@@ -418,7 +418,7 @@ class OrderlyServerTests
         val mockResponse = """{"data": [
                 {"name": "param1", "value": "1"},
                 {"name": "param2", "value": "2"}
-            ], 
+            ],
             "errors": null, "status": "success"}""".trimMargin()
 
         val mockQueryParams = mapOf("commit" to "testCommit")

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/logic/WorkflowLogicTests.kt
@@ -18,7 +18,7 @@ class WorkflowLogicTests
     private val mockParams = listOf(Parameter("disease", "defaultDisuses"), Parameter("year", "2020"))
     private val commitOnlyQs = mapOf("commit" to testCommit)
     private val mockTestOrderlyAPI = mock<OrderlyServerAPI> {
-        on { getRunnableReportNames(eq(mapOf("branch" to testBranch, "commit" to testCommit))) } doReturn listOf(
+        on { getRunnableReportNames(eq(mapOf("show_all" to "true", "branch" to testBranch, "commit" to testCommit))) } doReturn listOf(
                 "test1", "test2", "test3")
         on { getReportParameters(eq("test1"), eq(commitOnlyQs)) } doReturn mockParams
         on { getReportParameters(eq("test2"), eq(commitOnlyQs)) } doReturn mockParams
@@ -54,7 +54,7 @@ class WorkflowLogicTests
             test2
         """.trimIndent().reader()
         val mockOrderlyAPI = mock<OrderlyServerAPI> {
-            on { getRunnableReportNames(eq(mapOf("branch" to testBranch, "commit" to testCommit))) } doReturn listOf(
+            on { getRunnableReportNames(eq(mapOf("show_all" to "true", "branch" to testBranch, "commit" to testCommit))) } doReturn listOf(
                     "test1", "test2", "test3")
             on { getReportParameters(any(), eq(mapOf("commit" to testCommit))) } doReturn listOf<Parameter>()
         }
@@ -74,7 +74,7 @@ class WorkflowLogicTests
             test1
         """.trimIndent().reader()
         val mockOrderlyAPI = mock<OrderlyServerAPI> {
-            on { getRunnableReportNames(eq(mapOf())) } doReturn listOf("test1")
+            on { getRunnableReportNames(eq(mapOf("show_all" to "true"))) } doReturn listOf("test1")
             on { getReportParameters(eq("test1"), eq(mapOf())) } doReturn listOf<Parameter>()
         }
         val result = sut(mockOrderlyAPI).parseAndValidateWorkflowCSV(csvReader, null, null)
@@ -82,7 +82,7 @@ class WorkflowLogicTests
         assertThat(result[0].name).isEqualTo("test1")
         assertThat(result[0].params).isEqualTo(mapOf<String, String>())
 
-        verify(mockOrderlyAPI).getRunnableReportNames(eq(mapOf()))
+        verify(mockOrderlyAPI).getRunnableReportNames(eq(mapOf("show_all" to "true")))
         verify(mockOrderlyAPI).getReportParameters(eq("test1"), eq(mapOf()))
     }
 
@@ -158,7 +158,7 @@ class WorkflowLogicTests
     {
         val csvReader = """
             report,disease,year,age
-            SingleDefaultParam,HepB,2020,5 
+            SingleDefaultParam,HepB,2020,5
             SingleDefaultParam,,,
             SingleNoDefaultParam,,,
             TwoParamsOneDefault,,2021,
@@ -168,7 +168,7 @@ class WorkflowLogicTests
         """.trimIndent().reader()
 
         val mockOrderlyAPI = mock<OrderlyServerAPI> {
-            on { getRunnableReportNames(eq(mapOf("branch" to testBranch, "commit" to testCommit))) } doReturn listOf(
+            on { getRunnableReportNames(eq(mapOf("show_all" to "true", "branch" to testBranch, "commit" to testCommit))) } doReturn listOf(
                     "SingleDefaultParam", "SingleNoDefaultParam", "TwoParamsOneDefault", "TwoParamsNoDefault",
                     "ParamNotInFile"
             )


### PR DESCRIPTION
This fixes the bug where you cannot add an unchanged report to a workflow csv on a branch other than master 

I've added a check for this to an existing integration test but let me know if more suitable as a separate test.

I have been able to check this works but running the app locally and uploading a csv manually