### PR TITLE
vimc-7028: Fix workflow csv upload errors not being shown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/doc
 RUN apt-get update
 RUN apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
-RUN curl -sL https://deb.nodesource.com/setup_19.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get -y install nodejs
 
 # Setup gradle

--- a/src/app/static/package.json
+++ b/src/app/static/package.json
@@ -8,7 +8,7 @@
     "webpack": "webpack",
     "watch": "webpack --watch",
     "build": "webpack && npm run sass",
-    "sass": "if test ${NODE_ENV} = \"production\" ; then npm run sass-prod ; else npm run sass-dev ; fi",
+    "sass": "if [ \"$NODE_ENV\" = \"production\" ]; then npm run sass-prod ; else npm run sass-dev ; fi",
     "test": "TZ=utc jest -c jest.config.js",
     "lint": "npx eslint src --ext .js,.jsx,.ts,.tsx,vue"
   },

--- a/src/app/static/src/js/components/runWorkflow/runWorkflowReport.vue
+++ b/src/app/static/src/js/components/runWorkflow/runWorkflowReport.vue
@@ -77,8 +77,8 @@
                                  @dismissed="validationErrors=[]">
                             Failed to import from csv. The following issues were found:
                             <ul class="py-0 my-0 ml-2" :style="{listStyleType: 'disc'}">
-                                <li v-for="e in validationErrors" :key="e.message" class="import-validation-error">
-                                    {{ e.message }}
+                                <li v-for="e in validationErrors" :key="e.detail" class="import-validation-error">
+                                    {{ e.detail }}
                                 </li>
                             </ul>
                         </b-alert>

--- a/src/app/static/src/scss/index.scss
+++ b/src/app/static/src/scss/index.scss
@@ -1,7 +1,7 @@
 @import "style";
-@import "../../node_modules/datatables.net-bs4/css/dataTables.bootstrap4.css";
-@import "../../node_modules/treetables/tree-table.css";
-@import "../../node_modules/tokenize2/tokenize2.css";
+@import "../../node_modules/datatables.net-bs4/css/dataTables.bootstrap4";
+@import "../../node_modules/treetables/tree-table";
+@import "../../node_modules/tokenize2/tokenize2";
 
 $border-color: rgba(0, 0, 0, 0.125);
 #reports-table {

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
@@ -739,8 +739,8 @@ describe(`runWorkflowReport`, () => {
         await Vue.nextTick();
 
         expect(wrapper.vm.$data.validationErrors).toEqual([
-            {code: "bad-request", message: "ERROR 1"},
-            {code: "bad-request", message: "ERROR 2"}
+            {code: "bad-request", detail: "ERROR 1"},
+            {code: "bad-request", detail: "ERROR 2"}
         ]);
         expect(wrapper.emitted("update").length).toBe(1);
         expect(wrapper.emitted("update")[0][0]["reports"]).toStrictEqual([]);

--- a/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
+++ b/src/app/static/src/tests/components/runWorkflow/runWorkflowReport/runWorkflowReport.test.ts
@@ -62,8 +62,8 @@ describe(`runWorkflowReport`, () => {
         mockAxios.onPost("http://app/workflow/validate/?branch=test&commit=test")
             .replyOnce(500, {
                 errors: [
-                    {code: "bad-request", message: "ERROR 1"},
-                    {code: "bad-request", message: "ERROR 2"}
+                    {code: "bad-request", detail: "ERROR 1"},
+                    {code: "bad-request", detail: "ERROR 2"}
                 ]
             });
 


### PR DESCRIPTION
This fixes a couple of regressions I noticed on HIV deployment (you can see this on prod at hiv-orderly.dide.ic.ac.uk)
* It fixes styling on treetables, at the moment the arrow at the start of a row and the show pointer on hover are broken. I am guessing this is since https://github.com/vimc/orderly-web/pull/490 ? It fixes this styling by dropping the file extension on the included css
* When a user uploads a workflow csv, if there are any issues in the csv those errors are not reported back out to the user. I think this changed since switch from `message` to `detail` https://github.com/vimc/orderly-web/pull/506/files#diff-9b20cef9b37dc4c8a4eadf6dbfd9b873ad70bffc45880e7b72bde15cb4b925c4L5
