### PR TITLE
mrc-3664 introduced a first parameterized test

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ${ORDERLY_DEMO}:/orderly
     environment:
       REDIS_URL: redis://redis
+      ORDERLY_API_SERVER_IDENTITY: main
     depends_on:
       - "redis"
   api:

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -110,6 +110,7 @@ task compileFrontEnd() {
 
 ext.resetOrderlyDemo = {
     exec {
+        commandLine "echo", "'resetting demo'"
         commandLine "rm", "$projectDir/demo/*", "-rf"
         commandLine "rm", "$projectDir/demo/.git", "-rf"
         commandLine "tar", "xf", "$projectDir/demo.tar.gz"

--- a/src/app/build.gradle
+++ b/src/app/build.gradle
@@ -110,7 +110,6 @@ task compileFrontEnd() {
 
 ext.resetOrderlyDemo = {
     exec {
-        commandLine "echo", "'resetting demo'"
         commandLine "rm", "$projectDir/demo/*", "-rf"
         commandLine "rm", "$projectDir/demo/.git", "-rf"
         commandLine "tar", "xf", "$projectDir/demo.tar.gz"

--- a/src/app/orderly_demo/orderly_config.yml
+++ b/src/app/orderly_demo/orderly_config.yml
@@ -27,3 +27,11 @@ tags:
 
 global_resources:
   global
+
+remote:
+  main:
+    driver: "orderly::orderly_remote_path"
+    primary: false
+    default_branch_only: false
+    args:
+      path: "/orderly"

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
@@ -58,12 +58,11 @@ abstract class CustomConfigTests
 
         if (oldConfig.remote!!["main"]?.default_branch_only != defaultBranchOnly)
         {
-            // only reload if config has changed
             val newRemote = oldConfig.remote!!["main"]!!.copy(default_branch_only = defaultBranchOnly)
             val newConfig = oldConfig.copy(remote = linkedMapOf("main" to newRemote))
             configFile.writeText(mapper.writeValueAsString(newConfig))
-            HttpClient.post("http://localhost:8321/v1/reload/")
         }
+        HttpClient.post("http://localhost:8321/v1/reload/")
     }
 
     @BeforeEach

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/CustomConfigTests.kt
@@ -65,6 +65,10 @@ abstract class CustomConfigTests
         HttpClient.post("http://localhost:8321/v1/reload/")
     }
 
+
+    // We could probably do something fiddly with reflection to get the enum for parameterized tests
+    // here, but it would be fairly complicated, so for now just relying on the displayName which will
+    // contain the enum value
     @BeforeEach
     fun beforeEach(info: TestInfo)
     {

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/OrderlyConfig.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/OrderlyConfig.kt
@@ -1,0 +1,29 @@
+package org.vaccineimpact.orderlyweb.customConfigTests
+
+data class RemoteConfig(
+        val driver: String?,
+        val primary: Boolean?,
+        val default_branch_only: Boolean?,
+        val args: Any?
+)
+{
+    constructor() : this(null, null, null, null)
+}
+
+data class OrderlyConfig(
+        val database: Any?,
+        val fields: Any?,
+        val changelog: Any?,
+        val tags: Any?,
+        val global_resources: Any?,
+        val remote: LinkedHashMap<String, RemoteConfig>?
+)
+{
+    constructor() : this(null, null, null, null, null, null)
+}
+
+enum class ConfigType
+{
+    GIT_ALLOWED,
+    DEFAULT_BRANCH_ONLY
+}

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -55,12 +55,20 @@ class RunReportPageTests : SeleniumTest()
         assertThat(matches.size).isEqualTo(1)
     }
 
-    @Test
-    fun `can view git commits`()
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
+    fun `can view git commits`(configType: ConfigType)
     {
-        val commitsSelect = Select(driver.findElement(By.id("git-commit")))
-        assertThat(commitsSelect.options.size).isEqualTo(2)
-        assertThat(commitsSelect.options).allMatch { it.text.contains(Regex("[0-9a-f]{7}")) }
+        if (configType == ConfigType.GIT_ALLOWED)
+        {
+            val commitsSelect = Select(driver.findElement(By.id("git-commit")))
+            assertThat(commitsSelect.options.size).isEqualTo(2)
+            assertThat(commitsSelect.options).allMatch { it.text.contains(Regex("[0-9a-f]{7}")) }
+        }
+        else
+        {
+            assertThat(driver.findElements(By.id("git-commit"))).isEmpty()
+        }
     }
 
     @Test

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -65,7 +65,7 @@ class RunReportPageTests : SeleniumTest()
             val selectBranch = Select(tab.findElement(By.tagName("select")))
             assertThat(selectBranch.firstSelectedOption.text).isEqualTo("master")
             val commitsSelect = Select(driver.findElement(By.id("git-commit")))
-            assertThat(commitsSelect.options.size).isEqualTo(2)
+            assertThat(commitsSelect.options.size).isEqualTo(1)
             assertThat(commitsSelect.options).allMatch { it.text.contains(Regex("[0-9a-f]{7}")) }
         }
         else

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -57,7 +57,7 @@ class RunReportPageTests : SeleniumTest()
 
     @ParameterizedTest
     @EnumSource(ConfigType::class)
-    fun `can view git commits`(configType: ConfigType)
+    fun `can view git commits only when git allowed`(configType: ConfigType)
     {
         if (configType == ConfigType.GIT_ALLOWED)
         {

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -61,6 +61,9 @@ class RunReportPageTests : SeleniumTest()
     {
         if (configType == ConfigType.GIT_ALLOWED)
         {
+            val tab = driver.findElement(By.id("run-tab"))
+            val selectBranch = Select(tab.findElement(By.tagName("select")))
+            assertThat(selectBranch.firstSelectedOption.text).isEqualTo("master")
             val commitsSelect = Select(driver.findElement(By.id("git-commit")))
             assertThat(commitsSelect.options.size).isEqualTo(2)
             assertThat(commitsSelect.options).allMatch { it.text.contains(Regex("[0-9a-f]{7}")) }


### PR DESCRIPTION
This PR introduces parameterized tests as a way of running things against different orderly configs. If we like this pattern we can make most or all tests into parameterized tests; some will simply run multiple times, some will contain conditional assertions depending on the config type, as in this example.

~~Depends on https://github.com/vimc/orderly-web/pull/495~~