### PR TITLE
Use env var to set orderly server version

### DIFF
--- a/buildkite/common
+++ b/buildkite/common
@@ -22,9 +22,15 @@ GIT_BRANCH=$(echo $GIT_BRANCH | sed 's;/;-;g')
 
 BUILDKITE_DOCKER_AUTH_PATH=/var/lib/buildkite-agent/.docker/config.json
 
+if [ -n "${ORDERLY_SERVER_VERSION-}" ]; then
+    MONTAGU_ORDERLY_SERVER_VERSION=$ORDERLY_SERVER_VERSION
+else
+    MONTAGU_ORDERLY_SERVER_VERSION=$(<$here/../config/orderly_server_version)
+fi
+
 # Export env vars needed for running test dependencies
 export ORG=vimc
-export MONTAGU_ORDERLY_SERVER_VERSION=$(<$here/../config/orderly_server_version)
+export MONTAGU_ORDERLY_SERVER_VERSION=$MONTAGU_ORDERLY_SERVER_VERSION
 export GIT_ID=$GIT_ID
 export GIT_BRANCH=$GIT_BRANCH
 export MONTAGU_ORDERLY_PATH=$PWD/git

--- a/buildkite/common
+++ b/buildkite/common
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
+ROOT=$(realpath $here/..)
+
 if [ -n "${BUILDKITE-}" ]; then
     GIT_ID=${BUILDKITE_COMMIT:0:7}
 else
@@ -25,7 +27,7 @@ BUILDKITE_DOCKER_AUTH_PATH=/var/lib/buildkite-agent/.docker/config.json
 if [ -n "${ORDERLY_SERVER_VERSION-}" ]; then
     MONTAGU_ORDERLY_SERVER_VERSION=$ORDERLY_SERVER_VERSION
 else
-    MONTAGU_ORDERLY_SERVER_VERSION=$(<$here/../config/orderly_server_version)
+    MONTAGU_ORDERLY_SERVER_VERSION=$(<$ROOT/config/orderly_server_version)
 fi
 
 # Export env vars needed for running test dependencies


### PR DESCRIPTION
This is so we can set this in orderly.server to trigger a build of OW with a specific version of orderly.server to test if changes to orderly.server will break OW. If `ORDERLY_SERVER_VERSION` env var is not set this will fallback to existing behaviour

We will then trigger a build from orderly.server like
```
- trigger: "orderly-web"
    label: ":rocket: orderly-web (from orderly.server) :cloud:"
    env:
        ORDERLY_SERVER_VERSION: "${BUIDLKITE_COMMIT}"
```
