### PR TITLE
mrc-3068 upgrade to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,30 @@
-FROM vimc/node-docker:master
+FROM openjdk:11
 
-# Install OpenJDK
-RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list
 RUN apt-get update
-RUN apt-get install -t stretch-backports -y \
-    openjdk-8-jdk
-RUN rm /etc/apt/sources.list.d/stretch-backports.list
+RUN apt-get install -y build-essential
+
+# Install docker
+RUN apt-get update
+RUN apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        software-properties-common \
+        dirmngr \
+        apt-transport-https \
+        lsb-release \
+        gnupg \
+        ca-certificates
+
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update
+RUN apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get -y install nodejs
 
 # Setup gradle
 COPY src/gradlew /api/src/

--- a/buildkite/common
+++ b/buildkite/common
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -ex
 
-if [ "$BUILDKITE" = "true" ]; then
+if [ -n "${BUILDKITE-}" ]; then
     GIT_ID=${BUILDKITE_COMMIT:0:7}
 else
     GIT_ID=$(git rev-parse --short=7 HEAD)
 fi
 
-if [ "$BUILDKITE" = "true" ]; then
+if [ -n "${BUILDKITE-}" ]; then
     GIT_BRANCH=$BUILDKITE_BRANCH
 else
     GIT_BRANCH=$(git symbolic-ref --short HEAD)

--- a/customConfigTests.Dockerfile
+++ b/customConfigTests.Dockerfile
@@ -37,7 +37,6 @@ RUN apt-get update && apt-get install -yq \
                 ca-certificates \
                 fonts-liberation \
                 libgbm1 \
-                #libappindicator1 \
                 libnss3 \
                 lsb-release \
                 xdg-utils \

--- a/customConfigTests.Dockerfile
+++ b/customConfigTests.Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get update && apt-get install -yq \
                 libxtst6 \
                 ca-certificates \
                 fonts-liberation \
-                libappindicator1 \
+                libgbm1 \
+                #libappindicator1 \
                 libnss3 \
                 lsb-release \
                 xdg-utils \

--- a/dist.Dockerfile
+++ b/dist.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u121
+FROM openjdk:11
 
 RUN mkdir /static/public -p
 

--- a/scripts/install-chromedriver.sh
+++ b/scripts/install-chromedriver.sh
@@ -6,6 +6,6 @@ sudo apt-get install -y unzip xvfb libxi6 libgconf-2-4
 # See https://chromedriver.chromium.org/downloads/version-selection
 curl -sO https://chromedriver.storage.googleapis.com/$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$(google-chrome --product-version | cut -d. -f1-3))/chromedriver_linux64.zip
 unzip chromedriver_linux64.zip
-sudo mv chromedriver /usr/bin/chromedriver
-sudo chown root:root /usr/bin/chromedriver
-sudo chmod +x /usr/bin/chromedriver
+mv chromedriver /usr/bin/chromedriver
+chown root:root /usr/bin/chromedriver
+chmod +x /usr/bin/chromedriver

--- a/src/.idea/compiler.xml
+++ b/src/.idea/compiler.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11">
+      <module name="blackboxTests_main" target="11" />
+      <module name="blackboxTests_test" target="11" />
+      <module name="models_main" target="11" />
+      <module name="models_test" target="11" />
+      <module name="security_main" target="11" />
+      <module name="security_test" target="11" />
+    </bytecodeTargetLevel>
+  </component>
+</project>

--- a/src/.idea/gradle.xml
+++ b/src/.idea/gradle.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="delegatedBuild" value="false" />
+        <option name="testRunner" value="GRADLE" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="11" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+            <option value="$PROJECT_DIR$/customConfigTests" />
+            <option value="$PROJECT_DIR$/databaseInterface" />
+            <option value="$PROJECT_DIR$/generateDatabaseInterface" />
+            <option value="$PROJECT_DIR$/testHelpers" />
+            <option value="$PROJECT_DIR$/userCLI" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/ReportTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRepositoryTests/ReportTests.kt
@@ -334,7 +334,7 @@ class ReportTests : CleanDatabaseTests()
     @Test
     fun `can get latest dates for selected reports`()
     {
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         insertReport("test1", "v1", date = Timestamp.from(now.minusSeconds(60)))
         insertReport("test1", "v2", date = Timestamp.from(now))

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRunRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/ReportRunRepositoryTests.kt
@@ -15,7 +15,7 @@ import org.vaccineimpact.orderlyweb.models.ReportRunWithDate
 
 class ReportRunRepositoryTests : CleanDatabaseTests()
 {
-    private val now = Instant.now()
+    private val now = Instant.ofEpochMilli(1655378424228)
 
     private fun addTestReportRun(sut: OrderlyWebReportRunRepository)
     {

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/WorkflowRunReportRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/WorkflowRunReportRepositoryTests.kt
@@ -18,7 +18,7 @@ import java.time.Instant
 
 class WorkflowRunReportRepositoryTests : CleanDatabaseTests()
 {
-    private val startTime = Instant.now()
+    private val startTime = Instant.ofEpochMilli(1655378424228)
 
     @Before
     fun createWorkflow()
@@ -154,12 +154,11 @@ class WorkflowRunReportRepositoryTests : CleanDatabaseTests()
     @Test
     fun `can get report run when date is not null`()
     {
-        val now = Instant.now()
         val sut = OrderlyWebWorkflowRunReportRepository()
         insertWorkflowRunReport("test_wf_key", "report_with_date_key", "report_with_date_name",
-            mapOf(), now)
+            mapOf(), startTime)
         val result = sut.getReportRun("report_with_date_key")
-        assertThat(result.date).isEqualTo(now)
+        assertThat(result.date).isEqualTo(startTime)
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/WorkflowRunRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/WorkflowRunRepositoryTests.kt
@@ -16,13 +16,14 @@ import org.vaccineimpact.orderlyweb.tests.insertUser
 import java.time.Instant
 
 class WorkflowRunRepositoryTests : CleanDatabaseTests()
-{
+{   
+    
+    private val now = Instant.ofEpochMilli(1655378424228)
+
     @Test
     fun `can add workflow run`()
     {
         insertUser("user@email.com", "user.name")
-
-        val now = Instant.ofEpochMilli(1655378424228)
 
         val workflowRun = WorkflowRun(
                 "Interim report",
@@ -207,8 +208,6 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.ofEpochMilli(1655378424228)
-
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
                 WorkflowRun(
@@ -238,8 +237,6 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     fun `can get all workflow runs`()
     {
         insertUser("user@email.com", "user.name")
-
-        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
@@ -311,8 +308,6 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
         insertUser("user@email.com", "user.name")
         insertUser("user2@email.com", "user2.name")
 
-        val now = Instant.ofEpochMilli(1655378424228)
-
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
                 WorkflowRun(
@@ -355,8 +350,6 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
         insertUser("user@email.com", "user.name")
         insertUser("user2@email.com", "user2.name")
 
-        val now = Instant.ofEpochMilli(1655378424228)
-
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
                 WorkflowRun(
@@ -397,8 +390,6 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     fun `can get all workflow runs using non-empty name prefix`()
     {
         insertUser("user@email.com", "user.name")
-
-        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
@@ -441,8 +432,6 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.ofEpochMilli(1655378424228)
-
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
                 WorkflowRun(
@@ -484,8 +473,6 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.ofEpochMilli(1655378424228)
-
         val sut = OrderlyWebWorkflowRunRepository()
 
         val workflowRun = WorkflowRun(
@@ -524,8 +511,6 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     fun `does not get workflow details if key is invalid`()
     {
         insertUser("user@email.com", "user.name")
-
-        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/WorkflowRunRepositoryTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/database_tests/WorkflowRunRepositoryTests.kt
@@ -22,7 +22,7 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         val workflowRun = WorkflowRun(
                 "Interim report",
@@ -207,7 +207,7 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
@@ -239,7 +239,7 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
@@ -311,7 +311,7 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
         insertUser("user@email.com", "user.name")
         insertUser("user2@email.com", "user2.name")
 
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
@@ -355,7 +355,7 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
         insertUser("user@email.com", "user.name")
         insertUser("user2@email.com", "user2.name")
 
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
@@ -398,7 +398,7 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
@@ -441,7 +441,7 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
         sut.addWorkflowRun(
@@ -484,7 +484,7 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
 
@@ -525,7 +525,7 @@ class WorkflowRunRepositoryTests : CleanDatabaseTests()
     {
         insertUser("user@email.com", "user.name")
 
-        val now = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
 
         val sut = OrderlyWebWorkflowRunRepository()
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportLogsTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/ReportLogsTests.kt
@@ -28,8 +28,8 @@ class ReportLogsTests : IntegrationTest()
         val sessionCookie = webRequestHelper.webLoginWithMontagu(permissions)
         val contentType = ContentTypes.json
 
-        val now = Instant.now()
-        val now2 = Instant.now()
+        val now = Instant.ofEpochMilli(1655378424228)
+        val now2 = Instant.ofEpochMilli(1655378424229)
 
         OrderlyWebReportRunRepository().addReportRun(
             "key1",

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -100,7 +100,7 @@ class WorkflowRunTests : IntegrationTest()
         val name = "Interim report"
         val key = "adventurous_aardvark"
         val email = "test.user@example.com"
-        val date = Instant.now()
+        val date = Instant.ofEpochMilli(1655378424228)
         val runWorkflowReport = listOf(
                 WorkflowRunReport(
                         "adventurous_aardvark",

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -51,7 +51,7 @@ def loadProperties() {
                     "but no corresponding properties file exists at $userPropertiesFile.absolutePath")
         }
     }
-    properties["project_dir"] = new File(properties["project_dir"]).getAbsolutePath()
+    properties["project_dir"] = file(properties["project_dir"]).getAbsolutePath()
     return properties
 }
 
@@ -84,7 +84,18 @@ subprojects {
         baseline = file("$rootDir/config/detekt/baseline.yml")
     }
 
-    tasks.detekt.jvmTarget = "1.8"
+    tasks.detekt.jvmTarget = "11"
+
+    compileKotlin {
+        kotlinOptions {
+            jvmTarget = "11"
+        }
+    }
+    compileTestKotlin {
+        kotlinOptions {
+            jvmTarget = "11"
+        }
+    }
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
+++ b/src/customConfigTests/src/test/resources/hoverfly/github-oauth2-login.json
@@ -49,10 +49,6 @@
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Referer" : [ {
             "matcher" : "glob",
             "value" : "http://localhost:8888/*"
@@ -135,10 +131,6 @@
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Cookie" : [ {
             "matcher" : "regex",
             "value" : ".*"
@@ -216,10 +208,6 @@
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Origin" : [ {
             "matcher" : "exact",
             "value" : "https://github.com"
@@ -294,10 +282,6 @@
           "Accept-Encoding" : [ {
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
-          } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
           } ],
           "Origin" : [ {
             "matcher" : "exact",
@@ -374,10 +358,6 @@
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Origin" : [ {
             "matcher" : "exact",
             "value" : "https://github.com"
@@ -452,10 +432,6 @@
           "Accept-Encoding" : [ {
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
-          } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
           } ],
           "Origin" : [ {
             "matcher" : "exact",
@@ -532,10 +508,6 @@
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Origin" : [ {
             "matcher" : "exact",
             "value" : "https://github.com"
@@ -610,10 +582,6 @@
           "Accept-Encoding" : [ {
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
-          } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
           } ],
           "Origin" : [ {
             "matcher" : "exact",
@@ -694,10 +662,6 @@
             "matcher" : "regex",
             "value" : ".*"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Cookie" : [ {
             "matcher" : "regex",
             "value" : ".*"
@@ -771,10 +735,6 @@
           "Accept-Encoding" : [ {
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
-          } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
           } ],
           "Content-Length" : [ {
             "matcher" : "regex",
@@ -904,10 +864,6 @@
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Referer" : [ {
             "matcher" : "exact",
             "value" : "https://github.com/"
@@ -972,10 +928,6 @@
           "Accept-Encoding" : [ {
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
-          } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
           } ],
           "Content-Length" : [ {
             "matcher" : "regex",
@@ -1066,10 +1018,6 @@
           "Cache-Control" : [ {
             "matcher" : "exact",
             "value" : "max-age=0"
-          } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
           } ],
           "Content-Length" : [ {
             "matcher" : "regex",
@@ -1181,10 +1129,6 @@
             "matcher" : "exact",
             "value" : "max-age=0"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Cookie" : [ {
             "matcher" : "regex",
             "value" : ".*"
@@ -1263,10 +1207,6 @@
             "matcher" : "exact",
             "value" : "gzip, deflate, br"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Origin" : [ {
             "matcher" : "exact",
             "value" : "https://github.com"
@@ -1342,10 +1282,6 @@
             "matcher" : "regex",
             "value" : ".*"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "Content-Length" : [ {
             "matcher" : "exact",
             "value" : "175"
@@ -1419,10 +1355,6 @@
             "matcher" : "exact",
             "value" : "token notarealtoken"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "User-Agent" : [ {
             "matcher" : "regex",
             "value" : ".*"
@@ -1495,10 +1427,6 @@
             "matcher" : "exact",
             "value" : "token notarealtoken"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "User-Agent" : [ {
             "matcher" : "regex",
             "value" : ".*"
@@ -1569,10 +1497,6 @@
           "Authorization" : [ {
             "matcher" : "exact",
             "value" : "token notarealtoken"
-          } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
           } ],
           "User-Agent" : [ {
             "matcher" : "regex",
@@ -1645,10 +1569,6 @@
             "matcher" : "exact",
             "value" : "token notarealtoken"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "User-Agent" : [ {
             "matcher" : "regex",
             "value" : ".*"
@@ -1719,10 +1639,6 @@
           "Authorization" : [ {
             "matcher" : "exact",
             "value" : "Bearer notarealtoken"
-          } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
           } ],
           "User-Agent" : [ {
             "matcher" : "regex",
@@ -1796,10 +1712,6 @@
             "matcher" : "exact",
             "value" : "token notarealtoken"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "User-Agent" : [ {
             "matcher" : "regex",
             "value" : ".*"
@@ -1872,10 +1784,6 @@
             "matcher" : "exact",
             "value" : "token notarealtoken"
           } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
-          } ],
           "User-Agent" : [ {
             "matcher" : "regex",
             "value" : ".*"
@@ -1947,10 +1855,6 @@
           "Authorization" : [ {
             "matcher" : "exact",
             "value" : "token notarealtoken"
-          } ],
-          "Connection" : [ {
-            "matcher" : "exact",
-            "value" : "keep-alive"
           } ],
           "User-Agent" : [ {
             "matcher" : "regex",

--- a/src/userCLI/Dockerfile
+++ b/src/userCLI/Dockerfile
@@ -1,4 +1,3 @@
-FROM openjdk:8u121-jre
+FROM openjdk:11
 ADD "userCLI.tar" /
 ENTRYPOINT ["sh", "/userCLI/bin/userCLI"]
-


### PR DESCRIPTION
Upgrade to Java 11. A few minor changes to the docker images, update to datetime tests to account for the fact that datetime precision coming out of the db is now only to milliseconds, and a change to the hoverfly code as apparently `keep-alive` header is no longer being set. Is the latter a problem?! Manual testing suggests not, the login flow works as expected when I run it locally. I have deployed this to UAT but can't test it because vpn access not working :roll_eyes: 