### PR TITLE
Add more DB/app readiness checks in between tests to fix flakiness

### DIFF
--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/SparkApp.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/SparkApp.kt
@@ -56,14 +56,15 @@ class OrderlyWeb
     {
         val freeMarkerConfig = buildFreemarkerConfig(File("templates").absoluteFile)
 
-        staticFiles.externalLocation(File("static/public").absolutePath)
-
         waitForGoSignal()
 
         logger.info("Using the following config")
         logger.info(getPropertiesAsString(AppConfig.properties))
 
         setupPort()
+
+        staticFiles.externalLocation(File("static/public").absolutePath)
+
         spk.before("*", AllowedOriginsFilter(AppConfig().getBool("allow.localhost")))
         spk.options("*") { _, res ->
             res.header("Access-Control-Allow-Headers", "Authorization")

--- a/src/customConfigTests/build.gradle
+++ b/src/customConfigTests/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation "com.github.fge:json-schema-validator:2.2.6"
     testImplementation "org.seleniumhq.selenium:selenium-java:3.11.0"
     testImplementation "io.specto:hoverfly-java:0.12.0"
-    testImplementation "com.sparkjava:spark-core:2.7.1"
+    testImplementation "com.sparkjava:spark-core:2.9.3"
     testImplementation "org.jooq:jooq:3.13.5"
     testImplementation "org.jooq:jooq-meta:3.13.5"
 

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
@@ -100,7 +100,7 @@ abstract class CustomConfigTests
         {
             return spark.Spark.routes().size > 0
         }
-        catch (e: NullPointerException)
+        catch (e: Exception)
         {
             false
         }

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
@@ -25,6 +25,10 @@ abstract class CustomConfigTests
         {
             Thread.sleep(500)
         }
+        while (isSparkInstanceRunning())
+        {
+            Thread.sleep(500)
+        }
 
         main(emptyArray())
         Thread.sleep(500)
@@ -51,6 +55,7 @@ abstract class CustomConfigTests
     fun cleanup()
     {
         spark.Spark.stop()
+
         File(AppConfig()["db.location"]).delete()
 
         // reset the properties
@@ -84,6 +89,18 @@ abstract class CustomConfigTests
             true
         }
         catch (e: BindException)
+        {
+            false
+        }
+    }
+
+    private fun isSparkInstanceRunning(): Boolean
+    {
+        return try
+        {
+            return spark.Spark.routes().size > 0
+        }
+        catch (e: NullPointerException)
         {
             false
         }

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
@@ -95,7 +95,6 @@ abstract class CustomConfigTests
         {
             JooqContext(dbLocation).use {
                 it.dsl.selectFrom(ORDERLYWEB_REPORT_VERSION_FULL).fetchAny()
-                it.dsl.selectFrom(ORDERLYWEB_REPORT_RUN).fetchAny()
             }
             true
         }

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
@@ -6,8 +6,7 @@ import org.junit.Before
 import org.vaccineimpact.orderlyweb.app_start.main
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.db.JooqContext
-import org.vaccineimpact.orderlyweb.db.Tables.ORDERLYWEB_USER
-import org.vaccineimpact.orderlyweb.db.Tables.REPORT_VERSION
+import org.vaccineimpact.orderlyweb.db.Tables.*
 import org.vaccineimpact.orderlyweb.db.getResource
 import org.vaccineimpact.orderlyweb.test_helpers.http.Response
 import java.io.File
@@ -95,7 +94,8 @@ abstract class CustomConfigTests
         return try
         {
             JooqContext(dbLocation).use {
-                it.dsl.selectFrom(ORDERLYWEB_USER).fetchAny()
+                it.dsl.selectFrom(ORDERLYWEB_REPORT_VERSION_FULL).fetchAny()
+                it.dsl.selectFrom(ORDERLYWEB_REPORT_RUN).fetchAny()
             }
             true
         }

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
@@ -3,6 +3,7 @@ package org.vaccineimpact.orderlyweb.customConfigTests
 import com.github.fge.jackson.JsonLoader
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
 import org.junit.Test
 import org.vaccineimpact.orderlyweb.db.AppConfig
 import org.vaccineimpact.orderlyweb.test_helpers.TestTokenHeader
@@ -13,6 +14,9 @@ class FineGrainedPermissionTests : CustomConfigTests()
     val apiBaseUrl: String = "http://localhost:${AppConfig()["app.port"]}/api/v1"
     val url = "$apiBaseUrl/login/"
 
+    @get:Rule
+    val debugHelper = DebugHelper()
+    
     @Test
     fun `can login when fine-grained permissions are turned off`()
     {

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/SeleniumDebugHelper.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/SeleniumDebugHelper.kt
@@ -6,18 +6,26 @@ import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.logging.LogType
 
-class DebugHelper: TestWatcher()
+class SeleniumDebugHelper: TestWatcher()
 {
     lateinit var driver: WebDriver
 
     override fun failed(e: Throwable, description: Description)
     {
         System.err.println(driver.findElement(By.cssSelector("body")).getAttribute("innerHTML"))
+        System.err.println(driver.manage().logs().get(LogType.BROWSER).joinToString(",") { it.message })
     }
 
     override fun finished(description: Description)
     {
-        System.err.println(driver.manage().logs().get(LogType.BROWSER).joinToString(",") { it.message })
         driver.quit()
+    }
+}
+
+class DebugHelper: TestWatcher()
+{
+    override fun failed(e: Throwable, description: Description)
+    {
+        e.printStackTrace()
     }
 }

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/SeleniumTest.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/SeleniumTest.kt
@@ -9,14 +9,16 @@ import org.openqa.selenium.By
 import org.openqa.selenium.Proxy
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeDriverService
+import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.support.ui.ExpectedConditions
 import org.openqa.selenium.support.ui.WebDriverWait
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyAuthorizationRepository
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyUserRepository
 import org.vaccineimpact.orderlyweb.models.UserSource
 import org.vaccineimpact.orderlyweb.models.permissions.ReifiedPermission
+import java.io.FileOutputStream
 import java.util.concurrent.TimeUnit
-
 
 abstract class SeleniumTest : CustomConfigTests()
 {
@@ -24,7 +26,7 @@ abstract class SeleniumTest : CustomConfigTests()
     protected lateinit var wait: WebDriverWait
 
     @get:Rule
-    val debugHelper = DebugHelper()
+    val debugHelper = SeleniumDebugHelper()
 
     companion object
     {
@@ -42,11 +44,15 @@ abstract class SeleniumTest : CustomConfigTests()
         proxy.httpProxy = "localhost:" + hoverflyRule.proxyPort
         proxy.sslProxy = "localhost:" + hoverflyRule.proxyPort
         System.setProperty("webdriver.chrome.whitelistedIps", "")
-        driver = ChromeDriver(org.openqa.selenium.chrome.ChromeOptions()
+        val chromeDriverService = ChromeDriverService.createDefaultService()
+        chromeDriverService.sendOutputTo(FileOutputStream("/dev/null"))
+        driver = ChromeDriver(chromeDriverService, ChromeOptions()
                 .apply {
-                    addArguments("--ignore-certificate-errors", "--headless", "--no-sandbox", "--disable-dev-shm-usage")
+                    addArguments("--ignore-certificate-errors", "--headless", "--no-sandbox",
+                            "--disable-dev-shm-usage")
                     setProxy(proxy)
                 })
+
         driver.manage().timeouts().implicitlyWait(12, TimeUnit.SECONDS)
         wait = WebDriverWait(driver, 12)
         debugHelper.driver = driver

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/http/HttpClient.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/http/HttpClient.kt
@@ -8,6 +8,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
+import java.io.Closeable
 import java.net.CookieManager
 import java.util.*
 
@@ -102,7 +103,7 @@ data class BasicAuthorization(val user: String, val password: String) : Authoriz
         }
 }
 
-class Response(private val okHttpResponse: okhttp3.Response)
+class Response(private val okHttpResponse: okhttp3.Response): Closeable
 {
     val content: ByteArray by lazy(okHttpResponse.body!!::bytes)
     val headers: Map<String, String>
@@ -110,4 +111,8 @@ class Response(private val okHttpResponse: okhttp3.Response)
     val statusCode: Int
         get() = okHttpResponse.code
     val text: String by lazy(okHttpResponse.body!!::string)
+    override fun close()
+    {
+        okHttpResponse.close()
+    }
 }


### PR DESCRIPTION
Adds some more checks before tests execute:
* is the template db available
* is the copied db available
* has the previous Spark instance stopped

Given flakiness it's hard to say whether this has fixed the issues, but I did re-run the last build 3 times and get 3 consecutive passes.