### PR TITLE
mrc-3934 make end-to-end report running tests run against different orderly configs

### DIFF
--- a/src/app/static/src/js/components/runWorkflow/runWorkflow.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflow.vue
@@ -18,7 +18,7 @@
             <a href="#" @click.prevent="$emit('view-progress', createdWorkflowKey)">View workflow progress</a>
         </div>
         <div class="pt-4 col-sm-6">
-            <error-info :default-message="defaultMessage" :api-error="error"></error-info>
+            <error-info default-message="An error occurred while running the workflow" :api-error="error"></error-info>
         </div>
     </div>
 </template>
@@ -123,7 +123,6 @@
                     })
                     .catch((error) => {
                         this.error = error;
-                        this.defaultMessage = "An error occurred while running the workflow";
                     });
             },
             updateRunWorkflowMetadata: function (update) {

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowReport.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowReport.vue
@@ -18,7 +18,7 @@
         </h2>
         <div v-if="isReady">
             <div class="pb-4">
-                <h3 id="git-header">
+                <h3 id="git-header" v-if="runReportMetadata && runReportMetadata.git_supported">
                     Git
                 </h3>
                 <div>

--- a/src/app/static/src/js/components/runWorkflow/workflowSummary/runWorkflowSummary.vue
+++ b/src/app/static/src/js/components/runWorkflow/workflowSummary/runWorkflowSummary.vue
@@ -2,8 +2,7 @@
     <div id="summary-header">
         <run-workflow-summary-header :workflow-summary="workflowSummary"></run-workflow-summary-header>
         <div v-if="hasDependenciesLength">
-            <workflow-summary-reports :workflow-summary="workflowSummary"
-                                      :git-commit="workflowMetadata.git_commit"/>
+            <workflow-summary-reports :workflow-summary="workflowSummary"/>
         </div>
         <error-info :default-message="defaultMessage" :api-error="error"></error-info>
     </div>

--- a/src/app/static/src/js/components/runWorkflow/workflowSummary/workflowSummaryReports.vue
+++ b/src/app/static/src/js/components/runWorkflow/workflowSummary/workflowSummaryReports.vue
@@ -59,7 +59,6 @@
 
     interface Props {
         workflowSummary: WorkflowSummaryResponse
-        gitCommit: string
     }
 
     interface Methods {
@@ -78,11 +77,7 @@
             workflowSummary: {
                 required: true,
                 type: Object
-            },
-            gitCommit: {
-                required: true,
-                type: String
-            },
+            }
         },
         methods: {
             reportInfo(reportName) {

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunReportPageTests.kt
@@ -31,7 +31,8 @@ class RunReportPageTests : SeleniumTest()
         driver.get(url)
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can view run tab`()
     {
         val tab = driver.findElement(By.id("run-tab"))
@@ -41,7 +42,8 @@ class RunReportPageTests : SeleniumTest()
         assertThat(select.firstSelectedOption.text).isEqualTo("master")
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can view run tab with querystring`()
     {
         val url = RequestHelper.webBaseUrl + "/run-report?report-name=minimal"
@@ -71,10 +73,12 @@ class RunReportPageTests : SeleniumTest()
         else
         {
             assertThat(driver.findElements(By.id("git-commit"))).isEmpty()
+            assertThat(driver.findElements(By.id("git-header"))).isEmpty()
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can view and select reports`()
     {
         val typeahead = driver.findElement(By.id("report"))
@@ -87,27 +91,36 @@ class RunReportPageTests : SeleniumTest()
         assertThat(matches[0].text).startsWith("minimal")
     }
 
-    @Test
-    fun `can change git branch to non-master and see changed reports only`()
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
+    fun `can change git branch to non-master and see changed reports iff git enabled`(configType: ConfigType)
     {
-        val gitBranch = driver.findElement(By.id("git-branch"))
-        val gitCommit = driver.findElement(By.id("git-commit"))
-        val oldCommit = gitCommit.getAttribute("value")
+        if (configType == ConfigType.GIT_ALLOWED)
+        {
+            val gitBranch = driver.findElement(By.id("git-branch"))
+            val gitCommit = driver.findElement(By.id("git-commit"))
+            val oldCommit = gitCommit.getAttribute("value")
 
-        Select(gitBranch).selectByIndex(1)
-        wait.until(ExpectedConditions.not(ExpectedConditions.attributeToBe(gitCommit, "value", oldCommit)))
-        assertThat(gitBranch.getAttribute("value")).isEqualTo("other")
-        val commitValue = gitCommit.getAttribute("value")
-        assertThat(commitValue).isNotBlank()
+            Select(gitBranch).selectByIndex(1)
+            wait.until(ExpectedConditions.not(ExpectedConditions.attributeToBe(gitCommit, "value", oldCommit)))
+            assertThat(gitBranch.getAttribute("value")).isEqualTo("other")
+            val commitValue = gitCommit.getAttribute("value")
+            assertThat(commitValue).isNotBlank()
 
-        // 'minimal' and 'global' reports from master should not be included, 'other' and 'view' should be
-        assertThat(reportIsAvailable("minimal")).isFalse()
-        assertThat(reportIsAvailable("global")).isFalse()
-        assertThat(reportIsAvailable("other")).isTrue()
-        assertThat(reportIsAvailable("view")).isTrue()
+            // 'minimal' and 'global' reports from master should not be included, 'other' and 'view' should be
+            assertThat(reportIsAvailable("minimal")).isFalse()
+            assertThat(reportIsAvailable("global")).isFalse()
+            assertThat(reportIsAvailable("other")).isTrue()
+            assertThat(reportIsAvailable("view")).isTrue()
+        }
+        else
+        {
+            assertThat(driver.findElements(By.id("git-branch"))).isEmpty()
+        }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can run a report and follow view log link to logs`()
     {
         val typeahead = driver.findElement(By.id("report"))
@@ -129,7 +142,8 @@ class RunReportPageTests : SeleniumTest()
         wait.until(ExpectedConditions.textToBePresentInElementLocated(By.cssSelector("h2"), "Running report logs"))
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can run a report and view logs`()
     {
         val typeahead = driver.findElement(By.id("report"))
@@ -152,7 +166,8 @@ class RunReportPageTests : SeleniumTest()
         assertThat(driver.findElement(By.cssSelector("#logs")).text).startsWith("minimal")
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can view logs tab`()
     {
         driver.findElement(By.id("logs-link")).click()
@@ -187,7 +202,8 @@ class RunReportPageTests : SeleniumTest()
         assertThat(paramInput[0].text).isEqualTo("new value")
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can add change message and type values`()
     {
         val typeahead = driver.findElement(By.id("report"))

--- a/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
+++ b/src/customConfigTests/src/test/kotlin/org/vaccineimpact/orderlyweb/customConfigTests/RunWorkflowTests.kt
@@ -4,6 +4,8 @@ import java.nio.file.Files
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.openqa.selenium.By
 import org.openqa.selenium.support.ui.ExpectedConditions
 import org.openqa.selenium.support.ui.ExpectedConditions.not
@@ -39,8 +41,9 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(tab.findElement(By.tagName("h2")).text).isEqualTo("Run workflow")
     }
 
-    @Test
-    fun `can create a blank workflow and select git branch`()
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
+    fun `can create a blank workflow and select git branch iff git enabled`(configType: ConfigType)
     {
         val tab = driver.findElement(By.id("run-workflow-tab"))
         val page = tab.findElement(By.id("create-workflow-container"))
@@ -49,22 +52,30 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(createButton.text).isEqualTo("Create a blank workflow")
 
         createButton.click()
-        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("git-branch")))
-        val branchSelect = driver.findElement(By.id("git-branch"))
-        assertThat(branchSelect.getAttribute("value")).isEqualTo("master")
-        val commitSelect = driver.findElement(By.id("git-commit"))
-        val commitValue = commitSelect.getAttribute("value")
-        assertThat(commitValue).isNotBlank()
+        if (configType == ConfigType.GIT_ALLOWED)
+        {
+            wait.until(ExpectedConditions.presenceOfElementLocated(By.id("git-branch")))
+            val branchSelect = driver.findElement(By.id("git-branch"))
+            assertThat(branchSelect.getAttribute("value")).isEqualTo("master")
+            val commitSelect = driver.findElement(By.id("git-commit"))
+            val commitValue = commitSelect.getAttribute("value")
+            assertThat(commitValue).isNotBlank()
 
-        //Select a git branch
-        Select(branchSelect).selectByIndex(1)
-        assertThat(branchSelect.getAttribute("value")).isEqualTo("other")
-        //Default commit value should update when new branch selected
-        wait.until(not(ExpectedConditions.attributeToBe(commitSelect, "value", commitValue)))
-        assertThat(commitSelect.getAttribute("value")).isNotBlank()
+            //Select a git branch
+            Select(branchSelect).selectByIndex(1)
+            assertThat(branchSelect.getAttribute("value")).isEqualTo("other")
+            //Default commit value should update when new branch selected
+            wait.until(not(ExpectedConditions.attributeToBe(commitSelect, "value", commitValue)))
+            assertThat(commitSelect.getAttribute("value")).isNotBlank()
+        }
+        else
+        {
+            assertThat(driver.findElements(By.id("git-branch"))).isEmpty()
+        }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can rerun workflow`()
     {
         val tab = driver.findElement(By.id("run-workflow-tab"))
@@ -86,7 +97,8 @@ class RunWorkflowTests : SeleniumTest()
         wait.until(ExpectedConditions.presenceOfElementLocated(By.id("summary-header")))
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can clone workflow`()
     {
         val tab = driver.findElement(By.id("run-workflow-tab"))
@@ -109,7 +121,8 @@ class RunWorkflowTests : SeleniumTest()
     }
 
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can add and remove reports from workflow`()
     {
         createWorkflow()
@@ -125,7 +138,8 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(nextButton.isEnabled).isFalse()
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can set parameter value`()
     {
         createWorkflow()
@@ -147,41 +161,55 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(nextButton.isEnabled).isTrue()
     }
 
-    @Test
-    fun `can change branch and see resulting workflow change`()
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
+    fun `can change branch and see resulting workflow change iff git enabled`(configType: ConfigType)
     {
         createWorkflow()
-        changeToOtherBranch()
-        addReport("other")
+        if (configType == ConfigType.GIT_ALLOWED)
+        {
+            changeToOtherBranch()
+            addReport("other")
 
-        //Expect report to be removed from workflow when change to a branch where report does not exist
-        changeToMasterBranch()
-        assertThat(driver.findElements(By.id("workflow-report-0")).isEmpty()).isTrue()
-        assertThat(driver.findElement(By.cssSelector(".alert")).text).contains(
-                "The following items are not present in this git commit and have been removed from the workflow:\n" +
-                "Report 'other'")
+            //Expect report to be removed from workflow when change to a branch where report does not exist
+            changeToMasterBranch()
+            assertThat(driver.findElements(By.id("workflow-report-0")).isEmpty()).isTrue()
+            assertThat(driver.findElement(By.cssSelector(".alert")).text).contains(
+                    "The following items are not present in this git commit and have been removed from the workflow:\n" +
+                            "Report 'other'"
+            )
+        }
     }
 
-    @Test
-    fun `can refresh git`()
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
+    fun `can refresh git iff git enabled`(configType: ConfigType)
     {
         val tab = driver.findElement(By.id("run-workflow-tab"))
         val page = tab.findElement(By.id("create-workflow-container"))
         val createButton = page.findElement(By.id("create-workflow"))
 
         createButton.click()
-        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("git-branch")))
+        if (configType == ConfigType.GIT_ALLOWED)
+        {
+            wait.until(ExpectedConditions.presenceOfElementLocated(By.id("git-branch")))
 
-        // We generally expect one git commit option in demo orderly before refresh, but have found that this can be two commits on Buildkite run. This may be related to having run a workflow in another test
-        assertThat(driver.findElements(By.cssSelector("#git-commit option")).count()).isIn(listOf(1, 2))
+            // We generally expect one git commit option in demo orderly before refresh, but have found that this can be two commits on Buildkite run. This may be related to having run a workflow in another test
+            assertThat(driver.findElements(By.cssSelector("#git-commit option")).count()).isIn(listOf(1, 2))
 
-        val refreshButton = driver.findElement(By.id("git-refresh-btn"))
-        refreshButton.click()
-        assertThat(driver.findElements(By.cssSelector(".error-message")).count()).isEqualTo(0)
-        wait.until(ExpectedConditions.numberOfElementsToBe(By.cssSelector("#git-commit option"), 2))
+            val refreshButton = driver.findElement(By.id("git-refresh-btn"))
+            refreshButton.click()
+            assertThat(driver.findElements(By.cssSelector(".error-message")).count()).isEqualTo(0)
+            wait.until(ExpectedConditions.numberOfElementsToBe(By.cssSelector("#git-commit option"), 2))
+        }
+        else
+        {
+            assertThat(driver.findElements(By.id("git-refresh-btn"))).isEmpty()
+        }
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can import csv file`()
     {
         val tmpFile = Files.createTempFile("test_import", ".csv").toFile()
@@ -199,16 +227,20 @@ class RunWorkflowTests : SeleniumTest()
         tmpFile.delete()
     }
 
-    @Test
-    fun `can see all reports in non-master branch`()
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
+    fun `can see all reports in non-master branch iff git enabled`(configType: ConfigType)
     {
         // Available reports should include those which are unchanged from master branch i.e. 'minimal' and 'global', as
         // well as branch-only reports e.g. 'other'
         createWorkflow()
-        changeToOtherBranch()
-        addReport("minimal")
-        addReport("global")
-        addReport("other")
+        if (configType == ConfigType.GIT_ALLOWED)
+        {
+            changeToOtherBranch()
+            addReport("minimal")
+            addReport("global")
+            addReport("other")
+        }
     }
 
     private fun addReport(reportName: String)
@@ -227,7 +259,7 @@ class RunWorkflowTests : SeleniumTest()
     {
         val createButton = driver.findElement(By.id("create-workflow"))
         createButton.click()
-        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("git-branch")))
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("workflow-reports")))
     }
 
     private fun changeToMasterBranch()
@@ -255,7 +287,8 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(commitSelect.getAttribute("value")).isNotBlank()
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can create a workflow and select the view progress link to navigate to the progress tab with workflow preselected and reports table generated, which persists when navigating off tab and back again, and re-run workflow in progress`()
     {
         // creates workflow with ui and navigates to the progress page with it selected
@@ -294,14 +327,14 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(table.text).contains("Reports")
         val rows = driver.findElements(By.cssSelector("#workflow-table tr"))
         assertThat(rows.count()).isEqualTo(3)
-        val minimalRow = rows.find{ it.text.startsWith("minimal") }!!
+        val minimalRow = rows.find { it.text.startsWith("minimal") }!!
         val minimalRowStatus = minimalRow.findElement(By.cssSelector("td:nth-child(2)"))
         assertThat(minimalRowStatus.text).isIn(listOf("Queued", "Running"))
-        val globalRow = rows.find{ it.text.startsWith("global") }!!
+        val globalRow = rows.find { it.text.startsWith("global") }!!
         val globalRowStatus = globalRow.findElement(By.cssSelector("td:nth-child(2)"))
         assertThat(globalRowStatus.text).isIn(listOf("Queued", "Running"))
-        wait.until(ExpectedConditions.textToBePresentInElement(minimalRowStatus,"Complete"))
-        wait.until(ExpectedConditions.textToBePresentInElement(globalRow,"Complete"))
+        wait.until(ExpectedConditions.textToBePresentInElement(minimalRowStatus, "Complete"))
+        wait.until(ExpectedConditions.textToBePresentInElement(globalRow, "Complete"))
 
         // view report log
         val viewLogLink = minimalRow.findElement(By.cssSelector("a.report-log-link"))
@@ -341,7 +374,8 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(workflowNameInput.getAttribute("readonly")).isEqualTo("true")
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `workflow progress link clears when updating the wizard`()
     {
         createWorkflow()
@@ -366,7 +400,8 @@ class RunWorkflowTests : SeleniumTest()
         wait.until(ExpectedConditions.invisibilityOfElementLocated(By.id("view-progress-link")))
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can display workflow summary`()
     {
         createWorkflow()
@@ -419,7 +454,7 @@ class RunWorkflowTests : SeleniumTest()
 
         val backButton = driver.findElement(By.id("previous-workflow"))
         backButton.click()
-        
+
         wait.until(ExpectedConditions.presenceOfElementLocated(By.id("workflow-report-1")))
         val removeReportBtns = driver.findElements(By.cssSelector(".remove-report-button"))
         removeReportBtns[1].click()
@@ -432,7 +467,8 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(driver.findElements(By.id("summary-warning")).count()).isEqualTo(0)
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can display workflow summary and progress with default params, non-default params, and no params`()
     {
         createWorkflow()
@@ -543,7 +579,8 @@ class RunWorkflowTests : SeleniumTest()
         assertThat(showDefault.text).isEqualTo("Show defaults...")
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ConfigType::class)
     fun `can display workflow summary with depends on and missing dependencies`()
     {
         createWorkflow()


### PR DESCRIPTION
This rolls out the parameterized test approach to all the tests that involve report/workflow running. In doing so I did find a couple small UI bugs, which I fixed. Where tests use git related functionality I have made the assertions conditional, otherwise just declared them as parameterized tests so they run for both cases, but assertions are identical.