### PR TITLE
mrc-3401 fix bug in spec

### DIFF
--- a/docs/spec/Artefact.schema.json
+++ b/docs/spec/Artefact.schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "format": { "type": "string"},
     "description": {"type": "string"},
-    "files": {"type": "array", "items": {"type": "string"}}
+    "files": {"type": "array", "items": {"$ref": "FileInfo.schema.json"}}
   },
   "additionalProperties": false
 }

--- a/docs/spec/FileInfo.schema.json
+++ b/docs/spec/FileInfo.schema.json
@@ -1,10 +1,9 @@
 {
-  "id": "DataInfo",
+  "id": "FileInfo",
   "type": "object",
   "properties": {
     "name": { "type": "string"},
-    "csv_size": {"type": "number"},
-    "rds_size": {"type": "number"}
+    "size": {"type": "number"}
   },
   "additionalProperties": false
 }

--- a/docs/spec/VersionDetails.schema.json
+++ b/docs/spec/VersionDetails.schema.json
@@ -9,11 +9,12 @@
         "date": {"type" :"string"},
         "published":  {"type" :"boolean"},
         "artefacts": { "type": "array", "items": { "$ref": "Artefact.schema.json"}},
-        "resources": {"type": "array", "items": {"type": "string"}},
+        "resources": {"type": "array", "items": {"$ref": "FileInfo.schema.json"}},
         "data_info": {"type":  "array", "items":  {"$ref": "DataInfo.schema.json"}},
         "parameter_values": {"type":  "object"},
 		"instances": {"type":  "object"}
 	},
-	"additionalProperties": false,
-	"required": ["name", "id", "display_name", "description", "date", "published", "parameter_values", "instances"]
+	"additionalProperties": true,
+	"required": ["name", "id", "display_name", "description", "date",
+		"published", "artefacts", "resources", "data_info", "parameter_values", "instances"]
 }

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -188,8 +188,8 @@ Schema: [`VersionDetails.schema.json`](VersionDetails.schema.json)
   "date": "2016-10-06 14:23:57.0",
   "data_info": {
     "name": "extract",
-    "csvSize": 751,
-    "rdsSize": 559
+    "csv_size": 751,
+    "rds_size": 559
   },
   "parameter_values": {
     "param1": "paramValue1",

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -176,7 +176,7 @@ Schema: [`VersionDetails.schema.json`](VersionDetails.schema.json)
     {
       "format": "staticgraph",
       "description": "A graph of things",
-      "files": [{name: "minimal", file:  "mygraph.png"]
+      "files": [{name: "mygraph.png", size: 123}]
     }
   ],
   "resources": [

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -168,30 +168,41 @@ Schema: [`VersionDetails.schema.json`](VersionDetails.schema.json)
 
 ```json
 {
-    "id": "20161006-142357-e80edf58",
-    "name": "minimal",
-    "displayname": null,
-    "description": null,
-    "artefacts": [
-      {        
-          "format": "staticgraph",
-          "description": "A graph of things",
-          "files": [
-            "mygraph.png"
-          ]        
-      }
-    ],
-    "resources": ["source/inputdata.csv"],
-    "date": "2016-10-06 14:23:57.0",   
-    "data_hashes": {
-      "dat": "386f507375907a60176b717016f0a648"
-    },
-    "parameter_values": {"param1": "paramValue1", "param2": "paramValue2"},
-    "instances": {"source": "science"},
-    "published": false,
-    "requester": "Funder McFunderface",
-    "author": "Researcher McResearcherface"
-  }
+  "id": "20161006-142357-e80edf58",
+  "name": "minimal",
+  "displayname": null,
+  "description": null,
+  "artefacts": [
+    {
+      "format": "staticgraph",
+      "description": "A graph of things",
+      "files": [
+        "mygraph.png"
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "name": "source/inputdata.csv",
+      "size": 20
+    }
+  ],
+  "date": "2016-10-06 14:23:57.0",
+  "data_info": {
+    "name": "extract",
+    "csvSize": 751,
+    "rdsSize": 559
+  },
+  "parameter_values": {
+    "param1": "paramValue1",
+    "param2": "paramValue2"
+  },
+  "instances": {
+    "source": "science"
+  },
+  "requester": "Funder McFunderface",
+  "author": "Researcher McResearcherface"
+}
 ```
 
 ## POST /reports/:name/run/

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -176,9 +176,7 @@ Schema: [`VersionDetails.schema.json`](VersionDetails.schema.json)
     {
       "format": "staticgraph",
       "description": "A graph of things",
-      "files": [
-        "mygraph.png"
-      ]
+      "files": [{name: "minimal", file:  "mygraph.png"]
     }
   ],
   "resources": [

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/VersionTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/VersionTests.kt
@@ -9,11 +9,13 @@ import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.db.JooqContext
 import org.vaccineimpact.orderlyweb.db.Tables.ORDERLYWEB_REPORT_VERSION_FULL
 import org.vaccineimpact.orderlyweb.db.Tables.REPORT_VERSION
+import org.vaccineimpact.orderlyweb.models.ArtefactFormat
+import org.vaccineimpact.orderlyweb.models.FileInfo
+import org.vaccineimpact.orderlyweb.models.FilePurpose
 import org.vaccineimpact.orderlyweb.models.Scope
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
 import org.vaccineimpact.orderlyweb.test_helpers.insertReport
-import org.vaccineimpact.orderlyweb.tests.InsertableChangelog
-import org.vaccineimpact.orderlyweb.tests.insertChangelog
+import org.vaccineimpact.orderlyweb.tests.*
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReader
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeGlobalReportReviewer
 import org.vaccineimpact.orderlyweb.tests.integration_tests.helpers.fakeReportReader
@@ -180,6 +182,12 @@ class VersionTests : IntegrationTest()
     fun `can get report by name and version`()
     {
         insertReport("testname", "testversion")
+        insertFileInput("testversion", "file.csv", FilePurpose.RESOURCE, 2345)
+        insertFileInput("testversion", "graph.png", FilePurpose.RESOURCE, 3456)
+        insertData("testversion", "dat", "some sql", "testdb", "somehash", 9876, 7654)
+        insertArtefact("testversion", "some artefact",
+                ArtefactFormat.DATA, files = listOf(FileInfo("artefactfile.csv", 1234)))
+
         val response = apiRequestHelper.get("/reports/testname/versions/testversion",
                 userEmail = fakeGlobalReportReader())
         assertSuccessful(response)


### PR DESCRIPTION
The spec/schema for `GET reports/:name/versions/:version` was wrong. This updates the integration test to actually pick this up (see https://github.com/vimc/orderly-web/pull/471/commits/e3be3248487ea09b8122ce76175e6f6aba8780c4 for failing test prior to schema change), and fixes the spec/schema so that it matches the behaviour of the endpoint.
