### PR TITLE
Update version of requirements in buildkite build

### DIFF
--- a/scripts/release/requirements.txt
+++ b/scripts/release/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
-requests==2.20.1
+requests==2.28.1
 docker
 pytest


### PR DESCRIPTION
Not sure if this will completely alleviate the package install problems, but Rich thinks it will be a good start. The agents have been updated to ubuntu 22. If there is still an issue after this upgrade we can have a look at https://mrc-ide.myjetbrains.com/youtrack/issue/RESIDE-325