### PR TITLE
Set combined tag when orderly.server branch is not default

### DIFF
--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -4,11 +4,20 @@ ARG git_id='UNKNOWN'
 ARG git_branch='UNKNOWN'
 ARG registry=vimc
 ARG name=orderly-web
+ARG orderly_server_branch
 
 ENV GIT_ID $git_id
 ENV APP_DOCKER_TAG $registry/$name
 ENV APP_DOCKER_COMMIT_TAG $registry/$name:$git_id
 ENV APP_DOCKER_BRANCH_TAG $registry/$name:$git_branch
+## If the orderly.server version is not the default branch
+## then use a combined tag so that we never replace an
+## existing tagged image built off master with an image
+## with a different version of orderly installed
+## ${orderly_server_branch:+-} expands to `-` if the var is set
+## and is an empty string otherwise
+ENV APP_DOCKER_COMMIT_TAG $registry/$name:$git_id${orderly_server_branch:+-}${orderly_server_branch}
+ENV APP_DOCKER_BRANCH_TAG $registry/$name:$git_branch${orderly_server_branch:+-}${orderly_server_branch}
 
 RUN npm run test --prefix=/api/src/app/static
 

--- a/buildkite/build-app.sh
+++ b/buildkite/build-app.sh
@@ -12,11 +12,12 @@ $here/make-build-env.sh
 
 # Create an image based on the build image to compile, test and package the app
 docker build \
-    --file app.Dockerfile \
-    --tag orderly-web-app-build \
-    --build-arg git_id=$GIT_ID \
-	  --build-arg git_branch=$GIT_BRANCH \
-	  .
+  --file app.Dockerfile \
+  --tag orderly-web-app-build \
+  --build-arg git_id=$GIT_ID \
+  --build-arg git_branch=$GIT_BRANCH \
+  --build-arg orderly_server_branch=$ORDERLY_SERVER_VERSION
+.
 
 # Generate orderly data and migrate for orderly web tables
 $here/make-db.sh
@@ -38,11 +39,11 @@ function cleanup() {
 }
 trap cleanup EXIT
 docker run --rm \
-    -v $PWD/demo:/api/src/app/demo \
-    -v $PWD/git:/api/src/app/git \
-    -v $PWD/reports:/api/src/app/build/reports \
-    -v $PWD/coverage:/api/src/app/coverage \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $BUILDKITE_DOCKER_AUTH_PATH:/root/.docker/config.json \
-    --network=host \
-    orderly-web-app-build
+  -v $PWD/demo:/api/src/app/demo \
+  -v $PWD/git:/api/src/app/git \
+  -v $PWD/reports:/api/src/app/build/reports \
+  -v $PWD/coverage:/api/src/app/coverage \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v $BUILDKITE_DOCKER_AUTH_PATH:/root/.docker/config.json \
+  --network=host \
+  orderly-web-app-build

--- a/buildkite/build-app.sh
+++ b/buildkite/build-app.sh
@@ -16,8 +16,8 @@ docker build \
   --tag orderly-web-app-build \
   --build-arg git_id=$GIT_ID \
   --build-arg git_branch=$GIT_BRANCH \
-  --build-arg orderly_server_branch=$ORDERLY_SERVER_VERSION
-.
+  --build-arg orderly_server_branch=$ORDERLY_SERVER_VERSION \
+  .
 
 # Generate orderly data and migrate for orderly web tables
 $here/make-db.sh

--- a/buildkite/build-cli.sh
+++ b/buildkite/build-cli.sh
@@ -16,6 +16,7 @@ here=$(dirname $0)
 docker build --tag orderly-web-cli-build \
     --build-arg git_id=$GIT_ID \
     --build-arg git_branch=$GIT_BRANCH \
+    --build-arg orderly_server_branch=$ORDERLY_SERVER_VERSION \
     -f cli.Dockerfile \
     .
 
@@ -24,7 +25,7 @@ $here/make-db.sh
 
 # Run the created image
 function cleanup() {
-  $here/../scripts/clear-docker.sh
+    $here/../scripts/clear-docker.sh
 }
 trap cleanup EXIT
 docker run --rm \
@@ -33,4 +34,3 @@ docker run --rm \
     -v $PWD/demo:/api/src/userCLI/demo \
     --network=host \
     orderly-web-cli-build
-

--- a/buildkite/build-css-generator.sh
+++ b/buildkite/build-css-generator.sh
@@ -17,5 +17,19 @@ docker build \
         -f css.Dockerfile \
         .
 
+## ORDERLY_SERVER_VERSION can be set as an env var to build
+## orderly-web with a specific version of orderly.server. We
+## do this on triggered build to test how changes to
+## orderly.server will affect OW. If the orderly.server
+## version is not the default branch then use a
+## combined tag so that we never replace an existing tagged
+## image built off master with an image with a different
+## version of orderly installed
+ORDERLY_SERVER_VERSION="${ORDERLY_SERVER_VERSION:-master}"
+if [ "$ORDERLY_SERVER_VERSION" != "master" ]; then
+        COMMIT_TAG="$COMMIT_TAG-$ORDERLY_SERVER_VERSION"
+        BRANCH_TAG="$BRANCH_TAG-$ORDERLY_SERVER_VERSION"
+fi
+
 docker push $COMMIT_TAG
 docker push $BRANCH_TAG

--- a/buildkite/common
+++ b/buildkite/common
@@ -28,11 +28,15 @@ if [ -n "${ORDERLY_SERVER_VERSION-}" ]; then
     MONTAGU_ORDERLY_SERVER_VERSION=$ORDERLY_SERVER_VERSION
 else
     MONTAGU_ORDERLY_SERVER_VERSION=$(<$ROOT/config/orderly_server_version)
+    ## Set ORDERLY_SERVER_VERSION to empty string to avoid unbound variable
+    ## error from scripts with -u set
+    ORDERLY_SERVER_VERSION=""
 fi
 
 # Export env vars needed for running test dependencies
 export ORG=vimc
 export MONTAGU_ORDERLY_SERVER_VERSION=$MONTAGU_ORDERLY_SERVER_VERSION
+export ORDERLY_SERVER_VERSION=$ORDERLY_SERVER_VERSION
 export GIT_ID=$GIT_ID
 export GIT_BRANCH=$GIT_BRANCH
 export MONTAGU_ORDERLY_PATH=$PWD/git

--- a/buildkite/make-migrate-image.sh
+++ b/buildkite/make-migrate-image.sh
@@ -18,6 +18,19 @@ docker build \
 
 $here//make-db.sh
 
+## ORDERLY_SERVER_VERSION can be set as an env var to build
+## orderly-web with a specific version of orderly.server. We
+## do this on triggered build to test how changes to
+## orderly.server will affect OW. If the orderly.server
+## version is not the default branch then use a
+## combined tag so that we never replace an existing tagged
+## image built off master with an image with a different
+## version of orderly installed
+ORDERLY_SERVER_VERSION="${ORDERLY_SERVER_VERSION:-master}"
+if [ "$ORDERLY_SERVER_VERSION" != "master" ]; then
+       COMMIT_TAG="$COMMIT_TAG-$ORDERLY_SERVER_VERSION"
+       BRANCH_TAG="$BRANCH_TAG-$ORDERLY_SERVER_VERSION"
+fi
+
 docker push $COMMIT_TAG
 docker push $BRANCH_TAG
-

--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -4,11 +4,18 @@ ARG git_id='UNKNOWN'
 ARG git_branch='UNKNOWN'
 ARG registry=vimc
 ARG name=orderly-web-user-cli
+ARG orderly_server_branch
 
 ENV GIT_ID $git_id
 ENV APP_DOCKER_TAG $registry/$name
-ENV APP_DOCKER_COMMIT_TAG $registry/$name:$git_id
-ENV APP_DOCKER_BRANCH_TAG $registry/$name:$git_branch
+## If the orderly.server version is not the default branch
+## then use a combined tag so that we never replace an
+## existing tagged image built off master with an image
+## with a different version of orderly installed
+## ${orderly_server_branch:+-} expands to `-` if the var is set
+## and is an empty string otherwise
+ENV APP_DOCKER_COMMIT_TAG $registry/$name:$git_id${orderly_server_branch:+-}${orderly_server_branch}
+ENV APP_DOCKER_BRANCH_TAG $registry/$name:$git_branch${orderly_server_branch:+-}${orderly_server_branch}
 
 CMD ./gradlew :userCLI:test :userCLI:docker -i -Pdocker_version=$GIT_ID -Pdocker_name=$APP_DOCKER_TAG \
     && docker tag $APP_DOCKER_COMMIT_TAG $APP_DOCKER_BRANCH_TAG \

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -17,6 +17,7 @@ docker_auth_path=${1:-/opt/teamcity-agent/.docker/config.json}
 docker build --tag orderly-web-cli-build \
     --build-arg git_id=$GIT_ID \
     --build-arg git_branch=$GIT_BRANCH \
+    --build-arg orderly_server_branch=$ORDERLY_SERVER_VERSION \
     -f cli.Dockerfile \
     .
 
@@ -30,4 +31,3 @@ docker run --rm \
     -v $PWD/demo:/api/src/userCLI/demo \
     --network=host \
     orderly-web-cli-build
-


### PR DESCRIPTION
What I want to achieve here is when `ORDERLY_SERVER_VERSION` env var is set any pushed image has the existing tag $registry/$name:$tag-$ORDERLY_SERVER_VERSION so e.g. the branch tag for CLI becomes vimc/orderly-web-user-cli:mrc-123-awd763s. When `ORDERLY_SERVER_VERSION` is not set i.e. the build is using the default branch of orderly server then tags are unaffected.

This will allow us to trigger a build from orderly.server on a branch which will test orderly-web will work with that branch but won't overwrite any existing docker images on docker hub. We'll need this for https://github.com/vimc/orderly.server/pull/123