### PR TITLE
mrc-3916 make error reponse schema consistent with porcelain

### DIFF
--- a/buildkite/run-smoke-test.sh
+++ b/buildkite/run-smoke-test.sh
@@ -31,7 +31,7 @@ docker exec orderly-web touch /etc/orderly/web/go_signal
 sleep 3
 
  # Hit the index page and check it works
-response=$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8888/api/v1)
+response=$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8888/api/v2)
 
 if [[ $response -ne 200 ]]; then exit 1; fi;
 

--- a/docs/spec/Error.schema.json
+++ b/docs/spec/Error.schema.json
@@ -1,9 +1,9 @@
 {
     "id": "Error",
     "properties": {
-        "code": { "$ref": "ErrorCode.schema.json" },
-        "message": { "type": "string" }
+        "error": { "$ref": "ErrorCode.schema.json" },
+        "detail": { "type": "string" }
     },
     "additionalProperties": false,
-    "required": [ "code", "message" ]
+    "required": [ "error", "detail" ]
 }

--- a/docs/spec/Error.schema.json
+++ b/docs/spec/Error.schema.json
@@ -2,7 +2,7 @@
     "id": "Error",
     "properties": {
         "error": { "$ref": "ErrorCode.schema.json" },
-        "detail": { "type": "string" }
+        "detail": { "type": [ "string", "null" ] }
     },
     "additionalProperties": false,
     "required": [ "error", "detail" ]

--- a/docs/spec/Response.schema.json
+++ b/docs/spec/Response.schema.json
@@ -7,7 +7,7 @@
         },
         "data": {},
         "errors": {
-            "type": "array",
+            "type": [ "array", "null" ],
             "items": { "$ref": "Error.schema.json" }
         }
     },

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -14,7 +14,7 @@ export MONTAGU_ORDERLY_SERVER_VERSION=$(<$config_path/orderly_server_version)
 
 mkdir -p $OUTPACK_DEMO
 docker pull mrcide/outpack.orderly:mrc-3914
-docker run -v $ORDERLY_DEMO:/orderly:ro -v $OUTPACK_DEMO:/outpack --env USER_ID=$UID mrcide/outpack.orderly:mrc-3914 /orderly /outpack --once
+docker run -v $ORDERLY_DEMO:/orderly:ro -v $OUTPACK_DEMO:/outpack -u $UID mrcide/outpack.orderly:mrc-3914 /orderly /outpack --once
 
 COMPOSE_FILE=$here/../scripts/docker-compose.yml
 

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/ContentTypes.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/ContentTypes.kt
@@ -2,6 +2,7 @@ package org.vaccineimpact.orderlyweb
 
 object ContentTypes
 {
+    const val any = "*/*"
     const val csv = "text/csv"
     const val json = "application/json"
     const val binarydata = "application/octet-stream"

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/RouteConfig.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/RouteConfig.kt
@@ -26,6 +26,12 @@ object APIRouteConfig : RouteConfig
 
 object WebRouteConfig : RouteConfig
 {
+    private val legacyEndpoint = WebEndpoint(
+            "/api/v1/*/",
+            IndexController::class,
+            "legacy"
+    ).json().transform()
+
     private val metricsEndpoint = WebEndpoint(
             "/metrics/",
             IndexController::class,
@@ -35,16 +41,16 @@ object WebRouteConfig : RouteConfig
 
     private val accessibilityEndpoint = WebEndpoint(
             "/accessibility/",
-            IndexController:: class,
+            IndexController::class,
             "accessibility"
     )
 
     private val adminEndpoint = WebEndpoint(
             "/manage-access/",
-            AdminController:: class,
+            AdminController::class,
             "admin"
     )
-    .secure(setOf("*/users.manage"))
+            .secure(setOf("*/users.manage"))
 
     override val endpoints: List<EndpointDefinition> =
             WebAuthRouteConfig.endpoints +
@@ -57,5 +63,6 @@ object WebRouteConfig : RouteConfig
                     WebPermissionRouteConfig.endpoints +
                     WebRoleRouteConfig.endpoints +
                     WebSettingsRouteConfig.endpoints +
-                    WebGitRouteConfig.endpoints + metricsEndpoint + adminEndpoint + accessibilityEndpoint
+                    WebGitRouteConfig.endpoints + metricsEndpoint + adminEndpoint +
+                    accessibilityEndpoint + legacyEndpoint
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/Router.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/app_start/Router.kt
@@ -34,7 +34,7 @@ class Router(
 
     companion object
     {
-        const val apiUrlBase = "/api/v1"
+        const val apiUrlBase = "/api/v2"
     }
 
     init

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/BundleController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/BundleController.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.orderlyweb.controllers.api
 
 import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.OrderlyServerAPI
 import org.vaccineimpact.orderlyweb.OrderlyServerClient
 import org.vaccineimpact.orderlyweb.controllers.Controller
@@ -24,7 +25,7 @@ class BundleController(
     fun pack(): Boolean
     {
         val url = "/v1/bundle/pack/${context.params(":name")}"
-        val response = orderlyServerAPI.post(url, context, transformResponse = false)
+        val response = orderlyServerAPI.post(url, context, accept = ContentTypes.any)
         val servletResponse = context.getSparkResponse().raw()
         servletResponse.contentType = "application/zip" // TODO content type to be passed through after VIMC-4388
         servletResponse.outputStream.write(response.bytes)

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/OutpackController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/api/OutpackController.kt
@@ -1,6 +1,7 @@
 package org.vaccineimpact.orderlyweb.controllers.api
 
 import org.vaccineimpact.orderlyweb.ActionContext
+import org.vaccineimpact.orderlyweb.ContentTypes
 import org.vaccineimpact.orderlyweb.OutpackServerClient
 import org.vaccineimpact.orderlyweb.PorcelainAPI
 import org.vaccineimpact.orderlyweb.controllers.Controller
@@ -35,7 +36,7 @@ class OutpackController(
         val url = "/file/${context.params(":hash")}"
         val response = outpackServerClient
                 .throwOnError()
-                .get(url, context, transformResponse = false)
+                .get(url, context, accept = ContentTypes.any)
 
         val servletResponse = context.getSparkResponse().raw()
         response.headers.map { servletResponse.setHeader(it.first, it.second) }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/IndexController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/IndexController.kt
@@ -13,10 +13,10 @@ import org.vaccineimpact.orderlyweb.viewmodels.AccessibilityViewModel
 import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 
 class IndexController(
-    actionContext: ActionContext,
-    private val orderly: OrderlyClient,
-    private val reportRepository: ReportRepository,
-    private val tagRepository: TagRepository
+        actionContext: ActionContext,
+        private val orderly: OrderlyClient,
+        private val reportRepository: ReportRepository,
+        private val tagRepository: TagRepository
 ) : Controller(actionContext)
 {
     constructor(context: ActionContext) :
@@ -47,6 +47,9 @@ class IndexController(
 
     fun legacy(): String
     {
-        throw BadRequest("OrderlyWeb has been upgraded. Please update your R package to a version > 0.1.15. See https://github.com/vimc/orderlyweb/#installation")
+        throw BadRequest(
+                "OrderlyWeb has been upgraded. Please update your R package to a version > 0.1.15. " +
+                        "See https://github.com/vimc/orderlyweb/#installation"
+        )
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/IndexController.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/controllers/web/IndexController.kt
@@ -8,6 +8,7 @@ import org.vaccineimpact.orderlyweb.db.repositories.OrderlyReportRepository
 import org.vaccineimpact.orderlyweb.db.repositories.OrderlyWebTagRepository
 import org.vaccineimpact.orderlyweb.db.repositories.ReportRepository
 import org.vaccineimpact.orderlyweb.db.repositories.TagRepository
+import org.vaccineimpact.orderlyweb.errors.BadRequest
 import org.vaccineimpact.orderlyweb.viewmodels.AccessibilityViewModel
 import org.vaccineimpact.orderlyweb.viewmodels.IndexViewModel
 
@@ -42,5 +43,10 @@ class IndexController(
     fun metrics(): String
     {
         return "running 1"
+    }
+
+    fun legacy(): String
+    {
+        throw BadRequest("OrderlyWeb has been upgraded. Please update your R package to a version > 0.1.15. See https://github.com/vimc/orderlyweb/#installation")
     }
 }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/OrderlyWebError.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/errors/OrderlyWebError.kt
@@ -15,7 +15,7 @@ abstract class OrderlyWebError(
     {
         fun formatProblemsIntoMessage(problems: Iterable<org.vaccineimpact.orderlyweb.models.ErrorInfo>): String
         {
-            val joined = problems.map { it.message }.joinToString("\n")
+            val joined = problems.map { it.detail }.joinToString("\n")
             return "the following problems occurred:\n$joined"
         }
     }

--- a/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Result.kt
+++ b/src/app/src/main/kotlin/org/vaccineimpact/orderlyweb/models/Result.kt
@@ -11,7 +11,7 @@ enum class ResultStatus
     SUCCESS, FAILURE
 }
 
-data class ErrorInfo(val code: String, val message: String)
+data class ErrorInfo(val error: String, val detail: String)
 {
-    override fun toString(): String = message
+    override fun toString(): String = detail
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/APIRequestHelper.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/helpers/APIRequestHelper.kt
@@ -19,7 +19,7 @@ import org.vaccineimpact.orderlyweb.tests.insertUser
 
 class APIRequestHelper : RequestHelper()
 {
-    override val baseUrl: String = "http://localhost:${AppConfig()["app.port"]}/api/v1"
+    override val baseUrl: String = "http://localhost:${AppConfig()["app.port"]}/api/v2"
     val authRepo = OrderlyAuthorizationRepository()
     val userRepo = OrderlyUserRepository()
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/RoutingTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/RoutingTests.kt
@@ -2,9 +2,25 @@ package org.vaccineimpact.orderlyweb.tests.integration_tests.tests
 
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import org.vaccineimpact.orderlyweb.ContentTypes
+import org.vaccineimpact.orderlyweb.db.AppConfig
+import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
 
 class RoutingTests : IntegrationTest()
 {
+
+    @Test
+    fun `v1 endpoints return informative error message`()
+    {
+        val baseUrl = "http://localhost:${AppConfig()["app.port"]}/api/v1"
+        val response = HttpClient.get("$baseUrl/reports/", mapOf("Accept" to ContentTypes.json))
+        assertJsonContentType(response)
+        Assertions.assertThat(response.statusCode).isEqualTo(400)
+        JSONValidator.validateError(
+                response.text, "bad-request",
+                "OrderlyWeb has been upgraded. Please update your R package to a version > 0.1.15. See https://github.com/vimc/orderlyweb/#installation"
+        )
+    }
 
     @Test
     fun `can get url with or without trailing slash`()

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/MontaguAuthenticationTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/api/auth/MontaguAuthenticationTests.kt
@@ -17,7 +17,7 @@ class MontaguAuthenticationTests : IntegrationTest()
         assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(
                 result.text,
-                expectedErrorCode = "montagu-token-invalid",
+                expectedError = "montagu-token-invalid",
                 expectedErrorText = "Montagu token not supplied in Authorization header, or Montagu token was invalid"
         )
     }
@@ -29,7 +29,7 @@ class MontaguAuthenticationTests : IntegrationTest()
         assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(
                 result.text,
-                expectedErrorCode = "montagu-token-invalid",
+                expectedError = "montagu-token-invalid",
                 expectedErrorText = "Montagu token not supplied in Authorization header, or Montagu token was invalid"
         )
     }
@@ -41,7 +41,7 @@ class MontaguAuthenticationTests : IntegrationTest()
         assertThat(result.statusCode).isEqualTo(401)
         JSONValidator.validateError(
                 result.text,
-                expectedErrorCode = "montagu-token-invalid",
+                expectedError = "montagu-token-invalid",
                 expectedErrorText = "Montagu token not supplied in Authorization header, or Montagu token was invalid"
         )
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/SettingsTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/SettingsTests.kt
@@ -55,7 +55,7 @@ class SettingsTests : IntegrationTest()
 
         assertThat(response.statusCode).isEqualTo(400)
         val json = JsonLoader.fromString(response.text)
-        AssertionsForClassTypes.assertThat(json["errors"][0]["code"].asText())
+        AssertionsForClassTypes.assertThat(json["errors"][0]["error"].asText())
                 .isEqualTo("invalid-operation-error")
 
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/integration_tests/tests/web/WorkflowRunTests.kt
@@ -424,12 +424,12 @@ class WorkflowRunTests : IntegrationTest()
         assertThat(response.statusCode).isEqualTo(400)
         val errors = JsonLoader.fromString(response.text)["errors"] as ArrayNode
         assertThat(errors.count()).isEqualTo(3)
-        assertThat(errors[0]["message"].asText()).isEqualTo("Row 4: row should contain 2 values, 3 values found")
-        assertThat(errors[0]["code"].asText()).isEqualTo("bad-request")
-        assertThat(errors[1]["message"].asText()).isEqualTo("Row 3, column 2: required parameter 'nmin' was not provided for report 'other'")
-        assertThat(errors[1]["code"].asText()).isEqualTo("bad-request")
-        assertThat(errors[2]["message"].asText()).isEqualTo("Row 5, column 1: report 'nonexistent' not found in Orderly")
-        assertThat(errors[2]["code"].asText()).isEqualTo("bad-request")
+        assertThat(errors[0]["detail"].asText()).isEqualTo("Row 4: row should contain 2 values, 3 values found")
+        assertThat(errors[0]["error"].asText()).isEqualTo("bad-request")
+        assertThat(errors[1]["detail"].asText()).isEqualTo("Row 3, column 2: required parameter 'nmin' was not provided for report 'other'")
+        assertThat(errors[1]["error"].asText()).isEqualTo("bad-request")
+        assertThat(errors[2]["detail"].asText()).isEqualTo("Row 5, column 1: report 'nonexistent' not found in Orderly")
+        assertThat(errors[2]["error"].asText()).isEqualTo("bad-request")
     }
 
     @Test
@@ -454,8 +454,8 @@ class WorkflowRunTests : IntegrationTest()
         assertThat(response.statusCode).isEqualTo(400)
         val errors = JsonLoader.fromString(response.text)["errors"] as ArrayNode
         assertThat(errors.count()).isEqualTo(1)
-        assertThat(errors[0]["message"].asText()).isEqualTo("File contains no rows")
-        assertThat(errors[0]["code"].asText()).isEqualTo("bad-request")
+        assertThat(errors[0]["detail"].asText()).isEqualTo("File contains no rows")
+        assertThat(errors[0]["error"].asText()).isEqualTo("bad-request")
     }
 
     @Test
@@ -473,8 +473,8 @@ class WorkflowRunTests : IntegrationTest()
         assertThat(response.statusCode).isEqualTo(400)
         val errors = JsonLoader.fromString(response.text)["errors"] as ArrayNode
         assertThat(errors.count()).isEqualTo(1)
-        assertThat(errors[0]["message"].asText()).isEqualTo("No data provided")
-        assertThat(errors[0]["code"].asText()).isEqualTo("bad-request")
+        assertThat(errors[0]["detail"].asText()).isEqualTo("No data provided")
+        assertThat(errors[0]["error"].asText()).isEqualTo("bad-request")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/security/clients/JWTCookieClientTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/security/clients/JWTCookieClientTests.kt
@@ -34,8 +34,8 @@ class JWTCookieClientTests
     {
         val sut = JWTCookieClient(mockTokenVerifier)
         val errorInfo = sut.errorInfo
-        assertThat(errorInfo.code).isEqualTo("cookie-bearer-token-invalid")
-        assertThat(errorInfo.message).isEqualTo("Bearer token not supplied in cookie 'orderlyweb_jwt_token', or bearer token was invalid")
+        assertThat(errorInfo.error).isEqualTo("cookie-bearer-token-invalid")
+        assertThat(errorInfo.detail).isEqualTo("Bearer token not supplied in cookie 'orderlyweb_jwt_token', or bearer token was invalid")
     }
 
 }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/app_start/ErrorHandlerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/app_start/ErrorHandlerTests.kt
@@ -23,7 +23,7 @@ class ErrorHandlerTests
     private val mockResponse = mock<Response>()
 
     private val mockApiRequest = mock<Request> {
-        on { this.pathInfo() } doReturn "/api/v1/test/"
+        on { this.pathInfo() } doReturn "/api/v2/test/"
         on { this.headers("Accept") } doReturn "anything"
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/BundleControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/BundleControllerTests.kt
@@ -101,7 +101,7 @@ class BundleControllerTests : ControllerTest()
         }
         val httpClient = getHttpClient("/v1/bundle/import", """{"status":"success","errors":null,"data":true}""".toByteArray())
         val controller = BundleController(context, config, OrderlyServerClient(config, httpClient))
-        assertThat(controller.import()).isEqualTo("""{"data":true,"errors":[],"status":"success"}""")
+        assertThat(controller.import()).isEqualTo("""{"status":"success","errors":null,"data":true}""")
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/api/ReportRunControllerTests.kt
@@ -26,23 +26,24 @@ class ReportRunControllerTests : ControllerTest()
         val params = mapOf("param" to "p1")
         val changelog = mapOf(
                 "message" to "test message",
-                "type" to "test type")
+                "type" to "test type"
+        )
 
         val actionContext: ActionContext = mock {
             on { params(":name") } doReturn reportName
             on { postData<Any>() } doReturn mapOf(
-                "instances" to mapOf("instance" to "i1"),
-                "params" to params,
-                "changelog" to changelog,
-                "gitBranch" to "branch1",
-                "gitCommit" to "abc123"
+                    "instances" to mapOf("instance" to "i1"),
+                    "params" to params,
+                    "changelog" to changelog,
+                    "gitBranch" to "branch1",
+                    "gitCommit" to "abc123"
             )
             on { queryParams("timeout") } doReturn "600"
             on { userProfile } doReturn CommonProfile().apply { id = "a@b.com" }
         }
 
         val mockAPIResponseText =
-            """{"data": {"name": "$reportName", "key": $reportKey, "path": "/status/$reportKey"}}"""
+                """{"data": {"name": "$reportName", "key": $reportKey, "path": "/status/$reportKey"}}"""
 
         val mockAPIResponse = PorcelainResponse(mockAPIResponseText, 200, Headers.headersOf())
 
@@ -52,13 +53,21 @@ class ReportRunControllerTests : ControllerTest()
                 "timeout" to "600"
         )
         val apiClient: OrderlyServerAPI = mock {
-            on { post(
-                    eq("/v1/reports/$reportName/run/"),
-                    eq(Gson().toJson(mapOf(
-                            "params" to params,
-                            "changelog" to changelog
-                    ))),
-                    eq(expectedQs)) } doReturn mockAPIResponse
+            on {
+                post(
+                        eq("/v1/reports/$reportName/run/"),
+                        eq(
+                                Gson().toJson(
+                                        mapOf(
+                                                "params" to params,
+                                                "changelog" to changelog
+                                        )
+                                )
+                        ),
+                        eq(expectedQs),
+                        any()
+                )
+            } doReturn mockAPIResponse
         }
 
         val mockReportRunRepo: ReportRunRepository = mock()
@@ -69,14 +78,14 @@ class ReportRunControllerTests : ControllerTest()
         assertThat(result).isEqualTo(mockAPIResponseText)
 
         verify(mockReportRunRepo).addReportRun(
-            eq(reportKey),
-            eq("a@b.com"),
-            any<Instant>(),
-            eq(reportName),
-            eq(mapOf("instance" to "i1")),
-            eq(params),
-            eq("branch1"),
-            eq("abc123")
+                eq(reportKey),
+                eq("a@b.com"),
+                any<Instant>(),
+                eq(reportName),
+                eq(mapOf("instance" to "i1")),
+                eq(params),
+                eq("branch1"),
+                eq("abc123")
         )
     }
 
@@ -89,7 +98,7 @@ class ReportRunControllerTests : ControllerTest()
         }
 
         val mockAPIResponseText =
-            """{"data": {"name": "$reportName", "key": $reportKey, "path": "/status/$reportKey"}}"""
+                """{"data": {"name": "$reportName", "key": $reportKey, "path": "/status/$reportKey"}}"""
 
         val mockAPIResponse = PorcelainResponse(mockAPIResponseText, 200, Headers.headersOf())
 
@@ -105,14 +114,14 @@ class ReportRunControllerTests : ControllerTest()
 
         assertThat(result).isEqualTo(mockAPIResponseText)
         verify(mockReportRunRepo).addReportRun(
-            eq(reportKey),
-            eq("a@b.com"),
-            any<Instant>(),
-            eq(reportName),
-            eq(mapOf()),
-            eq(mapOf()),
-            eq(null),
-            eq(null)
+                eq(reportKey),
+                eq("a@b.com"),
+                any<Instant>(),
+                eq(reportName),
+                eq(mapOf()),
+                eq(mapOf()),
+                eq(null),
+                eq(null)
         )
     }
 
@@ -126,7 +135,7 @@ class ReportRunControllerTests : ControllerTest()
         val url = "/v1/reports/$reportName/run/"
         val expectedBody = "{\"params\":{}}"
         val apiClient: OrderlyServerAPI = mock {
-            on { post(url, expectedBody, mapOf()) } doThrow PorcelainError(url, 500,"Orderly server")
+            on { post(url, expectedBody, mapOf()) } doThrow PorcelainError(url, 500, "Orderly server")
         }
 
         val mockReportRunRepo: ReportRunRepository = mock()
@@ -134,8 +143,8 @@ class ReportRunControllerTests : ControllerTest()
         val sut = ReportRunController(actionContext, mockReportRunRepo, apiClient, mock())
 
         assertThatThrownBy { sut.run() }
-            .isInstanceOf(PorcelainError::class.java)
-            .matches { (it as PorcelainError).httpStatus == 500 }
+                .isInstanceOf(PorcelainError::class.java)
+                .matches { (it as PorcelainError).httpStatus == 500 }
         verifyZeroInteractions(mockReportRunRepo)
     }
 

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/GitControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/GitControllerTests.kt
@@ -63,7 +63,7 @@ class GitControllerTests : ControllerTest()
 
         assertThat(response).isEqualTo(Serializer.instance.toResult("fetchResponse"))
         verify(mockContext2).setStatusCode(500)
-        verify(mockOrderlyServerAPI, times(0)).get(any(), context = any(), transformResponse = any())
+        verify(mockOrderlyServerAPI, times(0)).get(any(), context = any(), accept = eq("*/*"))
     }
 
     @Test

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/ReportRunControllerTests.kt
@@ -95,7 +95,7 @@ class ReportRunControllerTests
 
         val mockPorcelainResponse = PorcelainResponse(Serializer.instance.toResult(testReportStatus), 200, Headers.headersOf())
         val mockAPI = mock<OrderlyServerAPI>{
-            on { this.get(eq("/v1/reports/testReportKey/status/"), any<Map<String, String>>()) } doReturn mockPorcelainResponse
+            on { this.get(eq("/v1/reports/testReportKey/status/"), any<Map<String, String>>(), any()) } doReturn mockPorcelainResponse
         }
 
         val sut = ReportRunController(context, mockReportRepo, mockWorkflowRepo, mockAPI)
@@ -129,7 +129,7 @@ class ReportRunControllerTests
         verify(mockWorkflowRepo, never()).checkReportIsInWorkflow(any(), any())
         verify(mockReportRepo, never()).updateReportRun(any(), any(), any(), any(), any())
         verify(mockReportRepo, times(1)).getReportRun("testReportKey")
-        verify(mockAPI, never()).get(any(), any<Map<String,String>>())
+        verify(mockAPI, never()).get(any(), any<Map<String,String>>(), any())
         assertThat(result).isSameAs(testReportRunLogFinished)
     }
 
@@ -147,7 +147,7 @@ class ReportRunControllerTests
 
         val mockPorcelainResponse = PorcelainResponse(Serializer.instance.toResult(testReportStatus), 200, Headers.headersOf())
         val mockAPI = mock<OrderlyServerAPI>{
-            on { this.get(eq("/v1/reports/testReportKey/status/"), any<Map<String, String>>()) } doReturn mockPorcelainResponse
+            on { this.get(eq("/v1/reports/testReportKey/status/"), any<Map<String, String>>(), any()) } doReturn mockPorcelainResponse
         }
 
         val sut = ReportRunController(context, mock(), mockWorkflowRepo, mockAPI)
@@ -178,7 +178,7 @@ class ReportRunControllerTests
 
         verify(mockWorkflowRepo).checkReportIsInWorkflow("testReportKey", "testWorkflow")
         verify(mockWorkflowRepo, never()).updateReportRun(any(), any(), any(), any(), any())
-        verify(mockAPI, never()).get(any(), any<Map<String,String>>())
+        verify(mockAPI, never()).get(any(), any<Map<String,String>>(), any())
         verify(mockWorkflowRepo, times(1)).getReportRun("testReportKey")
         assertThat(result).isSameAs(testReportRunLogFinished)
     }

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/controllers/web/WorkflowRunControllerTests.kt
@@ -93,7 +93,7 @@ class WorkflowRunControllerTests
         val mockAPIResponse = PorcelainResponse(Serializer.instance.gson.toJson(mockSummary), 200, Headers.headersOf())
 
         val apiClient = mock<OrderlyServerAPI> {
-            on { post(eq("/v1/workflow/summary/"), eq(requestBody), eq(emptyMap())) } doReturn mockAPIResponse
+            on { post(eq("/v1/workflow/summary/"), eq(requestBody), eq(emptyMap()), any()) } doReturn mockAPIResponse
             on { getReportParameters(eq("r1"), eq(mapOf("commit" to "1234"))) } doReturn listOf(
                     Parameter("nmin", "100"),
                     Parameter("disease", "YF")
@@ -150,7 +150,7 @@ class WorkflowRunControllerTests
         val mockAPIResponse = PorcelainResponse(Serializer.instance.gson.toJson(mockSummary), 200, Headers.headersOf())
 
         val apiClient = mock<OrderlyServerAPI> {
-            on { post(eq("/v1/workflow/summary/"), eq(requestBody), eq(emptyMap())) } doReturn mockAPIResponse
+            on { post(eq("/v1/workflow/summary/"), eq(requestBody), eq(emptyMap()), any()) } doReturn mockAPIResponse
             on { getReportParameters(eq("r1"), eq(mapOf())) } doReturn listOf(
                     Parameter("nmin", "100"),
                     Parameter("disease", "YF")
@@ -297,7 +297,7 @@ class WorkflowRunControllerTests
         val mockAPIResponse = PorcelainResponse(mockAPIResponseText, 200, Headers.headersOf())
 
         val apiClient = mock<OrderlyServerAPI> {
-            on { post(any(), any<String>(), any()) } doReturn mockAPIResponse
+            on { post(any(), any<String>(), any(), any()) } doReturn mockAPIResponse
         }
 
         val repo = mock<WorkflowRunRepository>()
@@ -422,7 +422,7 @@ class WorkflowRunControllerTests
         val mockResponse = """{"status": "failure", "data": null, "errors": []}"""
 
         val apiClient = mock<OrderlyServerAPI> {
-            on { post(any(), any<String>(), any()) } doReturn PorcelainResponse(
+            on { post(any(), any<String>(), any(), any()) } doReturn PorcelainResponse(
                     mockResponse,
                     400,
                     Headers.headersOf()
@@ -453,7 +453,7 @@ class WorkflowRunControllerTests
         }
 
         val apiClient = mock<OrderlyServerAPI> {
-            on { post(any(), any<String>(), any()) } doReturn PorcelainResponse(
+            on { post(any(), any<String>(), any(), any()) } doReturn PorcelainResponse(
                     """{"data": {"workflow_key": "workflow_key1",
                         | "reports": [{"key": "report_key1", "execution_order": 1,
                         |  "name": "report1", "params": {"key": "value"}}]}}""".trimMargin(),
@@ -543,7 +543,7 @@ class WorkflowRunControllerTests
         """.trimIndent()
         val mockAPIResponse = PorcelainResponse(mockAPIResponseText, 200, Headers.headersOf())
         val apiClient = mock<OrderlyServerAPI> {
-            on { get(any(), any<Map<String, String>>()) } doReturn mockAPIResponse
+            on { get(any(), any<Map<String, String>>(), any()) } doReturn mockAPIResponse
         }
         val apiClientWithError = mock<OrderlyServerAPI> {
             on { throwOnError() } doReturn apiClient
@@ -644,7 +644,7 @@ class WorkflowRunControllerTests
         """.trimIndent()
         val mockAPIResponse = PorcelainResponse(mockAPIResponseText, 200, Headers.headersOf())
         val apiClient = mock<OrderlyServerAPI> {
-            on { get(any(), any<Map<String, String>>()) } doReturn mockAPIResponse
+            on { get(any(), any<Map<String, String>>(), any()) } doReturn mockAPIResponse
         }
         val apiClientWithError = mock<OrderlyServerAPI> {
             on { throwOnError() } doReturn apiClient
@@ -690,7 +690,7 @@ class WorkflowRunControllerTests
             on { userProfile } doReturn CommonProfile().apply { id = "test@user.com" }
         }
         val apiClient = mock<OrderlyServerAPI> {
-            on { get(any(), any<Map<String, String>>()) } doThrow PorcelainError("", 400, "Orderly server")
+            on { get(any(), any<Map<String, String>>(), any()) } doThrow PorcelainError("", 400, "Orderly server")
         }
         val apiClientWithError = mock<OrderlyServerAPI> {
             on { throwOnError() } doReturn apiClient

--- a/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/errors/OrderlyWebErrorTests.kt
+++ b/src/app/src/test/kotlin/org/vaccineimpact/orderlyweb/tests/unit_tests/errors/OrderlyWebErrorTests.kt
@@ -81,6 +81,6 @@ class OrderlyWebErrorTests
         val result = sut.asResult()
         assertThat(result.status).isEqualTo(ResultStatus.FAILURE)
         assertThat(result.errors.count()).isEqualTo(1)
-        assertThat(result.errors[0].code).isEqualTo(expectedResultCode)
+        assertThat(result.errors[0].error).isEqualTo(expectedResultCode)
     }
 }

--- a/src/app/static/src/js/components/errorInfo.vue
+++ b/src/app/static/src/js/components/errorInfo.vue
@@ -24,7 +24,7 @@
                 response.data &&
                 response.data.errors &&
                 response.data.errors[0] &&
-                response.data.errors[0].message
+                response.data.errors[0].detail
         }
     })
 </script>

--- a/src/app/static/src/js/components/runWorkflow/runWorkflow.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflow.vue
@@ -18,7 +18,7 @@
             <a href="#" @click.prevent="$emit('view-progress', createdWorkflowKey)">View workflow progress</a>
         </div>
         <div class="pt-4 col-sm-6">
-            <error-info :default-message="defaultMessage" :api-error="error"></error-info>
+            <error-info default-message="An error occurred while running the workflow" :api-error="error"></error-info>
         </div>
     </div>
 </template>
@@ -123,7 +123,6 @@
                     })
                     .catch((error) => {
                         this.error = error;
-                        this.defaultMessage = "An error occurred while running the workflow";
                     });
             },
             updateRunWorkflowMetadata: function (update) {

--- a/src/app/static/src/js/components/storeErrorInfo.vue
+++ b/src/app/static/src/js/components/storeErrorInfo.vue
@@ -22,7 +22,7 @@
         },
         computed: {
             message: function () {
-                return this.error.message ? this.error.message : this.error.code
+                return this.error.detail ? this.error.detail : this.error.error
             }
         }
     });

--- a/src/app/static/src/js/utils/apiService.ts
+++ b/src/app/static/src/js/utils/apiService.ts
@@ -92,8 +92,8 @@ export class ApiService<S extends string, T extends string> implements API<S, T>
 
     private static createError() {
         return {
-            code: "MALFORMED_RESPONSE",
-            message: "Could not parse API response. Please contact support."
+            error: "MALFORMED_RESPONSE",
+            detail: "Could not parse API response. Please contact support."
         }
     }
 

--- a/src/app/static/src/js/utils/types.ts
+++ b/src/app/static/src/js/utils/types.ts
@@ -172,8 +172,8 @@ export interface PayloadWithType<T> extends Payload {
 }
 
 export interface Error {
-    code: string;
-    message: string | null;
+    error: string;
+    detail: string | null;
 }
 
 export interface Response {

--- a/src/app/static/src/tests/components/errorInfo.test.js
+++ b/src/app/static/src/tests/components/errorInfo.test.js
@@ -8,7 +8,7 @@ describe("errorInfo", () => {
         const wrapper = mount(ErrorInfo, {
             propsData: {
                 apiError: {
-                    response: {data: {"errors": [{"message": "test error message"}]}}
+                    response: {data: {"errors": [{"detail": "test error message"}]}}
                 },
                 defaultMessage: "test default"
             }

--- a/src/app/static/src/tests/components/storeErrorInfo.test.ts
+++ b/src/app/static/src/tests/components/storeErrorInfo.test.ts
@@ -1,7 +1,7 @@
 import {shallowMount} from "@vue/test-utils";
 import StoreErrorInfo from "../../js/components/storeErrorInfo.vue"
 
-const errorMessage =  {code: "Error", message: "Error Alert"}
+const errorMessage = {error: "Error", detail: "Error Alert"}
 
 function getWrapper(error = errorMessage) {
     return shallowMount(StoreErrorInfo, {
@@ -21,7 +21,7 @@ describe("vuex StoreErrorInfo", () => {
     });
 
     it("renders code value if message is not given", async () => {
-        const errorMsg = {code: "Error", message: null}
+        const errorMsg = {error: "Error", detail: null}
         const wrapper = getWrapper(errorMsg)
 
         expect(wrapper.find(".error-message").text()).toBe("Error");

--- a/src/app/static/src/tests/components/vuex/runReport/reportList.test.ts
+++ b/src/app/static/src/tests/components/vuex/runReport/reportList.test.ts
@@ -67,8 +67,8 @@ describe("vuex reportList", () => {
 
     it("renders error Alert correctly", async () => {
         const error = {
-            code: "ERROR",
-            message: "ERROR MSG"
+            error: "ERROR",
+            detail: "ERROR MSG"
         }
 
         const store = createStore({reportsError: error})

--- a/src/app/static/src/tests/mocks.ts
+++ b/src/app/static/src/tests/mocks.ts
@@ -119,7 +119,7 @@ export const mockFailure = (errorMsg: any) => {
     return {
         data: {},
         status: "failure",
-        errors: [{code: "ERROR", message: errorMsg}]
+        errors: [{error: "ERROR", detail: errorMsg}]
     }
 }
 

--- a/src/app/static/src/tests/store/errors/mutations.test.ts
+++ b/src/app/static/src/tests/store/errors/mutations.test.ts
@@ -3,7 +3,7 @@ import {ErrorsMutation, mutations} from "../../../js/store/errors/mutations";
 
 describe("errors mutations", () => {
 
-    const error = [{code: "ERROR", message: "TEST ERROR"}]
+    const error = [{error: "ERROR", detail: "TEST ERROR"}]
     const state = mockErrorState({errors: error})
 
     it("can set errors", () => {

--- a/src/app/static/src/tests/store/reports/actions.test.ts
+++ b/src/app/static/src/tests/store/reports/actions.test.ts
@@ -56,8 +56,8 @@ describe("vuex reportList action", () => {
         expect(commit.mock.calls[0][0]).toStrictEqual({
             type: ReportsMutation.SetReportsError,
             payload: {
-                code: "ERROR",
-                message: "Test Error"
+                error: "ERROR",
+                detail: "Test Error"
             }
         })
     })

--- a/src/app/static/src/tests/utils/apiService.test.ts
+++ b/src/app/static/src/tests/utils/apiService.test.ts
@@ -36,7 +36,7 @@ describe("ApiService", () => {
             .get("/reports");
 
         expect(committedType).toBe("TEST_TYPE");
-        expect(committedPayload["message"]).toBe("some error");
+        expect(committedPayload["detail"]).toBe("some error");
     });
 
     it("throws could not parse error if API response errors are empty", async () => {
@@ -163,8 +163,8 @@ async function expectCouldNotParseAPIResponseError() {
     expect(commit.mock.calls[0][0]).toStrictEqual({
         type: `errors/ErrorAdded`,
         payload: {
-            code: "MALFORMED_RESPONSE",
-            message: "Could not parse API response. Please contact support."
+            error: "MALFORMED_RESPONSE",
+            detail: "Could not parse API response. Please contact support."
         }
     });
     expect(commit.mock.calls[0][1]).toStrictEqual({root: true});

--- a/src/app/templates/500.ftl
+++ b/src/app/templates/500.ftl
@@ -3,7 +3,7 @@
     <h1>Something went wrong</h1>
    <ul>
     <#list errors as error>
-        <li>${error.message}</li>
+        <li>${error.detail}</li>
     </#list>
    </ul>
 </@layout>

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/FineGrainedPermissionTests.kt
@@ -12,7 +12,7 @@ import org.vaccineimpact.orderlyweb.test_helpers.http.HttpClient
 @ExtendWith(DebugHelper::class)
 class FineGrainedPermissionTests : CustomConfigTests()
 {
-    val apiBaseUrl: String = "http://localhost:${AppConfig()["app.port"]}/api/v1"
+    val apiBaseUrl: String = "http://localhost:${AppConfig()["app.port"]}/api/v2"
     val url = "$apiBaseUrl/login/"
 
     @Test

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubAuthenticationTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/GithubAuthenticationTests.kt
@@ -141,7 +141,7 @@ class GithubAuthenticationTests : CustomConfigTests()
             assertThat(result.statusCode).isEqualTo(401)
             JSONValidator.validateError(
                     result.text,
-                    expectedErrorCode = "github-token-invalid",
+                    expectedError = "github-token-invalid",
                     expectedErrorText = "GitHub token not supplied in Authorization header, or GitHub token was invalid"
             )
         }

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RequestHelper.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RequestHelper.kt
@@ -13,7 +13,7 @@ class RequestHelper
 {
     companion object
     {
-        val apiBaseUrl: String = "http://localhost:${AppConfig()["app.port"]}/api/v1"
+        val apiBaseUrl: String = "http://localhost:${AppConfig()["app.port"]}/api/v2"
         val webBaseUrl: String = "http://localhost:${AppConfig()["app.port"]}"
     }
 

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
@@ -159,7 +159,8 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(driver.findElements(By.id("workflow-report-0")).isEmpty()).isTrue()
         assertThat(driver.findElement(By.cssSelector(".alert")).text).contains(
                 "The following items are not present in this git commit and have been removed from the workflow:\n" +
-                "Report 'other'")
+                        "Report 'other'"
+        )
     }
 
     @Test
@@ -294,14 +295,14 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(table.text).contains("Reports")
         val rows = driver.findElements(By.cssSelector("#workflow-table tr"))
         assertThat(rows.count()).isEqualTo(3)
-        val minimalRow = rows.find{ it.text.startsWith("minimal") }!!
+        val minimalRow = rows.find { it.text.startsWith("minimal") }!!
         val minimalRowStatus = minimalRow.findElement(By.cssSelector("td:nth-child(2)"))
         assertThat(minimalRowStatus.text).isIn(listOf("Queued", "Running"))
-        val globalRow = rows.find{ it.text.startsWith("global") }!!
+        val globalRow = rows.find { it.text.startsWith("global") }!!
         val globalRowStatus = globalRow.findElement(By.cssSelector("td:nth-child(2)"))
         assertThat(globalRowStatus.text).isIn(listOf("Queued", "Running"))
-        wait.until(ExpectedConditions.textToBePresentInElement(minimalRowStatus,"Complete"))
-        wait.until(ExpectedConditions.textToBePresentInElement(globalRow,"Complete"))
+        wait.until(ExpectedConditions.textToBePresentInElement(minimalRowStatus, "Complete"))
+        wait.until(ExpectedConditions.textToBePresentInElement(globalRow, "Complete"))
 
         // view report log
         val viewLogLink = minimalRow.findElement(By.cssSelector("a.report-log-link"))
@@ -419,7 +420,7 @@ class RunWorkflowTests : SeleniumTest()
 
         val backButton = driver.findElement(By.id("previous-workflow"))
         backButton.click()
-        
+
         wait.until(ExpectedConditions.presenceOfElementLocated(By.id("workflow-report-1")))
         val removeReportBtns = driver.findElements(By.cssSelector(".remove-report-button"))
         removeReportBtns[1].click()
@@ -473,8 +474,8 @@ class RunWorkflowTests : SeleniumTest()
         wait.until(ExpectedConditions.visibilityOf(collapsedParams))
         assertThat(showDefault.text).isEqualTo("Hide defaults...")
 
-        assertThat(defaultParams.findElement(By.id("default-params-collapse-0-0")).getAttribute("innerHTML")).isEqualTo("disease: HepB")
-        assertThat(defaultParams.findElement(By.id("default-params-collapse-0-1")).getAttribute("innerHTML")).isEqualTo("nmin: 0.5")
+        assertThat(defaultParams.findElements(By.className("default-params-collapse")).map { it.getAttribute("innerHTML") })
+                .contains("disease: HepB", "nmin: 0.5")
 
         showDefault.click()
         wait.until(ExpectedConditions.invisibilityOf(collapsedParams))
@@ -535,8 +536,9 @@ class RunWorkflowTests : SeleniumTest()
         wait.until(ExpectedConditions.visibilityOf(collapsedParams))
         assertThat(showDefault.text).isEqualTo("Hide defaults...")
 
-        assertThat(defaultParams.findElements(By.className("default-params-collapse"))[0].getAttribute("innerHTML")).isEqualTo("disease: HepB")
-        assertThat(defaultParams.findElements(By.className("default-params-collapse"))[1].getAttribute("innerHTML")).isEqualTo("nmin: 0.5")
+        assertThat(defaultParams.findElements(By.className("default-params-collapse"))
+                .map { it.getAttribute("innerHTML") })
+                .contains("disease: HepB", "nmin: 0.5")
 
         showDefault.click()
         wait.until(ExpectedConditions.invisibilityOf(collapsedParams))

--- a/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/JSONValidator.kt
+++ b/src/testHelpers/src/main/kotlin/org/vaccineimpact/orderlyweb/test_helpers/JSONValidator.kt
@@ -42,21 +42,21 @@ class JSONValidator
     }
 
     fun validateError(response: String,
-                      expectedErrorCode: String?,
+                      expectedError: String?,
                       expectedErrorText: String?)
     {
         val json = parseJson(response)
         checkResultSchema(json, "failure")
-        if (expectedErrorCode != null)
+        if (expectedError != null)
         {
-            val error = json["errors"].singleOrNull { it["code"].asText() == expectedErrorCode }
+            val error = json["errors"].singleOrNull { it["error"].asText() == expectedError }
             if (error != null)
             {
-                assertThat(error["message"].asText()).contains(expectedErrorText)
+                assertThat(error["detail"].asText()).contains(expectedErrorText)
             }
             else
             {
-                fail("Expected error code '$expectedErrorCode' to be present in $response")
+                fail("Expected error '$expectedError' to be present in $response")
             }
         }
     }
@@ -64,7 +64,7 @@ class JSONValidator
     fun validateMultipleAuthErrors(response: String)
     {
         validateError(response,
-                expectedErrorCode = "bearer-token-invalid",
+                expectedError = "bearer-token-invalid",
                 expectedErrorText = "Bearer token not supplied in Authorization header, or bearer token was invalid")
     }
 


### PR DESCRIPTION
* Updates the response schema to match [porcelain]<https://github.com/reside-ic/porcelain/tree/master/inst/schema> 
* Updates the `PorcelainAPIClient` class to no longer de/re-serialize responses. This includes removing the `transformResponse` argument and replacing it with an `accept` argument to accommodate the non-json endpoints (previously we were using `transformResponse = false` to infer that an endpoint was not json.)
* Updates the API prefix to `v2`. 

Before we merge this we should get have all the following approved so we can merge and deploy them all together. These are all now ready for review as well (sorry!):

* https://github.com/vimc/orderlyweb/pull/20
* https://github.com/vimc/orderly-web-py/pull/13
* https://github.com/vimc/montagu-task-queue/pull/32
* https://github.com/vimc/montagu-api/pull/477
* https://github.com/vimc/montagu/pull/228